### PR TITLE
fix: 타이포그래피 행간 및 자간 업데이트

### DIFF
--- a/Sources/Montage/Foundation/Typography.swift
+++ b/Sources/Montage/Foundation/Typography.swift
@@ -148,7 +148,7 @@ public extension Typography {
         case .title1:
             letterSpacingEm = -0.027
         case .title2:
-            letterSpacingEm = -0.0246
+            letterSpacingEm = -0.0236
         case .title3:
             letterSpacingEm = -0.023
         case .heading1:
@@ -156,9 +156,9 @@ public extension Typography {
         case .heading2:
             letterSpacingEm = -0.012
         case .headline1:
-            letterSpacingEm = -0.001
+            letterSpacingEm = -0.002
         case .headline2:
-            letterSpacingEm = -0.001
+            letterSpacingEm = 0
         case .body1:
             letterSpacingEm = 0.0057
         case .body1Reading:

--- a/Sources/Montage/Foundation/Typography.swift
+++ b/Sources/Montage/Foundation/Typography.swift
@@ -195,9 +195,9 @@ public extension Typography {
         case .title3:
             return 32
         case .heading1:
-            return 28
+            return 30
         case .heading2:
-            return 26
+            return 28
         case .headline1:
             return 26
         case .headline2:
@@ -238,9 +238,9 @@ public extension Typography.Variant {
         case .title3:
             return 3.3333
         case .heading1:
-            return 2
+            return 3.6667
         case .heading2:
-            return 2
+            return 4
         case .headline2:
             return 1.6667
         case .headline1:


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/file/2orYfqIiuFhTGXKN1GARg7/2-Typo-%2F-Grid?type=design&node-id=3269-6206&mode=design&t=lRghQinWsUb6ro5j-4

### 📌 작업 완료 기한
- 2024/02/07

# 수정사항

## 수정 내용
타이포그래피 시스템 업데이트를 반영합니다.
- Heading 1 및 Heading 2의 행간을 2pt씩 높였습니다.
- 자간을 고르게 맞췄습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
행간|![Heading1-2-LineHeight-Before](https://github.com/wanteddev/montage-ios/assets/7247848/8dc09442-7ffc-4975-aab3-078614c965c8)|![Heading1-2-LineHeight-After](https://github.com/wanteddev/montage-ios/assets/7247848/fabf6282-3e42-49a0-9e93-a23059166bdc)
자간|![Title2-LetterSpacing-Before](https://github.com/wanteddev/montage-ios/assets/7247848/0460e635-8902-4ff2-9549-1aa0e4d0185d)|![Title2-LetterSpacing-After](https://github.com/wanteddev/montage-ios/assets/7247848/22795b33-d913-47a5-b7ee-0b9ee8236e8d)
자간|![Headline1-2-LetterSpacing-Before](https://github.com/wanteddev/montage-ios/assets/7247848/766b15a2-7fba-46ff-b978-d42fc880fcb0)|![Headline1-2-LetterSpacing-After](https://github.com/wanteddev/montage-ios/assets/7247848/f88eb723-77a8-47d8-8ef9-b6e9bfbf50e0)



# 확인사항
- [x] 동작 확인 
