### PR TITLE
[PI-47076] fix: Control 엘리먼트들에 대한 disable 상태 추가 (~4/28)

### DIFF
--- a/Sources/Montage/Components/Input/InputLabel.swift
+++ b/Sources/Montage/Components/Input/InputLabel.swift
@@ -37,10 +37,23 @@ public class InputLabel: UIView {
         set { elementView.state = newValue }
     }
     
+    public var bold: Bool = false {
+        didSet {
+            updateViews()
+        }
+    }
+    
+    public var disable: Bool = false {
+        didSet {
+            updateViews()
+        }
+    }
+    
     /// Input 요소를 설명하는 텍스트입니다.
     public var text: String? {
-        get { textLabel.attributedText?.string }
-        set { textLabel.attributedText = .montage(newValue ?? "", varient: Const.textVarient) }
+        didSet {
+            updateViews()
+        }
     }
     
     /// Input 요소에서 발생하는 이벤트를 수신하는 delegate 객체입니다.
@@ -122,9 +135,23 @@ extension InputLabel {
     }
 }
 
+extension InputLabel {
+    private func updateViews() {
+        isUserInteractionEnabled = false == disable
+        
+        elementView.disable = disable
+        textLabel.attributedText = .montage(
+            text ?? "",
+            varient: Const.textVarient,
+            color: disable ? .labelDisable : .labelNormal
+        )
+    }
+}
+
 /// 디자인시스템의 Input 요소들이 공통으로 가질 수 있는 프로퍼티를 정의한 프로토콜입니다.
 public protocol MontageControl: UIView {
     var state: MontageControlState { get set }
+    var disable: Bool { get set }
 }
 
 /// Input 요소들에서 사용할 수 있는 State를 정의합니다.

--- a/Sources/Montage/Element/Control/Check/Check.swift
+++ b/Sources/Montage/Element/Control/Check/Check.swift
@@ -33,6 +33,12 @@ extension Control {
             }
         }
         
+        public var disable: Bool = false {
+            didSet {
+                updateViews()
+            }
+        }
+        
         private lazy var imageView: UIImageView = {
             let view = UIImageView()
             view.isUserInteractionEnabled = false
@@ -100,11 +106,17 @@ extension Control.Check {
     }
     
     private func updateViews() {
+        isUserInteractionEnabled = false == disable
+        
         switch state {
         case .unchecked:
             imageView.tintColor = .alias(.labelAssistive)
         case .checked, .partial:
             imageView.tintColor = .alias(.primaryNormal)
+        }
+        
+        if disable {
+            imageView.tintColor = imageView.tintColor.withAlphaComponent(.opacity(.p060))
         }
     }
     

--- a/Sources/Montage/Element/Control/Checkbox/Checkbox.swift
+++ b/Sources/Montage/Element/Control/Checkbox/Checkbox.swift
@@ -113,28 +113,47 @@ extension Control.Checkbox {
         
         boxView.layer.cornerRadius = 3.0
         boxView.layer.borderWidth = 1.5
-        
-        switch state {
-        case .unchecked:
-            boxView.layer.backgroundColor = nil
-            boxView.layer.borderColor = UIColor.alias(.lineNormal).cgColor
-            imageView.image = nil
-        case .checked:
-            boxView.layer.backgroundColor = UIColor.alias(.primaryNormal).cgColor
-            boxView.layer.borderColor = UIColor.alias(.primaryNormal).cgColor
-            imageView.image = .montage(.checkThick)
-        case .partial:
-            boxView.layer.backgroundColor = UIColor.alias(.primaryNormal).cgColor
-            boxView.layer.borderColor = UIColor.alias(.primaryNormal).cgColor
-            imageView.image = .montage(.lineHorizontalThick)
-        }
-        
-        if disable {
-            imageView.tintColor = imageView.tintColor.withAlphaComponent(.opacity(.p060))
-        }
+        boxView.layer.backgroundColor = resolveCurrentBackgroundColor()
+        boxView.layer.borderColor = resolveCurrentBorderColor()
+        imageView.image = resolveCurrentImage()
     }
     
     @objc private func tapped() {
         delegate?.didTappedCheckbox(self)
+    }
+}
+
+extension Control.Checkbox {
+    private func resolveCurrentBackgroundColor() -> CGColor? {
+        let opacity: CGFloat = .opacity(disable ? .p060 : .p100)
+        
+        switch state {
+        case .unchecked:
+            return nil
+        case .checked, .partial:
+            return UIColor.alias(.primaryNormal).withAlphaComponent(opacity).cgColor
+        }
+    }
+    
+    private func resolveCurrentBorderColor() -> CGColor {
+        let opacity: CGFloat = .opacity(disable ? .p060 : .p100)
+        
+        switch state {
+        case .unchecked:
+            return UIColor.alias(.lineNormal).withAlphaComponent(opacity).cgColor
+        case .checked, .partial:
+            return UIColor.alias(.primaryNormal).withAlphaComponent(opacity).cgColor
+        }
+    }
+    
+    private func resolveCurrentImage() -> UIImage? {
+        switch state {
+        case .unchecked:
+            return nil
+        case .checked:
+            return .montage(.checkThick)
+        case .partial:
+            return .montage(.lineHorizontalThick)
+        }
     }
 }

--- a/Sources/Montage/Element/Control/Checkbox/Checkbox.swift
+++ b/Sources/Montage/Element/Control/Checkbox/Checkbox.swift
@@ -37,6 +37,12 @@ extension Control {
             }
         }
         
+        public var disable: Bool = false {
+            didSet {
+                updateViews()
+            }
+        }
+        
         private var tapRecognizer: UITapGestureRecognizer?
         
         private weak var delegate: CheckboxControlDelegate?
@@ -103,6 +109,8 @@ extension Control.Checkbox {
     }
     
     private func updateViews() {
+        isUserInteractionEnabled = false == disable
+        
         boxView.layer.cornerRadius = 3.0
         boxView.layer.borderWidth = 1.5
         
@@ -119,6 +127,10 @@ extension Control.Checkbox {
             boxView.layer.backgroundColor = UIColor.alias(.primaryNormal).cgColor
             boxView.layer.borderColor = UIColor.alias(.primaryNormal).cgColor
             imageView.image = .montage(.lineHorizontalThick)
+        }
+        
+        if disable {
+            imageView.tintColor = imageView.tintColor.withAlphaComponent(.opacity(.p060))
         }
     }
     

--- a/Sources/Montage/Element/Control/Radio/Radio.swift
+++ b/Sources/Montage/Element/Control/Radio/Radio.swift
@@ -34,6 +34,12 @@ extension Control {
             }
         }
         
+        public var disable: Bool = false {
+            didSet {
+                updateViews()
+            }
+        }
+        
         private lazy var boxView = UIView()
         
         private lazy var imageView: UIImageView = {
@@ -119,6 +125,8 @@ extension Control.Radio {
     }
     
     private func updateViews() {
+        isUserInteractionEnabled = false == disable
+        
         boxView.layer.cornerRadius = (Const.wrapperBoxSize.width - (Const.boxInset * 2)) / 2
         boxView.layer.borderWidth = 1.5
         
@@ -131,6 +139,10 @@ extension Control.Radio {
             boxView.layer.backgroundColor = UIColor.alias(.primaryNormal).cgColor
             boxView.layer.borderColor = UIColor.alias(.primaryNormal).cgColor
             imageView.image = .montage(.dot)
+        }
+        
+        if disable {
+            imageView.tintColor = imageView.tintColor.withAlphaComponent(.opacity(.p060))
         }
     }
     

--- a/Sources/Montage/Element/Control/Switch/Switch.swift
+++ b/Sources/Montage/Element/Control/Switch/Switch.swift
@@ -19,6 +19,12 @@ extension Control {
     public final class Switch: UISwitch {
         public weak var delegate: SwitchControlDelegate?
         
+        public var disable: Bool = false {
+            didSet {
+                self.isEnabled = false == disable
+            }
+        }
+        
         override init(frame: CGRect) {
             super.init(frame: frame)
             


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/NzeCJaXMkqRBlRd9CZCx8j/0-Component?node-id=1174%3A13000&t=g4XxBC84yipSJlp0-1

### 📌 작업 완료 기한
- 2023/04/28

# 수정사항

## 수정 내용
Control 엘리먼트들에서 누락되어 있던 disable 상태를 추가하고, 디자인에 맞도록 수정하였습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 12 27 05](https://user-images.githubusercontent.com/712513/235047876-0f9e7737-29ca-41b2-8928-b997bb953a61.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 12 25 40](https://user-images.githubusercontent.com/712513/235047891-f64ab28b-38c2-4a0c-8b01-2dd1040c8024.png)

# 확인사항
- [x] 동작 확인 
