### PR TITLE
fix: SwiftUI에서 버튼들이 정상적으로 노출되지 않는 문제 수정 (~4/17)

### DIFF
--- a/Sources/Montage/Element/Button/IconButton/IconButton.swift
+++ b/Sources/Montage/Element/Button/IconButton/IconButton.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension Button {
-    /// 외곽선 또는 배경으로 둘러 싸인 곡선 모서리 버튼입니다.
+    /// 단일 아이콘을 배경 또는 외곽선으로 감싸는 버튼입니다.
     /// [Figma](https://www.figma.com/file/NzeCJaXMkqRBlRd9CZCx8j/0-Component?node-id=1174%3A12997&t=5otLCYvozBpnxZ7j-1) 에서 모양을 미리 확인할 수 있습니다.
     public class IconButton: UIView {
         /// 버튼의 외관을 결정하는 열거형입니다.
@@ -62,7 +62,7 @@ extension Button {
         
         private var insetConstraints: [NSLayoutConstraint] = []
         
-        /// RoundButton 객체를 생성합니다.
+        /// IconButton 객체를 생성합니다.
         public init(icon: Icon = .dot) {
             self.icon = icon
             
@@ -72,7 +72,7 @@ extension Button {
             bindEvent()
         }
         
-        override public required init?(coder: NSCoder) {
+        public required init?(coder: NSCoder) {
             self.icon = .dot
             
             super.init(coder: coder)
@@ -91,6 +91,14 @@ extension Button {
             super.layoutSubviews()
             
             setupLayer()
+        }
+        
+        /// Element의 기본적인 사이즈를 정의합니다.
+        override public var intrinsicContentSize: CGSize {
+            .init(
+                width: varient.iconSize.width + varient.inset * 2,
+                height: varient.iconSize.height + varient.inset * 2
+            )
         }
     }
 }

--- a/Sources/Montage/Element/Button/IconButton/IconButtonController.swift
+++ b/Sources/Montage/Element/Button/IconButton/IconButtonController.swift
@@ -11,8 +11,8 @@ extension Button {
     public struct IconButtonController: UIViewRepresentable {
         @State public var varient: IconButton.Varient
         @State public var icon: Icon
-        @State public var state: Decorate.Interaction.State
-        @State public var disable: Bool
+        @State public var state: Decorate.Interaction.State = .normal
+        @State public var disable: Bool = false
         
         public typealias UIViewType = IconButton
         
@@ -25,6 +25,16 @@ extension Button {
             uiView.icon = icon
             uiView.state = state
             uiView.disable = disable
+        }
+    }
+}
+
+struct IconButtonController_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            Button.IconButtonController(varient: .normal, icon: .apps).fixedSize()
+            Button.IconButtonController(varient: .background, icon: .apps).fixedSize()
+            Button.IconButtonController(varient: .outlined(size: .normal), icon: .apps).fixedSize()
         }
     }
 }

--- a/Sources/Montage/Element/Button/RoundButton/RoundButton.swift
+++ b/Sources/Montage/Element/Button/RoundButton/RoundButton.swift
@@ -99,7 +99,7 @@ extension Button {
             bindEvent()
         }
         
-        override public required init?(coder: NSCoder) {
+        public required init?(coder: NSCoder) {
             super.init(coder: coder)
             
             setupViews()
@@ -116,6 +116,19 @@ extension Button {
             super.layoutSubviews()
             
             setupLayer()
+        }
+        
+        /// Element의 기본적인 사이즈를 정의합니다.
+        override public var intrinsicContentSize: CGSize {
+            let textSize = getAttributedText().size()
+            let iconSize = size.iconSize
+            let edgeInsets = size.edgeInsets
+            let iconCount = [leftIcon, rightIcon].filter({ $0 != nil }).count
+            
+            return .init(
+                width: iconSize.width * CGFloat(iconCount) + textSize.width + edgeInsets.horizontal,
+                height: max(iconSize.height, textSize.height) + edgeInsets.vertical
+            )
         }
     }
 }
@@ -244,7 +257,11 @@ extension Button.RoundButton {
     }
     
     private func updateTextLabel() {
-        textLabel.attributedText = .montage(
+        textLabel.attributedText = getAttributedText()
+    }
+    
+    private func getAttributedText() -> NSAttributedString {
+        .montage(
             text,
             varient: size.typoVarient,
             weight: .bold,

--- a/Sources/Montage/Element/Button/RoundButton/RoundButtonController.swift
+++ b/Sources/Montage/Element/Button/RoundButton/RoundButtonController.swift
@@ -10,12 +10,12 @@ import SwiftUI
 extension Button {
     public struct RoundButtonController: UIViewRepresentable {
         @State public var varient: RoundButton.Varient
-        @State public var size: RoundButton.Size
-        @State public var leftIcon: Icon
-        @State public var rightIcon: Icon
+        @State public var size: RoundButton.Size = .medium
+        @State public var leftIcon: Icon?
+        @State public var rightIcon: Icon?
         @State public var text: String
-        @State public var state: Decorate.Interaction.State
-        @State public var disable: Bool
+        @State public var state: Decorate.Interaction.State = .normal
+        @State public var disable: Bool = false
         
         public typealias UIViewType = RoundButton
         
@@ -31,6 +31,69 @@ extension Button {
             uiView.text = text
             uiView.state = state
             uiView.disable = disable
+        }
+    }
+}
+
+struct RoundButtonController_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading, spacing: .spacing(.pt20)) {
+            VStack(alignment: .leading) {
+                Text("Primary").montage()
+                Button.RoundButtonController(
+                    varient: .primary,
+                    size: .large,
+                    text: "안녕하세요"
+                ).fixedSize()
+            }
+            
+            VStack(alignment: .leading) {
+                Text("Alternative").montage()
+                Button.RoundButtonController(
+                    varient: .alternative,
+                    size: .medium,
+                    text: "안녕하세요"
+                ).fixedSize()
+            }
+            
+            VStack(alignment: .leading) {
+                Text("Secondary").montage()
+                Button.RoundButtonController(
+                    varient: .secondary,
+                    size: .small,
+                    text: "안녕하세요"
+                ).fixedSize()
+            }
+            
+            VStack(alignment: .leading) {
+                Text("Assistive").montage()
+                Button.RoundButtonController(
+                    varient: .assistive,
+                    size: .small,
+                    text: "안녕하세요"
+                ).fixedSize()
+            }
+            
+            VStack(alignment: .leading) {
+                Text("Primary with left icon").montage()
+                Button.RoundButtonController(
+                    varient: .primary,
+                    size: .large,
+                    leftIcon: .apps,
+                    text: "안녕하세요"
+                ).fixedSize()
+            }
+            
+            VStack(alignment: .leading) {
+                Text("Primary with right icon").montage()
+                Button.RoundButtonController(
+                    varient: .primary,
+                    size: .medium,
+                    rightIcon: .chevronRightThick,
+                    text: "안녕하세요",
+                    disable: true
+                ).fixedSize()
+            }
         }
     }
 }

--- a/Sources/Montage/Element/Button/TextButton/TextButton.swift
+++ b/Sources/Montage/Element/Button/TextButton/TextButton.swift
@@ -16,7 +16,7 @@ public protocol TextButtonDelegate: AnyObject {
 
 
 extension Button {
-    /// 외곽선 또는 배경으로 둘러 싸인 곡선 모서리 버튼입니다.
+    /// 텍스트 및 아이콘으로 이루어진 버튼입니다.
     /// [Figma](https://www.figma.com/file/NzeCJaXMkqRBlRd9CZCx8j/0-Component?node-id=1174%3A12997&t=5otLCYvozBpnxZ7j-1) 에서 모양을 미리 확인할 수 있습니다.
     public class TextButton: UIView {
         private enum Const {
@@ -97,7 +97,7 @@ extension Button {
         
         private weak var delegate: TextButtonDelegate?
         
-        /// RoundButton 객체를 생성합니다.
+        /// TextButton 객체를 생성합니다.
         public init() {
             super.init(frame: .zero)
             
@@ -105,7 +105,7 @@ extension Button {
             bindEvent()
         }
         
-        override public required init?(coder: NSCoder) {
+        public required init?(coder: NSCoder) {
             super.init(coder: coder)
             
             setupViews()
@@ -122,6 +122,19 @@ extension Button {
             super.layoutSubviews()
             
             setupLayer()
+        }
+        
+        /// Element의 기본적인 사이즈를 정의합니다.
+        override public var intrinsicContentSize: CGSize {
+            let textSize = getAttributedText().size()
+            let iconSize = size.iconSize
+            let edgeInsets = size.edgeInsets
+            let iconCount = [leftIcon, rightIcon].filter({ $0 != nil }).count
+            
+            return .init(
+                width: iconSize.width * CGFloat(iconCount) + textSize.width + edgeInsets.horizontal,
+                height: max(iconSize.height, textSize.height) + edgeInsets.vertical
+            )
         }
     }
 }
@@ -247,7 +260,11 @@ extension Button.TextButton {
     }
     
     private func updateTextLabel() {
-        textLabel.attributedText = .montage(
+        textLabel.attributedText = getAttributedText()
+    }
+    
+    private func getAttributedText() -> NSAttributedString {
+        .montage(
             text,
             varient: size.typoVarient,
             weight: .bold,

--- a/Sources/Montage/Element/Button/TextButton/TextButtonController.swift
+++ b/Sources/Montage/Element/Button/TextButton/TextButtonController.swift
@@ -10,24 +10,35 @@ import SwiftUI
 
 extension Button {
     public struct TextButtonController: UIViewRepresentable {
-        @State public var size: RoundButton.Size
-        @State public var leftIcon: Icon
-        @State public var rightIcon: Icon
+        @State public var size: TextButton.Size = .medium
+        @State public var leftIcon: Icon?
+        @State public var rightIcon: Icon?
         @State public var text: String
-        @State public var disable: Bool
+        @State public var disable: Bool = false
         
-        public typealias UIViewType = RoundButton
+        public typealias UIViewType = TextButton
         
         public func makeUIView(context: Context) -> UIViewType {
             .init()
         }
         
         public func updateUIView(_ uiView: UIViewType, context: Context) {
-            uiView.size = size
             uiView.leftIcon = leftIcon
             uiView.rightIcon = rightIcon
             uiView.text = text
             uiView.disable = disable
+        }
+    }
+}
+
+struct TextButtonController_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            Button.TextButtonController(text: "안녕하세요").fixedSize()
+            Button.TextButtonController(size: .small, text: "안녕하세요").fixedSize()
+            Button.TextButtonController(leftIcon: .bubbleFill, text: "안녕하세요").fixedSize()
+            Button.TextButtonController(rightIcon: .circleClose, text: "안녕하세요").fixedSize()
+            Button.TextButtonController(size: .small, text: "안녕하세요", disable: true).fixedSize()
         }
     }
 }

--- a/Sources/Montage/Extension/SwiftUI/View+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/View+Montage.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public extension View {
+extension View {
     public func elevation(_ elevation: Elevation) -> Self {
         var currentView = self
         

--- a/Sources/Montage/Extension/UIKit/UIEdgeInsets+Montage.swift
+++ b/Sources/Montage/Extension/UIKit/UIEdgeInsets+Montage.swift
@@ -1,0 +1,18 @@
+//
+//  UIEdgeInsets+Montage.swift
+//  Montage
+//
+//  Created by Euigyom Kim on 2023/04/13.
+//
+
+import UIKit
+
+extension UIEdgeInsets {
+    var horizontal: CGFloat {
+        left + right
+    }
+
+    var vertical: CGFloat {
+        top + bottom
+    }
+}


### PR DESCRIPTION
# 개요

### 📌 작업 완료 기한
- 2023/04/14

# 수정사항

## 수정 내용
SwiftUI 로 감싼 버튼들이 fixedSize 적용시 노출되지 않는 문제를 수정하였습니다.

- 버튼의 사이즈를 시스템이 추측할 수 있도록 각 버튼 클래스에 `intrinsicContentSize` 을 정의해 주었습니다.
- 각 버튼의 컨트롤러에 프리뷰 코드를 추가하였습니다.

# 확인사항
- [x] 동작 확인 
