### PR TITLE
fix: 타이포그래피 매핑 바로잡기 (~5/10)

### DIFF
--- a/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
+++ b/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
@@ -350,7 +350,7 @@ extension Button.OutlinedButton.Size {
         case .medium:
             return .body2
         case .small:
-            return .label1
+            return .label2
         }
     }
     

--- a/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
+++ b/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
@@ -315,7 +315,7 @@ extension Button.SolidButton.Size {
         case .medium:
             return .body2
         case .small:
-            return .label1
+            return .label2
         }
     }
     


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/NzeCJaXMkqRBlRd9CZCx8j/0-Component?type=design&node-id=423-8298&t=wUdfKTmli1luyEel-4

### 📌 작업 완료 기한
- 2023/05/10

# 수정사항

## 수정 내용
버튼에서 small 사이즈일 때 타이포그래피를 의도했던 `label2`로 개선합니다. 큰 수정사항이 아닌 듯해 직접 PR을 드려보았습니다!

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 14 Pro - 2023-05-10 at 17 30 16](https://github.com/wanteddev/montage-ios/assets/7247848/78ab8314-db44-494d-bb76-616ed4f19f2d)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-10 at 17 29 38](https://github.com/wanteddev/montage-ios/assets/7247848/472b9152-2ed2-4dd4-95a3-5220497ed5de)


# 확인사항
- [x] 동작 확인 
