### PR TITLE
[PI-43543] feat: Grid Spacing 컴포넌트화

### DIFF
--- a/Sources/Montage/Extension/UIKit/CGFloat+Montage.swift
+++ b/Sources/Montage/Extension/UIKit/CGFloat+Montage.swift
@@ -1,0 +1,49 @@
+//
+//  CGFloat+Montage.swift
+//  Montage
+//
+//  Created by Euigyom Kim on 2023/02/23.
+//
+
+import Foundation
+
+public extension CGFloat {
+    static func spacing(from spacingComponent: Montage.Spacing) -> CGFloat {
+        switch spacingComponent {
+        case .pt01:
+            return 1
+        case .pt02:
+            return 2
+        case .pt04:
+            return 4
+        case .pt08:
+            return 8
+        case .pt12:
+            return 12
+        case .pt16:
+            return 16
+        case .pt20:
+            return 20
+        case .pt24:
+            return 24
+        case .pt28:
+            return 28
+        case .pt32:
+            return 32
+        case .pt36:
+            return 36
+        case .pt40:
+            return 40
+        case .pt48:
+            return 48
+        case .pt56:
+            return 56
+        case .pt64:
+            return 64
+        case .pt72:
+            return 72
+        case .pt80:
+            return 80
+        }
+    }
+}

--- a/Sources/Montage/Foundation/Spacing.swift
+++ b/Sources/Montage/Foundation/Spacing.swift
@@ -1,0 +1,30 @@
+//
+//  Spacing.swift
+//  Montage
+//
+//  Created by Euigyom Kim on 2023/02/23.
+//
+
+import Foundation
+
+public extension Montage {
+    enum Spacing: String, CaseIterable {
+        case pt01
+        case pt02
+        case pt04
+        case pt08
+        case pt12
+        case pt16
+        case pt20
+        case pt24
+        case pt28
+        case pt32
+        case pt36
+        case pt40
+        case pt48
+        case pt56
+        case pt64
+        case pt72
+        case pt80
+    }
+}


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/2orYfqIiuFhTGXKN1GARg7/2-Typo%2FGrid---%F0%9F%93%B1Small?node-id=2280%3A3579&t=lNDNxU0eBL57oQ8n-1

### 📌 작업 완료 기한
- 2023/02/27

# 수정사항

## 수정 내용
Grid 시스템 중 Spacing 단위에 대한 컴포넌트화를 진행하였습니다.
샘플 앱 (빌드 6 이후 버전) > Icon 화면 우상단에서 Spacing 컴포넌트를 직접 선택하여 실제 수치를 확인하실 수 있습니다.

- Icon Wrapper의 Inset
- Icon Wrapper와 Title 사이의 간격 

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-24 at 10 35 09](https://user-images.githubusercontent.com/712513/221070793-d5a19a41-14bc-4227-83fe-8b58981a7057.png)

# 확인사항
- [x] 동작 확인 
