### PR TITLE
SwiftUI에서 사용할 수 있는 InteracitonController 추가

### DIFF
--- a/Sources/Montage/Element/Button/IconButton/IconButton.swift
+++ b/Sources/Montage/Element/Button/IconButton/IconButton.swift
@@ -196,7 +196,7 @@ extension Button.IconButton {
     }
     
     private func setupInteraction() {
-        interaction.varient = variant.interactionVarient
+        interaction.variant = variant.interactionVariant
         
         setupInteractionContraints()
     }
@@ -352,7 +352,7 @@ extension Button.IconButton {
             }
         }()
         interaction.color = variant.interactionColor
-        interaction.varient = variant.interactionVarient
+        interaction.variant = variant.interactionVariant
     }
     
     private func updateIconView() {
@@ -492,7 +492,7 @@ extension Button.IconButton.Variant {
         .labelNormal
     }
     
-    var interactionVarient: Decorate.Interaction.Varient {
+    var interactionVariant: Decorate.Interaction.Variant {
         switch self {
         case .normal, .outlined: .light
         case .background(_, let isAlternative):

--- a/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
+++ b/Sources/Montage/Element/Button/OutlineButton/OutlinedButton.swift
@@ -227,7 +227,7 @@ extension Button.OutlinedButton {
     }
     
     private func setupInteraction() {
-        interaction.varient = variant.interactionVarient
+        interaction.variant = variant.interactionVariant
         
         setupInteractionContraints()
     }
@@ -343,7 +343,7 @@ extension Button.OutlinedButton {
         rightIconView.tintColor = contentColor
         uniqueIconView.tintColor = contentColor
         interaction.color = variant.interactionColor
-        interaction.varient = variant.interactionVarient
+        interaction.variant = variant.interactionVariant
     }
     
     private func updateIconView() {
@@ -475,7 +475,7 @@ extension Button.OutlinedButton.Variant {
         }
     }
     
-    var interactionVarient: Decorate.Interaction.Varient {
+    var interactionVariant: Decorate.Interaction.Variant {
         switch self {
         case .primary:
             return .normal

--- a/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
+++ b/Sources/Montage/Element/Button/SolidButton/SolidButton.swift
@@ -219,7 +219,7 @@ extension Button.SolidButton {
     }
     
     private func setupInteraction() {
-        interaction.varient = variant.interactionVarient
+        interaction.variant = variant.interactionVariant
         
         setupInteractionContraints()
     }
@@ -451,7 +451,7 @@ extension Button.SolidButton.Variant {
         .labelNormal
     }
 
-    var interactionVarient: Decorate.Interaction.Varient {
+    var interactionVariant: Decorate.Interaction.Variant {
         switch self {
         case .primary:
             return .strong

--- a/Sources/Montage/Element/Decorate/Interaction/Interaction.swift
+++ b/Sources/Montage/Element/Decorate/Interaction/Interaction.swift
@@ -13,7 +13,7 @@ extension Decorate {
             case normal, hovered, focused, pressed
         }
         
-        public enum Varient {
+        public enum Variant {
             case normal, light, strong
         }
         
@@ -29,16 +29,16 @@ extension Decorate {
             }
         }
         
-        var varient: Varient {
+        var variant: Variant {
             didSet {
                 updateView()
             }
         }
         
-        init(state: State = .normal, color: Color.Alias = .labelNormal, varient: Varient = .normal) {
+        init(state: State = .normal, color: Color.Alias = .labelNormal, variant: Variant = .normal) {
             self.state = state
             self.color = color
-            self.varient = varient
+            self.variant = variant
             
             super.init(frame: .zero)
             
@@ -48,7 +48,7 @@ extension Decorate {
         required init?(coder: NSCoder) {
             self.state = .normal
             self.color = .labelNormal
-            self.varient = .normal
+            self.variant = .normal
             
             super.init(coder: coder)
             
@@ -60,7 +60,7 @@ extension Decorate {
 extension Decorate.Interaction {
     private func setupView() {
         isUserInteractionEnabled = false
-        alpha = state.alpha * varient.weight
+        alpha = state.alpha * variant.weight
         backgroundColor = .alias(self.color)
     }
     
@@ -70,7 +70,7 @@ extension Decorate.Interaction {
             delay: 0,
             options: [.beginFromCurrentState, .curveEaseInOut]
         ) { [self] in
-            self.alpha = state.alpha * varient.weight
+            self.alpha = state.alpha * variant.weight
             self.backgroundColor = .alias(color)
         }
     }
@@ -91,7 +91,7 @@ extension Decorate.Interaction.State {
     }
 }
 
-extension Decorate.Interaction.Varient {
+extension Decorate.Interaction.Variant {
     var weight: CGFloat {
         switch self {
         case .normal:

--- a/Sources/Montage/Element/Decorate/Interaction/InteractionController.swift
+++ b/Sources/Montage/Element/Decorate/Interaction/InteractionController.swift
@@ -1,0 +1,55 @@
+//
+//  InteractionController.swift
+//
+//
+//  Created by Ahn Sang Hoon on 6/24/24.
+//
+
+import SwiftUI
+
+extension Decorate {
+    public struct InteractionController: UIViewRepresentable {
+        public var state: Interaction.State = .normal
+        public var variant: Interaction.Variant = .normal
+        public var color: Color.Alias = .labelNormal
+        
+        public typealias UIViewType = Interaction
+        
+        
+        public init(
+            state: Interaction.State = .normal,
+            variant: Interaction.Variant = .normal,
+            color: Color.Alias = .labelNormal
+        ) {
+            self.state = state
+            self.variant = variant
+            self.color = color
+        }
+        
+        public func makeUIView(context: Context) -> UIViewType {
+            .init(
+                state: state,
+                color: color,
+                variant: variant
+            )
+        }
+        
+        public func updateUIView(_ uiView: UIViewType, context: Context) {
+            uiView.state = state
+            uiView.variant = variant
+            uiView.color = color
+        }
+    }
+}
+
+#Preview {
+    HStack {
+        Decorate.InteractionController()
+            .background(SwiftUI.Color.cyan)
+        
+        Decorate.InteractionController(
+            state: .pressed
+        )
+        .background(SwiftUI.Color.red)
+    }
+}


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=14854-45438&m=dev

### 📌 작업 완료 기한
- 2024/06/26

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* UIKit에서는 사용할 수 있는 Decorate/Interaction Element가 존재하지만, SwftUI에서는 사용할 수 없고,
* Element에서 Interaction을 얹어서 사용하는 경우가 많아 SwiftUI에서 사용할 수 있도록 Element를 추가합니다.


# 확인사항
- [X] 동작 확인 
