### PR TITLE
feat: NSAttributedString+montage 에 lineBreakMode 추가 (~3/28)

### DIFF
--- a/Sources/Montage/Extension/UIKit/NSAttributedString+Montage.swift
+++ b/Sources/Montage/Extension/UIKit/NSAttributedString+Montage.swift
@@ -13,7 +13,8 @@ public extension NSAttributedString {
         varient: Montage.Typography.Variant = .body1,
         size: Montage.Typography.Size = .small,
         weight: Montage.Typography.Weight = .regular,
-        color: Montage.Color.Alias = .labelNormal
+        color: Montage.Color.Alias = .labelNormal,
+        lineBreakMode: NSLineBreakMode = .byWordWrapping
     ) -> NSAttributedString {
         let font = UIFont.montage(varient: varient, weight: weight, size: size)
         let lineHeight = Montage.Typography.getLineHeight(varient: varient, size: size)
@@ -31,6 +32,7 @@ public extension NSAttributedString {
                 let style = NSMutableParagraphStyle()
                 style.alignment = .left
                 style.minimumLineHeight = lineHeight
+                style.lineBreakMode = lineBreakMode
                 return style
             }()
         ])


### PR DESCRIPTION
# 개요
- 🔗 관련 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-45900

### 📌 작업 완료 기한
- 2023/03/28

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
- NSAttributedString+montage를 적용한 UILabel에는 label에서 제공하는 lineBreakMode가 적용되지 않습니다.
- NSAttributedString에 lineBreakMode를 적용하기 위해서는 NSParagraphStyle을 사용하여 적용해야 했습니다.
- NSParagraphStyle을 직접 외부에서 주입하는것 보다, 자주 사용될 수 있는 NSLineBreakMode를 지정하여 주입하는 방법을 채택하였습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screen Shot - iPhone 8 - 2023-03-28 at 12 49 50](https://user-images.githubusercontent.com/39300449/228123280-14e93544-8a60-4bd9-8b48-07e0844d5b3c.png)|![Simulator Screen Shot - iPhone 8 - 2023-03-28 at 12 47 56](https://user-images.githubusercontent.com/39300449/228123287-02464d6c-c77c-44b8-b529-95d160a51652.png)


# 확인사항
- [X] 동작 확인 
