### PR TITLE
feat: SwiftUI 에서 Element 내부 Handler 를 사용할 수 있도록 구현 (~4/21)

### DIFF
--- a/Sources/Montage/Element/Button/IconButton/IconButtonController.swift
+++ b/Sources/Montage/Element/Button/IconButton/IconButtonController.swift
@@ -13,6 +13,7 @@ extension Button {
         @State public var icon: Icon
         @State public var state: Decorate.Interaction.State = .normal
         @State public var disable: Bool = false
+        @State public var handler: (() -> Void)?
         
         public typealias UIViewType = IconButton
         
@@ -25,6 +26,7 @@ extension Button {
             uiView.icon = icon
             uiView.state = state
             uiView.disable = disable
+            uiView.handler = handler
         }
     }
 }

--- a/Sources/Montage/Element/Button/IconButton/IconButtonController.swift
+++ b/Sources/Montage/Element/Button/IconButton/IconButtonController.swift
@@ -34,9 +34,25 @@ extension Button {
 struct IconButtonController_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            Button.IconButtonController(varient: .normal, icon: .apps).fixedSize()
-            Button.IconButtonController(varient: .background, icon: .apps).fixedSize()
-            Button.IconButtonController(varient: .outlined(size: .normal), icon: .apps).fixedSize()
+            Button.IconButtonController(
+                varient: .normal,
+                icon: .apps
+            ) {
+                debugPrint(">>> hello world!")
+            }
+            .fixedSize()
+            
+            Button.IconButtonController(
+                varient: .background,
+                icon: .apps
+            )
+            .fixedSize()
+            
+            Button.IconButtonController(
+                varient: .outlined(size: .normal),
+                icon: .apps
+            )
+            .fixedSize()
         }
     }
 }

--- a/Sources/Montage/Element/Button/RoundButton/RoundButtonController.swift
+++ b/Sources/Montage/Element/Button/RoundButton/RoundButtonController.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Pretendard
 
 extension Button {
     public struct RoundButtonController: UIViewRepresentable {
@@ -46,7 +47,10 @@ struct RoundButtonController_Previews: PreviewProvider {
                     varient: .primary,
                     size: .large,
                     text: "안녕하세요"
-                ).fixedSize()
+                ) {
+                    debugPrint(">>> hello world!")
+                }
+                .fixedSize()
             }
             
             VStack(alignment: .leading) {
@@ -96,6 +100,9 @@ struct RoundButtonController_Previews: PreviewProvider {
                     disable: true
                 ).fixedSize()
             }
+        }
+        .onAppear {
+            try! Pretendard.registerFonts()
         }
     }
 }

--- a/Sources/Montage/Element/Button/RoundButton/RoundButtonController.swift
+++ b/Sources/Montage/Element/Button/RoundButton/RoundButtonController.swift
@@ -16,6 +16,7 @@ extension Button {
         @State public var text: String
         @State public var state: Decorate.Interaction.State = .normal
         @State public var disable: Bool = false
+        @State public var handler: (() -> Void)?
         
         public typealias UIViewType = RoundButton
         
@@ -31,6 +32,7 @@ extension Button {
             uiView.text = text
             uiView.state = state
             uiView.disable = disable
+            uiView.handler = handler
         }
     }
 }

--- a/Sources/Montage/Element/Button/TextButton/TextButtonController.swift
+++ b/Sources/Montage/Element/Button/TextButton/TextButtonController.swift
@@ -5,8 +5,9 @@
 //  Created by Euigyom Kim on 2023/04/11.
 //
 
-
 import SwiftUI
+
+import Pretendard
 
 extension Button {
     public struct TextButtonController: UIViewRepresentable {
@@ -36,11 +37,19 @@ extension Button {
 struct TextButtonController_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            Button.TextButtonController(text: "안녕하세요").fixedSize()
+            Button.TextButtonController(
+                text: "안녕하세요"
+            ) {
+                debugPrint(">>> hello world!")
+            }
+            .fixedSize()
             Button.TextButtonController(size: .small, text: "안녕하세요").fixedSize()
             Button.TextButtonController(leftIcon: .bubbleFill, text: "안녕하세요").fixedSize()
             Button.TextButtonController(rightIcon: .circleClose, text: "안녕하세요").fixedSize()
             Button.TextButtonController(size: .small, text: "안녕하세요", disable: true).fixedSize()
+        }
+        .onAppear {
+            try! Pretendard.registerFonts()
         }
     }
 }

--- a/Sources/Montage/Element/Button/TextButton/TextButtonController.swift
+++ b/Sources/Montage/Element/Button/TextButton/TextButtonController.swift
@@ -15,6 +15,7 @@ extension Button {
         @State public var rightIcon: Icon?
         @State public var text: String
         @State public var disable: Bool = false
+        @State public var handler: (() -> Void)?
         
         public typealias UIViewType = TextButton
         
@@ -27,6 +28,7 @@ extension Button {
             uiView.rightIcon = rightIcon
             uiView.text = text
             uiView.disable = disable
+            uiView.handler = handler
         }
     }
 }

--- a/Sources/Montage/Element/Control/Check/CheckController.swift
+++ b/Sources/Montage/Element/Control/Check/CheckController.swift
@@ -27,8 +27,7 @@ extension Control {
 struct MontageCheckController_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            Control.CheckController(state: .checked)
-                .frame(width: 24, height: 24)
+            Control.CheckController(state: .checked).fixedSize()
         }
     }
 }

--- a/Sources/Montage/Element/Control/Checkbox/CheckboxController.swift
+++ b/Sources/Montage/Element/Control/Checkbox/CheckboxController.swift
@@ -27,7 +27,7 @@ extension Control {
 struct CheckboxController_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            Control.CheckboxController(state: .checked)
+            Control.CheckboxController(state: .checked).fixedSize()
         }
     }
 }

--- a/Sources/Montage/Element/Control/Radio/RadioController.swift
+++ b/Sources/Montage/Element/Control/Radio/RadioController.swift
@@ -27,7 +27,7 @@ extension Control {
 struct RadioController_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            Control.RadioController(state: .checked).frame(width: 24, height: 24)
+            Control.RadioController(state: .checked).fixedSize()
         }
     }
 }


### PR DESCRIPTION
# 개요

### 📌 작업 완료 기한
- 2023/04/21

# 수정사항

## 수정 내용
SwiftUI 에서 사용하던 기존 Element의 경우 [onTapGesture](https://developer.apple.com/documentation/swiftui/view/ontapgesture(count:perform:)) 를 통해 터치 이벤트를 처리하게 의도했지만, Element 내부에 이미 존재하는 Handler 를 통해 터치 이벤트를 처리할 수 있도록 변경하여 closure 형태로 버튼 이벤트를 처리할 수 있게 수정하였습니다.

# 확인사항
- [x] 동작 확인 
