### PR TITLE
fix: Typography에서 Kerning 대신 Tracking 사용

### DIFF
--- a/Sources/Montage/Extension/UIKit/NSAttributedString+Montage.swift
+++ b/Sources/Montage/Extension/UIKit/NSAttributedString+Montage.swift
@@ -18,7 +18,7 @@ public extension NSAttributedString {
         .init(string: string, attributes: [
             .font: UIFont.montage(varient: varient, weight: weight, size: size),
             .foregroundColor: UIColor.alias(color),
-            .kern: Montage.Typography.getKern(varient: varient, size: size),
+            .tracking: Montage.Typography.getTracking(varient: varient, size: size),
             .paragraphStyle: {
                 let style = NSMutableParagraphStyle()
                 style.alignment = .left

--- a/Sources/Montage/Foundation/Typography.swift
+++ b/Sources/Montage/Foundation/Typography.swift
@@ -106,7 +106,7 @@ public extension Montage.Typography {
         }
     }
     
-    static func getKern(varient: Variant, size: Size) -> CGFloat {
+    static func getTracking(varient: Variant, size: Size) -> CGFloat {
         let sementicSize = getSementicSize(varient: varient, size: size)
         let letterSpacingEm: CGFloat
         


### PR DESCRIPTION
Signed-off-by: Kil Hyung-jin <orioncactus@gmail.com>

# 개요
- 🎨  디자인 링크 : 
  - Typography: https://www.figma.com/file/VvMaZNKE9pGKsrtPDirfxz/MONTAGE?node-id=602%3A2&t=loYNSOxlE3toSZiC-1

### 📌 작업 완료 기한
- 2023/01/31

# 수정사항

## 수정 내용
- 자간 조절을 Kerning으로 적용할 경우 글꼴에서 특정 라틴 문자 사이마다 적용된 간격이 무시되어 Kerning이 아닌 Tracking으로 적용합니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-31 at 17 26 37](https://user-images.githubusercontent.com/7247848/215707761-b8ea859f-719b-4a32-b4f1-d18b349428f2.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-31 at 17 26 15](https://user-images.githubusercontent.com/7247848/215707714-d05085e4-df4a-4497-adb9-a8e2f37ccaf1.png)

# 확인사항
- [x] 동작 확인 
