### PR TITLE
fix: 타이포그래피 관련 코드 개선

### DIFF
--- a/Sources/Montage/Extension/SwiftUI/Text+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/Text+Montage.swift
@@ -10,14 +10,11 @@ import SwiftUI
 public extension Text {
     func montage(
         varient: Typography.Variant = .body1,
-        size: Typography.Size = .small,
         weight: Typography.Weight = .regular,
         color: Color.Alias = .labelNormal
-    ) -> some View {
-        font(.montage(varient: varient, weight: weight, size: size))
+    ) -> Text {
+        font(.montage(varient: varient, weight: weight, size: .small))
+            .tracking(Typography.getTracking(varient: varient, size: .small))
             .foregroundColor(.alias(color))
-            .tracking(Typography.getTracking(varient: varient, size: size))
-            .lineSpacing(varient.lineSpacing)
-            .padding(.vertical, varient.padding)
     }
 }

--- a/Sources/Montage/Extension/SwiftUI/Text+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/Text+Montage.swift
@@ -10,11 +10,12 @@ import SwiftUI
 public extension Text {
     func montage(
         varient: Typography.Variant = .body1,
+        size: Typography.Size = .small,
         weight: Typography.Weight = .regular,
         color: Color.Alias = .labelNormal
     ) -> Text {
-        font(.montage(varient: varient, weight: weight, size: .small))
-            .tracking(Typography.getTracking(varient: varient, size: .small))
+        font(.montage(varient: varient, weight: weight, size: size))
+            .tracking(Typography.getTracking(varient: varient, size: size))
             .foregroundColor(.alias(color))
     }
 }

--- a/Sources/Montage/Extension/SwiftUI/View+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/View+Montage.swift
@@ -30,4 +30,8 @@ extension View {
         
         return currentView
     }
+    
+    public func paragraph(varient: Typography.Variant) -> some View {
+        lineSpacing(varient.lineSpacing).padding(.vertical, varient.padding)
+    }
 }

--- a/Sources/Montage/Extension/UIKit/NSAttributedString+Montage.swift
+++ b/Sources/Montage/Extension/UIKit/NSAttributedString+Montage.swift
@@ -42,6 +42,7 @@ public extension NSAttributedString {
                 style.alignment = .left
                 style.minimumLineHeight = lineHeight
                 style.lineBreakMode = lineBreakMode
+                style.lineBreakStrategy = .hangulWordPriority
                 return style
             }()
         ])

--- a/Sources/Montage/Foundation/Typography.swift
+++ b/Sources/Montage/Foundation/Typography.swift
@@ -226,7 +226,7 @@ public extension Typography.Variant {
         case .label1:
             return 3.3333
         case .label1Reading:
-            return 5
+            return 5.3333
         case .label2:
             return 3.3333
         case .caption1:

--- a/Sources/Montage/Foundation/Typography.swift
+++ b/Sources/Montage/Foundation/Typography.swift
@@ -31,6 +31,7 @@ public enum Typography {
         case body2
         case body2Reading
         case label1
+        case label1Reading
         case label2
         case caption1
         case caption2
@@ -118,6 +119,8 @@ public extension Typography {
             return 15
         case .label1:
             return 14
+        case .label1Reading:
+            return 14
         case .label2:
             return 13
         case .caption1:
@@ -152,6 +155,8 @@ public extension Typography {
             letterSpacingEm = 0.0096
         case .label1:
             letterSpacingEm = 0.0145
+        case .label1Reading:
+            letterSpacingEm = 0.0145
         case .label2:
             letterSpacingEm = 0.0194
         case .caption1:
@@ -185,6 +190,8 @@ public extension Typography {
             return 24
         case .label1:
             return 20
+        case .label1Reading:
+            return 22
         case .label2:
             return 18
         case .caption1:
@@ -218,6 +225,8 @@ public extension Typography.Variant {
             return 6
         case .label1:
             return 3.3333
+        case .label1Reading:
+            return 5
         case .label2:
             return 3.3333
         case .caption1:


### PR DESCRIPTION
# 개요

### 📌 작업 완료 기한
- 2023/06/23

# 수정사항

## 수정 내용
타이포그래피 관련 코드들을 개선하여 좀 더 사용성을 높였습니다.

- SwiftUI에서 사용되던 Text Extension의 반환값을 View에서 Text로 변경하여 각각 다른 스타일의 Text들을 합칠 수 있도록 개선하였습니다.
- SwiftUI의 View Extension에 `.paragraph(_:)`를 추가하여 문단에 대한 스타일을 Text와 따로 적용할 수 있도록 하였습니다.
- `.label1Reading` Varient가 추가되었습니다. [피그마 디자인 링크](https://www.figma.com/file/2orYfqIiuFhTGXKN1GARg7/2-Typo%2FGrid---%F0%9F%93%B1Small?type=design&node-id=1161%3A1141&mode=design&t=atDh7ezOqxBldZXB-1) 첨부 드립니다.

# 확인사항
- [x] 동작 확인 
