### PR TITLE
[PI-45329] feat: Push Badge 엘리먼트 구현 (~4/28)

### DIFF
--- a/Sources/Montage/Element/Badge/Content/ContentBadge.swift
+++ b/Sources/Montage/Element/Badge/Content/ContentBadge.swift
@@ -89,7 +89,7 @@ extension Badge {
         
         private weak var delegate: TextButtonDelegate?
         
-        /// TextButton 객체를 생성합니다.
+        /// 객체를 생성합니다.
         public init() {
             super.init(frame: .zero)
             

--- a/Sources/Montage/Element/Badge/Push/PushBadge.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadge.swift
@@ -13,12 +13,14 @@ extension Badge {
     public class Push: UIView {
         private enum Const {
             static let defaultDotSize: CGSize = .init(width: 4, height: 4)
+            static let defaultNumberLimit: Int = 1000
         }
         
         public enum Varient: Equatable {
             case dot, new, number(Int)
         }
         
+        /// 뱃지의 외관 값을 가져오거나 설정합니다.
         public var varient: Varient = .dot {
             didSet {
                 setupUpdateableConstraints()
@@ -31,7 +33,7 @@ extension Badge {
         
         private var stackViewConstraints: [NSLayoutConstraint] = []
         
-        /// Push 뱃지 객체를 생성합니다.
+        /// 객체를 생성합니다.
         public init() {
             super.init(frame: .zero)
             
@@ -154,7 +156,8 @@ extension Badge.Push {
         case .new:
             return .init(string: "N", attributes: attribute)
         case .number(let number):
-            return .init(string: "\(number)", attributes: attribute)
+            let numberStr = number >= Const.defaultNumberLimit ? "999+" : "\(number)"
+            return .init(string: numberStr, attributes: attribute)
         }
     }
 }

--- a/Sources/Montage/Element/Badge/Push/PushBadge.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadge.swift
@@ -140,12 +140,13 @@ extension Badge.Push {
 extension Badge.Push {
     private func getAttributedText() -> NSAttributedString? {
         let attribute: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 9.0, weight: .bold),
+            .font: UIFont.pretendard(ofSize: 9, weight: .bold),
             .foregroundColor: UIColor.alias(.staticWhite),
             .kern: 0.28,
             .paragraphStyle: {
                 let style = NSMutableParagraphStyle()
                 style.lineHeightMultiple = 1.07
+                style.alignment = .center
                 return style
             }()
         ]

--- a/Sources/Montage/Element/Badge/Push/PushBadge.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadge.swift
@@ -6,11 +6,168 @@
 //
 
 import UIKit
+import Pretendard
 
 extension Badge {
     /// 특정 요소에 대한 알림을 표시할 수 있는 뱃지입니다
     public class Push: UIView {
+        private enum Const {
+            static let defaultDotSize: CGSize = .init(width: 4, height: 4)
+        }
         
+        public enum Varient: Equatable {
+            case dot, new, number(Int)
+        }
+        
+        public var varient: Varient = .dot {
+            didSet {
+                setupUpdateableConstraints()
+                updateViews()
+            }
+        }
+        
+        private lazy var stackView = UIStackView()
+        private lazy var textLabel = UILabel()
+        
+        private var stackViewConstraints: [NSLayoutConstraint] = []
+        
+        /// Push 뱃지 객체를 생성합니다.
+        public init() {
+            super.init(frame: .zero)
+            
+            setupViews()
+        }
+        
+        public required init?(coder: NSCoder) {
+            super.init(coder: coder)
+            
+            setupViews()
+        }
+        
+        public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+            super.traitCollectionDidChange(previousTraitCollection)
+            
+            updateViews()
+        }
+        
+        public override func layoutSubviews() {
+            super.layoutSubviews()
+            
+            setupLayer()
+        }
+        
+        /// Element의 기본적인 사이즈를 정의합니다.
+        override public var intrinsicContentSize: CGSize {
+            guard let text = getAttributedText() else { return Const.defaultDotSize }
+            
+            let textSize = text.size()
+            let edgeInsets = varient.edgeInsets
+            
+            return .init(
+                width: textSize.width + edgeInsets.horizontal,
+                height: textSize.height + edgeInsets.vertical
+            )
+        }
     }
 }
 
+extension Badge.Push {
+    private func setupViews() {
+        addSubview(stackView)
+        
+        setupStackView()
+        setupUpdateableConstraints()
+        
+        updateViews()
+    }
+    
+    private func setupStackView() {
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.addArrangedSubview(textLabel)
+    }
+    
+    private func setupUpdateableConstraints() {
+        setupStackViewConstraints()
+        updateConstraints()
+        setupLayer()
+    }
+    
+    private func setupStackViewConstraints() {
+        NSLayoutConstraint.deactivate(stackViewConstraints)
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let insets = varient.edgeInsets
+        
+        let constraints = [
+            stackView.leftAnchor.constraint(equalTo: leftAnchor, constant: insets.left),
+            stackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -insets.right),
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -insets.bottom),
+            stackView.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ]
+        
+        NSLayoutConstraint.activate(constraints)
+        stackViewConstraints = constraints
+    }
+    
+    private func setupLayer() {
+        layer.cornerRadius = frame.height / 2
+        layer.masksToBounds = true
+    }
+}
+
+extension Badge.Push {
+    private func updateViews() {
+        updateColor()
+        updateTextLabel()
+        invalidateIntrinsicContentSize()
+    }
+    
+    private func updateColor() {
+        backgroundColor = .alias(.primaryNormal)
+    }
+    
+    private func updateTextLabel() {
+        textLabel.isHidden = varient == .dot
+        textLabel.attributedText = getAttributedText()
+    }
+}
+
+extension Badge.Push {
+    private func getAttributedText() -> NSAttributedString? {
+        let attribute: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 9.0, weight: .bold),
+            .foregroundColor: UIColor.alias(.staticWhite),
+            .kern: 0.28,
+            .paragraphStyle: {
+                let style = NSMutableParagraphStyle()
+                style.lineHeightMultiple = 1.07
+                return style
+            }()
+        ]
+        
+        switch varient {
+        case .dot:
+            return nil
+        case .new:
+            return .init(string: "N", attributes: attribute)
+        case .number(let number):
+            return .init(string: "\(number)", attributes: attribute)
+        }
+    }
+}
+
+extension Badge.Push.Varient {
+    var edgeInsets: UIEdgeInsets {
+        switch self {
+        case .dot:
+            return .init(top: 2, left: 2, bottom: 2, right: 2)
+        case .number:
+            return .init(top: 2, left: 5.5, bottom: 2, right: 5.5)
+        case .new:
+            return .init(top: 2, left: 4.5, bottom: 2, right: 4.5)
+        }
+    }
+}

--- a/Sources/Montage/Element/Badge/Push/PushBadge.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadge.swift
@@ -1,0 +1,16 @@
+//
+//  PushBadge.swift
+//  Montage
+//
+//  Created by Euigyom Kim on 2023/04/26.
+//
+
+import UIKit
+
+extension Badge {
+    /// 특정 요소에 대한 알림을 표시할 수 있는 뱃지입니다
+    public class Push: UIView {
+        
+    }
+}
+

--- a/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
@@ -5,4 +5,43 @@
 //  Created by Euigyom Kim on 2023/04/26.
 //
 
-import Foundation
+import SwiftUI
+import Pretendard
+
+extension Badge {
+    public struct PushBadgeController: UIViewRepresentable {
+        /// 뱃지의 외관입니다.
+        @State public var varient: Badge.Push.Varient = .dot
+        
+        public typealias UIViewType = Badge.Push
+        
+        public func makeUIView(context: Context) -> UIViewType {
+            .init()
+        }
+        
+        public func updateUIView(_ uiView: UIViewType, context: Context) {
+            uiView.varient = varient
+        }
+    }
+}
+
+var pushBadgeControllerPreview: some View {
+    VStack(alignment: .leading, spacing: .spacing(.pt20)) {
+        Badge.PushBadgeController(varient: .dot).fixedSize()
+        
+        Badge.PushBadgeController(varient: .new).fixedSize()
+        
+        Badge.PushBadgeController(varient: .number(1)).fixedSize()
+        
+        Badge.PushBadgeController(varient: .number(999)).fixedSize()
+    }
+}
+
+struct PushBadgeController_Previews: PreviewProvider {
+    static var previews: some View {
+        pushBadgeControllerPreview
+            .padding()
+            .background(SwiftUI.Color(.alias(.backgroundNormal)))
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
@@ -1,0 +1,8 @@
+//
+//  PushBadgeController.swift
+//  Montage
+//
+//  Created by Euigyom Kim on 2023/04/26.
+//
+
+import Foundation


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/NzeCJaXMkqRBlRd9CZCx8j/0-Component?node-id=1174%3A12997&t=g4XxBC84yipSJlp0-1

### 📌 작업 완료 기한
- 2023/04/28

# 수정사항

## 수정 내용
사용자에게 알림을 표현할 때 사용할 수 있는 Push Badge 엘리먼트를 구현하였습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 10 18 42](https://user-images.githubusercontent.com/712513/235031695-3715c24f-f093-43a3-b748-b147415b28a9.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 10 18 46](https://user-images.githubusercontent.com/712513/235031713-368877ed-a0e6-44c9-a0c0-bf6585c39cba.png)

# 확인사항
- [x] 동작 확인 
