### PR TITLE
fix: 누락된 컴포넌트 내부 컬러셋 추가

### DIFF
--- a/Sources/Montage/Asset/Color.xcassets/Component/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Component/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Component/componentFillAlternative.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Component/componentFillAlternative.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.080",
+          "blue" : "0x7C",
+          "green" : "0x73",
+          "red" : "0x70"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.220",
+          "blue" : "0x7C",
+          "green" : "0x73",
+          "red" : "0x70"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Component/componentFillNormal.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Component/componentFillNormal.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.160",
+          "blue" : "0x7C",
+          "green" : "0x73",
+          "red" : "0x70"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.280",
+          "blue" : "0x7C",
+          "green" : "0x73",
+          "red" : "0x70"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Component/componentFillStrong.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Component/componentFillStrong.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.050",
+          "blue" : "0x7C",
+          "green" : "0x73",
+          "red" : "0x70"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.120",
+          "blue" : "0x7C",
+          "green" : "0x73",
+          "red" : "0x70"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Component/componentMaterialDimmer.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Component/componentMaterialDimmer.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.280",
+          "blue" : "0x19",
+          "green" : "0x17",
+          "red" : "0x17"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.740",
+          "blue" : "0x10",
+          "green" : "0x0F",
+          "red" : "0x0F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Extension/UIKit/UIColor+Montage.swift
+++ b/Sources/Montage/Extension/UIKit/UIColor+Montage.swift
@@ -19,4 +19,8 @@ extension UIColor {
     public static func alias(_ type: Montage.Color.Alias) -> UIColor {
         .init(dynamicProvider: type.convert)
     }
+    
+    static func component(_ type: Montage.Color.Component) -> UIColor {
+        load(name: type.name)
+    }
 }

--- a/Sources/Montage/Foundation/Color.swift
+++ b/Sources/Montage/Foundation/Color.swift
@@ -420,5 +420,14 @@ public extension Montage {
                 return .load(name: globalType.name)
             }
         }
+        
+        enum Component: String {
+            case fillNormal
+            case fillStrong
+            case fillAlternative
+            case materialDimmer
+            
+            public var name: String { rawValue }
+        }
     }
 }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/YfMmyQn7XDsRFm5PqV2rLU/Color---Light-(New)?node-id=1%3A45&t=fRsJyWvtP2WrVMZX-1

### 📌 작업 완료 기한
- 2023/02/17

# 수정사항

## 수정 내용
컬러셋에서 누락된 디자인 시스템 내부 색상을 추가하였습니다.
추가된 색상에는 알파값까지 포함되어 있습니다.

- Component - Fill - Normal, Strong, Alternative
- Component - Material - Dimmer