### PR TITLE
fix: 일부 맞지 않는 letter-spacing 수치를 조정

### DIFF
--- a/Sources/Montage/Foundation/Typography.swift
+++ b/Sources/Montage/Foundation/Typography.swift
@@ -120,7 +120,7 @@ public extension Montage.Typography {
         case .heading1:
             letterSpacingEm = size == .small ? -0.012 : -0.0194
         case .heading2:
-            letterSpacingEm = 0
+            letterSpacingEm = -0.001
         case .body1:
             letterSpacingEm = 0.0057
         case .body1Reading:

--- a/Sources/Montage/Foundation/Typography.swift
+++ b/Sources/Montage/Foundation/Typography.swift
@@ -118,9 +118,9 @@ public extension Montage.Typography {
         case .title2:
             letterSpacingEm = size == .small ? -0.023 : -0.0246
         case .heading1:
-            letterSpacingEm = size == .small ? -0.02 : -0.0194
+            letterSpacingEm = size == .small ? -0.012 : -0.0194
         case .heading2:
-            letterSpacingEm = size == .small ? -0.027 : -0.002
+            letterSpacingEm = 0
         case .body1:
             letterSpacingEm = 0.0057
         case .body1Reading:


### PR DESCRIPTION
Signed-off-by: Euigyom Kim <egkim@dehol.kr>

# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/VvMaZNKE9pGKsrtPDirfxz/MONTAGE?node-id=1149%3A1433&t=lWi0bY7N2T6ptjnI-1

### 📌 작업 완료 기한
- 2023/02/02

# 수정사항

## 수정 내용
Typography 의 Varient 중 Heading1, Heading2 에 적용되는 letter-spacing 수치를 변경하였습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-02 at 09 04 33](https://user-images.githubusercontent.com/712513/216198067-dd3087bd-dc4c-4a97-a5eb-f9a9980b9224.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-02 at 09 11 29](https://user-images.githubusercontent.com/712513/216198054-59972eb5-1a5c-4efb-8ed9-42b814dbe4d9.png)

# 확인사항
- [x] 동작 확인 
