### PR TITLE
[PI-47521] feat: 새로운 labelNeutral 컬러 추가 (~4/28)

### DIFF
--- a/Sources/Montage/Foundation/Color.swift
+++ b/Sources/Montage/Foundation/Color.swift
@@ -241,6 +241,11 @@ public enum Color {
         case labelStrong
         
         ///
+        /// Figma상의 `.color-alias-label-neutral` 토큰과 대응되는 값입니다.
+        ///
+        case labelNeutral
+        
+        ///
         /// Figma상의 `.color-alias-label-alternative` 토큰과 대응되는 값입니다.
         ///
         case labelAlternative
@@ -371,6 +376,8 @@ public enum Color {
                 globalType = style == .dark ? .globalNeutral99 : .globalNeutral10
             case .labelStrong:
                 globalType = style == .dark ? .globalCommon100 : .globalCommon0
+            case .labelNeutral:
+                globalType = style == .dark ? .globalNeutral80 : .globalNeutral30
             case .labelAlternative:
                 globalType = style == .dark ? .globalNeutral50 : .globalNeutral60
             case .labelAssistive:


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/j7Y8t3z3rni3snTsQGmq2q/1-Color---%F0%9F%8C%9A-Dark?node-id=108%3A2&t=9BEfxnlgsyXzmvRN-1

### 📌 작업 완료 기한
- 2023/04/28

# 수정사항

## 수정 내용
새로운 Alias 라벨 컬러인 .labelNeutral 을 추가하였습니다.

### 미리보기
📱|Light|Dark
---|---|---
iPhone|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 10 49 06](https://user-images.githubusercontent.com/712513/235035146-6b40806f-3629-43e1-83e4-f091b9f6bcac.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 10 49 10](https://user-images.githubusercontent.com/712513/235035159-32843b11-49ee-4c96-b991-4cff4c2c72ed.png)

# 확인사항
- [x] 동작 확인 
