### PR TITLE
fix: Icon 크기 조절 시 이미지 깨지는 현상 수정 (~5/22)

### DIFF
--- a/Sources/Montage/Asset/Icon.xcassets/android.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/android.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/apps.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/apps.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/arrowDown.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/arrowDown.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/arrowLeft.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/arrowLeft.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/arrowRight.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/arrowRight.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/arrowUp.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/arrowUp.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bell.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bell.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bellFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bellFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bellPlus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bellPlus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/blank.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/blank.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/book.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/book.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bookFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bookFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bookmark.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bookmark.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bookmarkFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bookmarkFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bubble.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bubble.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bubbleFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bubbleFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bubblePlus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bubblePlus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/bubblePlusFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/bubblePlusFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/businessBag.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/businessBag.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/businessBagFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/businessBagFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/calendar.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/calendar.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/camera.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/camera.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/cameraFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/cameraFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/caretDown.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/caretDown.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/caretUp.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/caretUp.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/change.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/change.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/check.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/check.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/checkThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/checkThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeft.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeft.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeftSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeftSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeftThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeftThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeftThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleLeftThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRight.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRight.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRightSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRightSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRightThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRightThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRightThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDoubleRightThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDown.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDown.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDownSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDownSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDownThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDownThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronDownThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronDownThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeft.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeft.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeftSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeftSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeftThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeftThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeftThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeftThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeftTight.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeftTight.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeftTightSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeftTightSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeftTightThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeftTightThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronLeftTightThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronLeftTightThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRight.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRight.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRightSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRightSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRightThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRightThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRightThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRightThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRightTight.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRightTight.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRightTightSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRightTightSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRightTightThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRightTightThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronRightTightThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronRightTightThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronUp.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronUp.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronUpSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronUpSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronUpThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronUpThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/chevronUpThickSmall.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/chevronUpThickSmall.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circle.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circle.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleBlock.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleBlock.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleCheck.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleCheck.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleCheckFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleCheckFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleClose.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleClose.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleExclamation.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleExclamation.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleExclamationFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleExclamationFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleInfo.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleInfo.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleInfoFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleInfoFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circlePlus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circlePlus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circlePlusFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circlePlusFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circlePoint.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circlePoint.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleQuestion.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleQuestion.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/circleQuestionFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/circleQuestionFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/close.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/close.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/closeThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/closeThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/coins.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/coins.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/coinsFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/coinsFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/company.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/company.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/companyCheck.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/companyCheck.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/companyCheckFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/companyCheckFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/companyFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/companyFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/companyPlus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/companyPlus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/companyPlusFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/companyPlusFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/compass.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/compass.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/compassFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/compassFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/copy.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/copy.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/crown.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/crown.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/crownFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/crownFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/desktop.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/desktop.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/desktopFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/desktopFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/document.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/document.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/documentFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/documentFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/documentPerson.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/documentPerson.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/documentPersonFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/documentPersonFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/documentText.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/documentText.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/documentTextFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/documentTextFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/dot.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/dot.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/download.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/download.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/exclamation.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/exclamation.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/externalLink.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/externalLink.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/eye.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/eye.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/eyeFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/eyeFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/eyeSlash.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/eyeSlash.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/eyeSlashFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/eyeSlashFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/faceSmile.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/faceSmile.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/faceSmileFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/faceSmileFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/filter.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/filter.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/filterFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/filterFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/folder.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/folder.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/folderFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/folderFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/folderJob.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/folderJob.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/folderJobFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/folderJobFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/folderStar.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/folderStar.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/folderStarFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/folderStarFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/full.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/full.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/globe.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/globe.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/graduation.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/graduation.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/handle.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/handle.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/heart.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/heart.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/heartFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/heartFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/history.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/history.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/home.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/home.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/homeFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/homeFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/image.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/image.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/keyboard.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/keyboard.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/like.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/like.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/likeFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/likeFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/lineHorizontal.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/lineHorizontal.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/lineHorizontalThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/lineHorizontalThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/link.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/link.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/list.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/list.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/listCategory.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/listCategory.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/location.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/location.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/locationFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/locationFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/lock.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/lock.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/lockFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/lockFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/lockOpen.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/lockOpen.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/lockOpenFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/lockOpenFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoApple.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoApple.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoFacebook.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoFacebook.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoGooglePlay.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoGooglePlay.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoInstagram.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoInstagram.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoKakao.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoKakao.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoLinkedIn.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoLinkedIn.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoNaverBlog.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoNaverBlog.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/logoYoutube.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/logoYoutube.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/magicWand.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/magicWand.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/mail.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/mail.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/menu.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/menu.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/menuThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/menuThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/message.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/message.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/messageFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/messageFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/minus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/minus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/minusThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/minusThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/mobile.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/mobile.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/mobileFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/mobileFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/moreHorizontal.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/moreHorizontal.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/moreVertical.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/moreVertical.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/moreVerticalTight.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/moreVerticalTight.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/navigationCareer.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/navigationCareer.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/navigationMenu.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/navigationMenu.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/navigationMypage.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/navigationMypage.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/navigationRecruit.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/navigationRecruit.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/navigationSocial.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/navigationSocial.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/pause.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/pause.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/pencil.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/pencil.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/pencilFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/pencilFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/person.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/person.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/personFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/personFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/personPlus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/personPlus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/personPlusFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/personPlusFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/persons.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/persons.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/personsFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/personsFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/pin.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/pin.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/pinFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/pinFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/play.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/play.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/plus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/plus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/plusThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/plusThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/question.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/question.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/refresh.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/refresh.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/search.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/search.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/searchThick.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/searchThick.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/send.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/send.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/sendFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/sendFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/setting.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/setting.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/share.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/share.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/shareIos.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/shareIos.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/square.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/square.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squareFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squareFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squareHan.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squareHan.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squareHangul.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squareHangul.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squareKana.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squareKana.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squareLatin.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squareLatin.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squareMore.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squareMore.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squarePlus.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squarePlus.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/squarePlusFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/squarePlusFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/star.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/star.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/starFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/starFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/template.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/template.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/templateFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/templateFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/thumbnail.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/thumbnail.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/thunder.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/thunder.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/thunderFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/thunderFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/trash.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/trash.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/triangle.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/triangle.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/triangleExclamation.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/triangleExclamation.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/triangleExclamationFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/triangleExclamationFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/triangleFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/triangleFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/trophy.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/trophy.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/trophyFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/trophyFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/tune.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/tune.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/upload.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/upload.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/verifiedCheck.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/verifiedCheck.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/verifiedCheckFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/verifiedCheckFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/verifiedStar.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/verifiedStar.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/verifiedStarFill.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/verifiedStarFill.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/Sources/Montage/Asset/Icon.xcassets/write.imageset/Contents.json
+++ b/Sources/Montage/Asset/Icon.xcassets/write.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
# 개요

### 📌 작업 완료 기한
- 2024/05/22

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
- PI-64109 수정 중, Montage의 이미지에 Preserve Vector Data 가 체크되어 있지 않아, scale을 변경할 때 icon이 깨지는 현상이 있습니다.
- 따라서 Preserve Vector Data 가 체크하여 scale을 변경할 때에도 문제가 없도록 합니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|<img width="130" alt="image" src="https://github.com/wanteddev/montage-ios/assets/39300449/55038566-b61b-44ac-9b63-55b944bd26ec">|<img width="123" alt="image" src="https://github.com/wanteddev/montage-ios/assets/39300449/cba239b8-9bad-43ba-93e6-d09d8d91b7dc">

# 확인사항
- [X] 동작 확인 
