### PR TITLE
[PI-63802] 3D Touch가 있는 모델에서 3D Touch를 off하면 버튼이 눌리지 않는 현상 수정 (~5/13)

### DIFF
--- a/Sources/Montage/Element/Button/IconButton/IconButton.swift
+++ b/Sources/Montage/Element/Button/IconButton/IconButton.swift
@@ -217,7 +217,8 @@ extension Button.IconButton {
         case .changed:
             // 스크롤 시 버튼이 눌리지 않도록 state를 normal로 변경
             // 3D touch 모델은 스크롤 하지 않아도 changed가 실행되서 적용하지 않음
-            if traitCollection.forceTouchCapability != UIForceTouchCapability.available {
+            if traitCollection.forceTouchCapability != UIForceTouchCapability.available
+                && traitCollection.forceTouchCapability != UIForceTouchCapability.unavailable {
                 interaction.state = .normal
             }
         case .ended:

--- a/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
+++ b/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
@@ -304,7 +304,8 @@ extension Button.OutlinedButton {
         case .changed:
             // 스크롤 시 버튼이 눌리지 않도록 state를 normal로 변경
             // 3D touch 모델은 스크롤 하지 않아도 changed가 실행되서 적용하지 않음
-            if traitCollection.forceTouchCapability != UIForceTouchCapability.available {
+            if traitCollection.forceTouchCapability != UIForceTouchCapability.available
+                && traitCollection.forceTouchCapability != UIForceTouchCapability.unavailable {
                 interaction.state = .normal
             }
         case .ended:

--- a/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
+++ b/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
@@ -297,7 +297,8 @@ extension Button.SolidButton {
         case .changed:
             // 스크롤 시 버튼이 눌리지 않도록 state를 normal로 변경
             // 3D touch 모델은 스크롤 하지 않아도 changed가 실행되서 적용하지 않음
-            if traitCollection.forceTouchCapability != UIForceTouchCapability.available {
+            if traitCollection.forceTouchCapability != UIForceTouchCapability.available
+                && traitCollection.forceTouchCapability != UIForceTouchCapability.unavailable {
                 interaction.state = .normal
             }
         case .ended:

--- a/Sources/Montage/Element/Button/TextButton/TextButton.swift
+++ b/Sources/Montage/Element/Button/TextButton/TextButton.swift
@@ -292,7 +292,8 @@ extension Button.TextButton {
         case .changed:
             // 스크롤 시 버튼이 눌리지 않도록 state를 normal로 변경
             // 3D touch 모델은 스크롤 하지 않아도 changed가 실행되서 적용하지 않음
-            if traitCollection.forceTouchCapability != UIForceTouchCapability.available {
+            if traitCollection.forceTouchCapability != UIForceTouchCapability.available
+                && traitCollection.forceTouchCapability != UIForceTouchCapability.unavailable {
                 interaction.state = .normal
             }
         case .ended:


### PR DESCRIPTION
# 개요
- 🔗 JIRA 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-63802

### 📌 작업 완료 기한
- 2024/05/13

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->

3D Touch가 있는 기기에서 버튼을 눌렀을 때 touch change event가 발생하여 
traitCollection.forceTouchCapability가 available이 아닐 때만 button의 state를 normal로 설정했는데
3D Touch가 있는 기기는 설정에서 3D Touch를 off할 수 있어서 이 때는  traitCollection.forceTouchCapability가 unavailable이 되어 버튼을 눌렀을 때 state가 normal로 설정되는 이슈입니다.

3D Touch를 off했을 때 unavailable값도 체크하여 state가 normal로 변경되지 않도록 수정하였습니다.


### 미리보기
작업 전|작업 후
---|---
<video src="https://github.com/wanteddev/montage-ios/assets/4862222/cdaf8ad1-8646-4f61-8504-54fbc8204453">|<video src="https://github.com/wanteddev/montage-ios/assets/4862222/7434fecd-a483-4534-9da5-5bcc64b481a5">

