### PR TITLE
[PI-59445] 버튼 위에서 스크롤되도록 하고 스크롤 시 버튼이 눌리지 않도록 수정 (~1/24)

### DIFF
--- a/Sources/Montage/Element/Button/IconButton/IconButton.swift
+++ b/Sources/Montage/Element/Button/IconButton/IconButton.swift
@@ -214,7 +214,10 @@ extension Button.IconButton {
         switch recognizer.state {
         case .began:
             interaction.state = .pressed
+        case .changed:
+            interaction.state = .normal
         case .ended:
+            guard interaction.state == .pressed else { return }
             if let view = recognizer.view, view.bounds.contains(recognizer.location(in: recognizer.view)) {
                 handler?()
             }
@@ -230,7 +233,7 @@ extension Button.IconButton: UIGestureRecognizerDelegate {
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        return false
+        return true
     }
 }
 

--- a/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
+++ b/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
@@ -301,7 +301,10 @@ extension Button.OutlinedButton {
         switch recognizer.state {
         case .began:
             interaction.state = .pressed
+        case .changed:
+            interaction.state = .normal
         case .ended:
+            guard interaction.state == .pressed else { return }
             if let view = recognizer.view, view.bounds.contains(recognizer.location(in: recognizer.view)) {
                 handler?()
             }
@@ -317,7 +320,7 @@ extension Button.OutlinedButton: UIGestureRecognizerDelegate {
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        return false
+        return true
     }
 }
 

--- a/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
+++ b/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
@@ -294,7 +294,10 @@ extension Button.SolidButton {
         switch recognizer.state {
         case .began:
             interaction.state = .pressed
+        case .changed:
+            interaction.state = .normal
         case .ended:
+            guard interaction.state == .pressed else { return }
             if let view = recognizer.view, view.bounds.contains(recognizer.location(in: recognizer.view)) {
                 handler?()
             }
@@ -310,7 +313,7 @@ extension Button.SolidButton: UIGestureRecognizerDelegate {
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        return false
+        return true
     }
 }
 

--- a/Sources/Montage/Element/Button/TextButton/TextButton.swift
+++ b/Sources/Montage/Element/Button/TextButton/TextButton.swift
@@ -289,7 +289,10 @@ extension Button.TextButton {
         switch recognizer.state {
         case .began:
             interaction.state = .pressed
+        case .changed:
+            interaction.state = .normal
         case .ended:
+            guard interaction.state == .pressed else { return }
             if let view = recognizer.view, view.bounds.contains(recognizer.location(in: recognizer.view)) {
                 handler?()
             }
@@ -305,7 +308,7 @@ extension Button.TextButton: UIGestureRecognizerDelegate {
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        return false
+        return true
     }
 }
 

--- a/Sources/Montage/Element/Chip/Action/ActionChip.swift
+++ b/Sources/Montage/Element/Chip/Action/ActionChip.swift
@@ -145,6 +145,7 @@ extension Chip.Action {
     
     private func bindEvent() {
         let longPressRecognizer = UILongPressGestureRecognizer()
+        longPressRecognizer.delegate = self
         longPressRecognizer.minimumPressDuration = 0
         longPressRecognizer.cancelsTouchesInView = false
         longPressRecognizer.addTarget(self, action: #selector(longPressed))
@@ -295,7 +296,10 @@ extension Chip.Action {
         switch recognizer.state {
         case .began:
             interaction.state = .pressed
+        case .changed:
+            interaction.state = .normal
         case .ended:
+            guard interaction.state == .pressed else { return }
             if let view = recognizer.view, view.bounds.contains(recognizer.location(in: recognizer.view)) {
                 handler?()
             }
@@ -303,6 +307,15 @@ extension Chip.Action {
         default:
             break
         }
+    }
+}
+
+extension Chip.Action: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        return true
     }
 }
 


### PR DESCRIPTION
### 📌 작업 완료 기한
- 2024/01/18

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->

기본 버튼은 버튼 위에서 스크롤이 되고 있고 스크롤 시 버튼이 눌리지 않도록 되어 있어서 
비슷하게 수정해보았습니다.
추가로 Chip.Action 쪽도 스크롤이 되고 있지 않아서 버튼과 동일하게 구현하였습니다.

### 미리보기
작업 전

https://github.com/wanteddev/montage-ios/assets/4862222/f71e0fb6-6c1f-45bf-8048-a614f94368a1

작업 후

https://github.com/wanteddev/montage-ios/assets/4862222/7efdbb5e-a43d-4c42-944f-8a0f6b96ef06



