### PR TITLE
fix: Chip 컴포넌트의 cornerRadius 사이즈를 조정 (~1/5)

### DIFF
--- a/Sources/Montage/Element/Chip/Action/ActionChip.swift
+++ b/Sources/Montage/Element/Chip/Action/ActionChip.swift
@@ -216,7 +216,7 @@ extension Chip.Action {
     }
     
     private func setupLayer() {
-        layer.cornerRadius = frame.height / 2
+        layer.cornerRadius = size.cornerRadius
         layer.masksToBounds = true
     }
 }
@@ -365,6 +365,17 @@ extension Chip.Action.Size {
         case .large:
             return 5.0
         case .medium, .small:
+            return 4.0
+        }
+    }
+    
+    var cornerRadius: CGFloat {
+        switch self {
+        case .large:
+            return 8.0
+        case .medium:
+            return 6.0
+        case .small:
             return 4.0
         }
     }

--- a/Sources/Montage/Element/Chip/Filter/FilterChip.swift
+++ b/Sources/Montage/Element/Chip/Filter/FilterChip.swift
@@ -200,7 +200,7 @@ extension Chip.Filter {
     }
     
     private func setupLayer() {
-        layer.cornerRadius = frame.height / 2
+        layer.cornerRadius = size.cornerRadius
         layer.masksToBounds = true
     }
 }
@@ -327,6 +327,15 @@ extension Chip.Filter.Size {
             return 5.0
         case .medium:
             return 4.0
+        }
+    }
+    
+    var cornerRadius: CGFloat {
+        switch self {
+        case .large:
+            return 8.0
+        case .medium:
+            return 6.0
         }
     }
 }

--- a/Sources/Montage/Element/Chip/MultiSelect/MultiSelectChip.swift
+++ b/Sources/Montage/Element/Chip/MultiSelect/MultiSelectChip.swift
@@ -187,7 +187,7 @@ extension Chip.MultiSelect {
     }
     
     private func setupLayer() {
-        layer.cornerRadius = frame.height / 2
+        layer.cornerRadius = size.cornerRadius
         layer.masksToBounds = true
     }
 }
@@ -297,6 +297,15 @@ extension Chip.MultiSelect.Size {
             return 5.0
         case .medium:
             return 4.0
+        }
+    }
+    
+    var cornerRadius: CGFloat {
+        switch self {
+        case .large:
+            return 8.0
+        case .medium:
+            return 6.0
         }
     }
 }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/7RHtWV3Pw6I98UEDjbx5V1/0-Component?type=design&node-id=476%3A6441&mode=dev

### 📌 작업 완료 기한
- 2024/01/05

# 수정사항

## 수정 내용
Chip 컴포넌트의 cornerRadius 사이즈를 최신화 하였습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 15 Pro - 2024-01-04 at 17 46 52](https://github.com/wanteddev/montage-ios/assets/712513/86a74cb9-95ab-4c68-946a-80d0ae26dfc3)|![Simulator Screenshot - iPhone 15 Pro - 2024-01-04 at 17 46 36](https://github.com/wanteddev/montage-ios/assets/712513/1290b93d-a2e6-4e48-a9c3-33197bd130e9)

# 확인사항
- [x] 동작 확인 
