### PR TITLE
[PI-47878] fix: 일부 버튼의 아이콘과 텍스트 사이 간격 조정 + edge inset 변경 (~5/4)

### DIFF
--- a/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
+++ b/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
@@ -124,9 +124,11 @@ extension Button {
             let iconSize = size.iconSize
             let edgeInsets = size.edgeInsets
             let iconCount = [leftIcon, rightIcon].filter({ $0 != nil }).count
+            let iconWidths = iconSize.width * CGFloat(iconCount)
+            let spacings = size.gap * CGFloat(iconCount)
             
             return .init(
-                width: iconSize.width * CGFloat(iconCount) + textSize.width + edgeInsets.horizontal,
+                width: iconWidths + spacings + textSize.width + edgeInsets.horizontal,
                 height: max(iconSize.height, textSize.height) + edgeInsets.vertical
             )
         }
@@ -157,7 +159,7 @@ extension Button.OutlinedButton {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = .spacing(.pt04)
+        stackView.spacing = size.gap
         stackView.addArrangedSubview(leftIconView)
         stackView.addArrangedSubview(textLabel)
         stackView.addArrangedSubview(rightIconView)
@@ -166,6 +168,7 @@ extension Button.OutlinedButton {
     private func setupUpdateableConstraints() {
         setupIconViewConstraints()
         setupStackViewConstraints()
+        stackView.spacing = size.gap
         updateConstraints()
         setupLayer()
     }
@@ -358,7 +361,18 @@ extension Button.OutlinedButton.Size {
         case .medium:
             return .init(top: 9, left: 20, bottom: 9, right: 20)
         case .small:
-            return .init(top: 7, left: 12, bottom: 7, right: 12)
+            return .init(top: 7, left: 14, bottom: 7, right: 14)
+        }
+    }
+    
+    var gap: CGFloat {
+        switch self {
+        case .large:
+            return 6.0
+        case .medium:
+            return 5.0
+        case .small:
+            return 4.0
         }
     }
 }

--- a/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
+++ b/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
@@ -120,9 +120,11 @@ extension Button {
             let iconSize = size.iconSize
             let edgeInsets = size.edgeInsets
             let iconCount = [leftIcon, rightIcon].filter({ $0 != nil }).count
+            let iconWidths = iconSize.width * CGFloat(iconCount)
+            let spacings = size.gap * CGFloat(iconCount)
             
             return .init(
-                width: iconSize.width * CGFloat(iconCount) + textSize.width + edgeInsets.horizontal,
+                width: iconWidths + spacings + textSize.width + edgeInsets.horizontal,
                 height: max(iconSize.height, textSize.height) + edgeInsets.vertical
             )
         }
@@ -153,7 +155,7 @@ extension Button.SolidButton {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = .spacing(.pt04)
+        stackView.spacing = size.gap
         stackView.addArrangedSubview(leftIconView)
         stackView.addArrangedSubview(textLabel)
         stackView.addArrangedSubview(rightIconView)
@@ -162,6 +164,7 @@ extension Button.SolidButton {
     private func setupUpdateableConstraints() {
         setupIconViewConstraints()
         setupStackViewConstraints()
+        stackView.spacing = size.gap
         updateConstraints()
         setupLayer()
     }
@@ -323,7 +326,18 @@ extension Button.SolidButton.Size {
         case .medium:
             return .init(top: 9, left: 20, bottom: 9, right: 20)
         case .small:
-            return .init(top: 7, left: 12, bottom: 7, right: 12)
+            return .init(top: 7, left: 14, bottom: 7, right: 14)
+        }
+    }
+    
+    var gap: CGFloat {
+        switch self {
+        case .large:
+            return 6.0
+        case .medium:
+            return 5.0
+        case .small:
+            return 4.0
         }
     }
 }

--- a/Sources/Montage/Element/Chip/Action/ActionChip.swift
+++ b/Sources/Montage/Element/Chip/Action/ActionChip.swift
@@ -10,10 +10,6 @@ import UIKit
 extension Chip {
     /// 액션을 설정하거나 실행(이동, 추가, 삭제)합니다.
     public class Action: UIView {
-        private enum Const {
-            static var iconSpacing: CGFloat = .spacing(.pt04)
-        }
-        
         /// 칩의 외관을 결정하는 열거형입니다.
         public enum Varient {
             case filled, outlined
@@ -125,7 +121,7 @@ extension Chip {
             let edgeInsets = size.edgeInsets
             let iconCount = [leftIcon, rightIcon].filter({ $0 != nil }).count
             let iconWidths = iconSize.width * CGFloat(iconCount)
-            let spacings = Const.iconSpacing * CGFloat(iconCount)
+            let spacings = size.gap * CGFloat(iconCount)
             
             return .init(
                 width: iconWidths + spacings + textSize.width + edgeInsets.horizontal,
@@ -159,7 +155,7 @@ extension Chip.Action {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = Const.iconSpacing
+        stackView.spacing = size.gap
         stackView.addArrangedSubview(leftIconView)
         stackView.addArrangedSubview(textLabel)
         stackView.addArrangedSubview(rightIconView)
@@ -168,6 +164,7 @@ extension Chip.Action {
     private func setupUpdateableConstraints() {
         setupIconViewConstraints()
         setupStackViewConstraints()
+        stackView.spacing = size.gap
         updateConstraints()
         setupLayer()
     }
@@ -359,7 +356,16 @@ extension Chip.Action.Size {
         case .medium:
             return .init(top: 6, left: 12, bottom: 6, right: 12)
         case .small:
-            return .init(top: 4, left: 8, bottom: 4, right: 8)
+            return .init(top: 4, left: 9, bottom: 4, right: 9)
+        }
+    }
+    
+    var gap: CGFloat {
+        switch self {
+        case .large:
+            return 5.0
+        case .medium, .small:
+            return 4.0
         }
     }
 }

--- a/Sources/Montage/Element/Chip/Filter/FilterChip.swift
+++ b/Sources/Montage/Element/Chip/Filter/FilterChip.swift
@@ -10,10 +10,6 @@ import UIKit
 extension Chip {
     /// 액션을 설정하거나 실행(이동, 추가, 삭제)합니다.
     public class Filter: UIView {
-        private enum Const {
-            static var iconSpacing: CGFloat = .spacing(.pt04)
-        }
-        
         /// 칩의 외관을 결정하는 열거형입니다.
         public enum Varient {
             case normal, expand
@@ -114,9 +110,10 @@ extension Chip {
             let textSize = getAttributedText().size()
             let iconSize = size.iconSize
             let edgeInsets = size.edgeInsets
+            let spacings = size.gap
             
             return .init(
-                width: iconSize.width + Const.iconSpacing + textSize.width + edgeInsets.horizontal,
+                width: iconSize.width + spacings + textSize.width + edgeInsets.horizontal,
                 height: max(iconSize.height, textSize.height) + edgeInsets.vertical
             )
         }
@@ -146,7 +143,7 @@ extension Chip.Filter {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = Const.iconSpacing
+        stackView.spacing = size.gap
         stackView.addArrangedSubview(textLabel)
         stackView.addArrangedSubview(arrowIconView)
     }
@@ -154,6 +151,7 @@ extension Chip.Filter {
     private func setupUpdateableConstraints() {
         setupIconViewConstraints()
         setupStackViewConstraints()
+        stackView.spacing = size.gap
         updateConstraints()
         setupLayer()
     }
@@ -320,6 +318,15 @@ extension Chip.Filter.Size {
             return .init(top: 9, left: 16, bottom: 9, right: 12)
         case .medium:
             return .init(top: 6, left: 12, bottom: 6, right: 12)
+        }
+    }
+    
+    var gap: CGFloat {
+        switch self {
+        case .large:
+            return 5.0
+        case .medium:
+            return 4.0
         }
     }
 }

--- a/Sources/Montage/Element/Chip/MultiSelect/MultiSelectChip.swift
+++ b/Sources/Montage/Element/Chip/MultiSelect/MultiSelectChip.swift
@@ -9,10 +9,6 @@ import UIKit
 
 extension Chip {
     final public class MultiSelect: UIView {
-        private enum Const {
-            static var iconSpacing: CGFloat = .spacing(.pt04)
-        }
-        
         /// 칩의 사이즈를 결정하는 열거형입니다.
         public enum Size {
             case medium, large
@@ -101,9 +97,10 @@ extension Chip {
             let textSize = getAttributedText().size()
             let iconSize = size.iconSize
             let edgeInsets = size.edgeInsets
+            let spacings = size.gap
             
             return .init(
-                width: iconSize.width + Const.iconSpacing + textSize.width + edgeInsets.horizontal,
+                width: iconSize.width + spacings + textSize.width + edgeInsets.horizontal,
                 height: max(iconSize.height, textSize.height) + edgeInsets.vertical
             )
         }
@@ -133,7 +130,7 @@ extension Chip.MultiSelect {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = Const.iconSpacing
+        stackView.spacing = size.gap
         stackView.addArrangedSubview(iconView)
         stackView.addArrangedSubview(textLabel)
     }
@@ -141,6 +138,7 @@ extension Chip.MultiSelect {
     private func setupUpdateableConstraints() {
         setupIconViewConstraints()
         setupStackViewConstraints()
+        stackView.spacing = size.gap
         updateConstraints()
         setupLayer()
     }
@@ -290,6 +288,15 @@ extension Chip.MultiSelect.Size {
             return .init(top: 9, left: 16, bottom: 9, right: 16)
         case .medium:
             return .init(top: 6, left: 12, bottom: 6, right: 12)
+        }
+    }
+    
+    var gap: CGFloat {
+        switch self {
+        case .large:
+            return 5.0
+        case .medium:
+            return 4.0
         }
     }
 }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/NzeCJaXMkqRBlRd9CZCx8j/0-Component?node-id=2632%3A19289&t=9bCFRedvBlB8lnHZ-1

### 📌 작업 완료 기한
- 2023/05/04

# 수정사항

## 수정 내용
SolidButton과 OutlinedButton의 Inset과 Spacing 값을 조정하였습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 14 Pro - 2023-05-04 at 11 50 06](https://user-images.githubusercontent.com/712513/236101304-eb05704a-044a-4bf0-b155-5daa4c0666a5.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-04 at 11 50 24](https://user-images.githubusercontent.com/712513/236101289-6aea0423-2fa2-4a8e-bd47-5b27cf74c42d.png)

# 확인사항
- [x] 동작 확인 
