### PR TITLE
컬러 추가 및 업데이트 (~4/11)

### DIFF
--- a/Sources/Montage/Asset/Color.xcassets/Purple/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple0.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple0.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple10.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x47",
+          "green" : "0x02",
+          "red" : "0x29"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple100.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple20.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7D",
+          "green" : "0x0A",
+          "red" : "0x58"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple30.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple30.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB8",
+          "green" : "0x1C",
+          "red" : "0x86"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple40.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple40.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE3",
+          "green" : "0x36",
+          "red" : "0xAD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple50.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x59",
+          "red" : "0xCB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple60.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple60.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x78",
+          "red" : "0xD4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple70.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple70.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x96",
+          "red" : "0xDE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple80.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple80.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xBA",
+          "red" : "0xE9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple90.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple90.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xD6",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple95.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple95.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xED",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple99.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Purple/globalPurple99.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFB",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Montage/Asset/Color.xcassets/Red/globalRed20.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Red/globalRed20.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x04",
-          "green" : "0x04",
-          "red" : "0x75"
+          "blue" : "0x03",
+          "green" : "0x03",
+          "red" : "0x73"
         }
       },
       "idiom" : "universal"

--- a/Sources/Montage/Asset/Color.xcassets/Red/globalRed30.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/Red/globalRed30.colorset/Contents.json
@@ -7,7 +7,7 @@
           "alpha" : "1.000",
           "blue" : "0x0C",
           "green" : "0x0C",
-          "red" : "0xB2"
+          "red" : "0xB0"
         }
       },
       "idiom" : "universal"

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange10.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange10.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0x2E",
-        "green": "0x11",
-        "blue": "0x00"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x0F",
+          "red" : "0x29"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange20.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange20.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0x5C",
-        "green": "0x22",
-        "blue": "0x00"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x21",
+          "red" : "0x59"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange30.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange30.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0x94",
-        "green": "0x36",
-        "blue": "0x00"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x35",
+          "red" : "0x91"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange40.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange40.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0xCC",
-        "green": "0x4B",
-        "blue": "0x00"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x4A",
+          "red" : "0xC9"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange50.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange50.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0xFF",
-        "green": "0x5E",
-        "blue": "0x00"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x5E",
+          "red" : "0xFF"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange60.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange60.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0xFF",
-        "green": "0x7B",
-        "blue": "0x2E"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2E",
+          "green" : "0x7B",
+          "red" : "0xFF"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange70.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange70.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x63",
-          "green" : "0x9C",
+          "blue" : "0x61",
+          "green" : "0x9B",
           "red" : "0xFF"
         }
       },

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange80.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange80.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0xFF",
-        "green": "0xC0",
-        "blue": "0x9C"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x96",
+          "green" : "0xBD",
+          "red" : "0xFF"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange90.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange90.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0xFE",
-        "green": "0xDB",
-        "blue": "0xC6"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC4",
+          "green" : "0xD9",
+          "red" : "0xFE"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange95.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange95.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0xFE",
-        "green": "0xEE",
-        "blue": "0xE5"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xEE",
+          "red" : "0xFE"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange99.colorset/Contents.json
+++ b/Sources/Montage/Asset/Color.xcassets/RedOrange/globalRedOrange99.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "colors": [
+  "colors" : [
     {
-      "color": {
-        "alpha": 1.0,
-        "red": "0xFF",
-        "green": "0xFA",
-        "blue": "0xF7"
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xFA",
+          "red" : "0xFF"
+        }
       },
-      "idiom": "universal"
+      "idiom" : "universal"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Montage/Foundation/Color.swift
+++ b/Sources/Montage/Foundation/Color.swift
@@ -184,6 +184,21 @@ public enum Color {
         case globalViolet10
         case globalViolet0
         
+        // PURPLE
+        case globalPurple100
+        case globalPurple99
+        case globalPurple95
+        case globalPurple90
+        case globalPurple80
+        case globalPurple70
+        case globalPurple60
+        case globalPurple50
+        case globalPurple40
+        case globalPurple30
+        case globalPurple20
+        case globalPurple10
+        case globalPurple0
+        
         // PINK
         case globalPink100
         case globalPink99
@@ -374,6 +389,11 @@ public enum Color {
         case accentViolet
         
         ///
+        /// Figma상의 `.color-alias-accent-purple` 토큰과 대응되는 값입니다.
+        ///
+        case accentPurple
+        
+        ///
         /// Figma상의 `.color-alias-accent-redOrange` 토큰과 대응되는 값입니다.
         ///
         case accentRedOrange
@@ -462,6 +482,8 @@ public enum Color {
                 globalType = style == .dark ? .globalLightBlue60 : .globalLightBlue50
             case .accentViolet:
                 globalType = style == .dark ? .globalViolet60 : .globalViolet50
+            case .accentPurple:
+                globalType = style == .dark ? .globalPurple60 : .globalPurple50
             case .accentPink:
                 globalType = style == .dark ? .globalPink60 : .globalPink50
             case .accentRedOrange:
@@ -561,6 +583,7 @@ public enum Color {
         case cyan
         case lightBlue
         case violet
+        case purple
         case pink
         case redOrange
         
@@ -582,6 +605,8 @@ public enum Color {
                 return .accentLightBlue
             case .violet:
                 return .accentViolet
+            case .purple:
+                return .accentPurple
             case .pink:
                 return .accentPink
             case .redOrange:

--- a/Sources/Montage/Foundation/Color.swift
+++ b/Sources/Montage/Foundation/Color.swift
@@ -562,6 +562,7 @@ public enum Color {
         case lightBlue
         case violet
         case pink
+        case redOrange
         
         func resolveAsAlias() -> Alias {
             switch self {
@@ -583,6 +584,8 @@ public enum Color {
                 return .accentViolet
             case .pink:
                 return .accentPink
+            case .redOrange:
+                return .accentRedOrange
             }
         }
         


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://wantedx.slack.com/archives/C068KCRS2LD/p1712544312279499

### 📌 작업 완료 기한
- 2024/04/11

# 수정사항
- 컬러 시스템에서 팔레트 수정 및 추가, 시멘틱 추가가 있습니다.
- Display P3 프로필이던 색을 sRGB로 맞췄습니다.

## 수정 내용
#### 팔레트
추가:
- Purple/99: `#FEFBFF`
- Purple/95: `#F9EDFF`
- Purple/90: `#F2D6FF`
- Purple/80: `#E9BAFF`
- Purple/70: `#DE96FF`
- Purple/60: `#D478FF`
- Purple/50: `#CB59FF`
- Purple/40: `#AD36E3`
- Purple/30: `#861CB8`
- Purple/20: `#580A7D`
- Purple/10: `#290247`

업데이트:
- Red/30: `#B00C0C` (이전 `#B20C0C`)
- Red/20: `#730303` (이전 `#750404`)
- Red Orange/90: `#FED9C4` (이전 `#FEDBC6`)
- Red Orange/80: `#FFBD96` (이전 `#FFC09C`)
- Red Orange/70: `#FF9B61` (이전 `#FF9C63`)
- Red Orange/40: `#C94A00` (이전 `#CC4B00`)
- Red Orange/30: `#913500` (이전 `#943600`)
- Red Orange/20: `#592100` (이전 `#5C2200`)
- Red Orange/10: `#290F00` (이전 `#2E1100`)

컬러 프로필 변경:
- Red Orange: sRGB로 변경

—

#### 시멘틱
추가:
- Accent/Purple
    - Light: `Purple/50`
    - Dark: `Purple/60`

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![1-1](https://github.com/wanteddev/montage-ios/assets/7247848/97533751-2ba0-4ab1-a32b-6b17f0cf7f07)|![1-2](https://github.com/wanteddev/montage-ios/assets/7247848/34ff3e00-1b55-4f22-a844-2451fd68df43)
iPhone|![2-1](https://github.com/wanteddev/montage-ios/assets/7247848/9cdf8e97-947d-4da8-870f-fddf95afff22)|![2-2](https://github.com/wanteddev/montage-ios/assets/7247848/a0346f67-2895-473f-8867-ff03eee4eabd)
iPhone|![3-1](https://github.com/wanteddev/montage-ios/assets/7247848/4f29778b-ca08-41b2-ac94-b44e61039529)|![3-2](https://github.com/wanteddev/montage-ios/assets/7247848/d955f887-7e8e-4837-98c9-e1d9eb83510b)
iPhone|![4-1](https://github.com/wanteddev/montage-ios/assets/7247848/f9ebb198-021e-49f0-93bd-287539be9199)|![4-2](https://github.com/wanteddev/montage-ios/assets/7247848/1e52f88c-e220-4923-bba8-2fb606baac7a)
iPhone|![5](https://github.com/wanteddev/montage-ios/assets/7247848/309eb7d9-66a3-4151-aaab-2dfbaa49e80a)|--


# 확인사항
- [x] 동작 확인 

