### PR TITLE
chore: repo 에 PR 리뷰 여부 확인을 위한 Labeler 추가 (~4/18)

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Labeler
+
+on:
+  pull_request:
+	types: [synchronize]
+  pull_request_review:
+	types: [submitted]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+	timeout-minutes: 3
+	runs-on: [self-hosted, utility]
+	steps:
+	  - uses: jsryudev/pr-review-labeler@v0.2.2
+		with:
+		  repo-token: ${{ secrets.GITHUB_TOKEN }}
+		  target-approved-count: 2
+		  label-to-be-added: "accepted"
+		  label-to-be-removed: "in review"


### PR DESCRIPTION
# 개요

### 📌 작업 완료 기한
- 2023/04/18

# 수정사항

## 수정 내용
PR 리뷰가 2개 이상 진행 되었을 때, in review 라벨을 accepted 로 변경해주는 Labeler 를 적용하였습니다.

# 확인사항
- [ ] 동작 확인 
