### PR TITLE
[PI-65505] Select Component 추가

### DIFF
--- a/Sources/Montage/Components/Select/MultipleSelect.swift
+++ b/Sources/Montage/Components/Select/MultipleSelect.swift
@@ -74,6 +74,12 @@ extension Select {
         /// > 기본값은 false입니다.
         private let requiredBadge: Bool
         
+        /// MultipleSelect의 shadow 배경색입니다.
+        /// > 기본값은 systemBackgroundColor 입니다.
+        /// >
+        /// > shadow 배경색 변경이 필요할때 사용합니다.
+        private let shadowBackgroundColor: SwiftUI.Color
+
         /// MultipleSelect의 왼쪽 컨텐츠입니다.
         /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
         private var leftContent: (() -> any View)?
@@ -94,6 +100,7 @@ extension Select {
             disable: Bool = false,
             heading: String? = nil,
             requiredBadge: Bool = false,
+            backgroundColor: SwiftUI.Color = .init(uiColor: UIColor.systemBackground),
             leftContent: (() -> any View)? = nil,
             onTapItem: ((Select.Multiple.Item) -> Void)? = nil,
             onTap: (() -> Void)? = nil
@@ -106,6 +113,7 @@ extension Select {
             self.disable = disable
             self.heading = heading
             self.requiredBadge = requiredBadge
+            self.shadowBackgroundColor = backgroundColor
             self.leftContent = leftContent
             self.onTapItem = onTapItem
             self.onTap = onTap
@@ -144,76 +152,86 @@ extension Select {
                     }
                 }
                 
-                HStack(spacing: 8) {
-                    if let leftContent {
-                        AnyView(leftContent())
-                    }
-                    
-                    ZStack {
-                        HStack {
-                            if items.isEmpty {
-                                Text(placeholder)
-                                    .montage(
-                                        variant: .body1,
-                                        weight: .regular,
-                                        alias: disable ? .labelDisable : .labelAlternative
-                                    )
-                                    .paragraph(variant: .body1)
-                            } else {
-                                if render == .normal {
-                                    Text(items.map { $0.text }.joined(separator: ", "))
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(shadowBackgroundColor)
+                        .shadow(
+                            color: .alias(.staticBlack).opacity(0.03),
+                            radius: 2,
+                            x: 0, y: 1
+                        )
+
+                    HStack(spacing: 8) {
+                        if let leftContent {
+                            AnyView(leftContent())
+                        }
+                        
+                        ZStack {
+                            HStack {
+                                if items.isEmpty {
+                                    Text(placeholder)
                                         .montage(
                                             variant: .body1,
                                             weight: .regular,
-                                            alias: disable ? .labelDisable :
-                                                    .labelNormal
+                                            alias: disable ? .labelDisable : .labelAlternative
                                         )
                                         .paragraph(variant: .body1)
                                 } else {
-                                    Chip(
-                                        items: items,
-                                        disable: disable,
-                                        onTapItem: onTapItem
-                                    )
+                                    if render == .normal {
+                                        Text(items.map { $0.text }.joined(separator: ", "))
+                                            .montage(
+                                                variant: .body1,
+                                                weight: .regular,
+                                                alias: disable ? .labelDisable :
+                                                        .labelNormal
+                                            )
+                                            .paragraph(variant: .body1)
+                                    } else {
+                                        Chip(
+                                            items: items,
+                                            disable: disable,
+                                            onTapItem: onTapItem
+                                        )
+                                    }
                                 }
+                                Spacer()
                             }
-                            Spacer()
+                            .padding(.horizontal, 4)
+                            .contentShape(Rectangle())
+                        }
+                        
+                        if active, variant == .negative {
+                            Image.montage(.circleExclamationFill)
+                                .resizable()
+                                .frame(width: 22, height: 22)
+                                .foregroundStyle(SwiftUI.Color.alias(.statusNegative))
+                        }
+                        
+                        Button.IconButton(
+                            variant: .normal(size: 16),
+                            icon: .chevronDownThickSmall,
+                            iconColor: disable ? SwiftUI.Color.alias(.labelDisable) : .alias(.labelAlternative)
+                        ) {
+                            onTap?()
                         }
                         .padding(.horizontal, 4)
-                        .contentShape(Rectangle())
                     }
-                                    
-                    if active, variant == .negative {
-                        Image.montage(.circleExclamationFill)
-                            .resizable()
-                            .frame(width: 22, height: 22)
-                            .foregroundStyle(SwiftUI.Color.alias(.statusNegative))
+                    .padding(.all, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
+                    )
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .inset(by: 0.5)
+                            .stroke(strokeColor, lineWidth: focus ? 2 : 1)
                     }
-                    
-                    Button.IconButton(
-                        variant: .normal(size: 16),
-                        icon: .chevronDownThickSmall,
-                        iconColor: disable ? SwiftUI.Color.alias(.labelDisable) : .alias(.labelAlternative)
-                    ) {
-                        onTap?()
-                    }
-                    .padding(.horizontal, 4)
+                    .shadow(
+                        color: .alias(.staticBlack).opacity(0.03),
+                        radius: 2,
+                        x: 0, y: 1
+                    )
                 }
-                .padding(.all, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
-                )
-                .overlay {
-                    RoundedRectangle(cornerRadius: 12)
-                        .inset(by: -0.5)
-                        .stroke(strokeColor, lineWidth: focus ? 2 : 1)
-                }
-                .shadow(
-                    color: .alias(.staticBlack).opacity(0.03),
-                    radius: 2,
-                    x: 0, y: 1
-                )
             }
             .onChange(of: items, perform: { newValue in
                 active = (newValue.isEmpty == false)

--- a/Sources/Montage/Components/Select/MultipleSelect.swift
+++ b/Sources/Montage/Components/Select/MultipleSelect.swift
@@ -116,7 +116,7 @@ extension Select {
                 if variant == .normal {
                     focus ? .alias(.primaryNormal).opacity(0.43) : .alias(.lineNeutral)
                 } else {
-                   .alias(.statusNegative).opacity(0.43)
+                    .alias(.statusNegative).opacity(0.28)
                 }
             } else {
                 .alias(.lineNeutral)
@@ -197,6 +197,7 @@ extension Select {
                     ) {
                         onTap?()
                     }
+                    .padding(.horizontal, 4)
                 }
                 .padding(.all, 12)
                 .background(
@@ -204,23 +205,15 @@ extension Select {
                         .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
                 )
                 .overlay {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 12)
-                            .inset(by: focus ? 2 : 1)
-                            .stroke(strokeColor, lineWidth: focus ? 2 : 1)
-                        
-                        RoundedRectangle(cornerRadius: 12)
-                            .foregroundStyle(.clear)
-                            .background(.black.opacity(0))
-                            .shadow(
-                                color: .black.opacity(0.03),
-                                radius: 1,
-                                x: 0,
-                                y: 1
-                            )
-                            .blur(radius: 2)
-                    }
+                    RoundedRectangle(cornerRadius: 12)
+                        .inset(by: focus ? 2 : 1)
+                        .stroke(strokeColor, lineWidth: focus ? 2 : 1)
                 }
+                .shadow(
+                    color: .alias(.staticBlack).opacity(0.03),
+                    radius: 2,
+                    x: 0, y: 1
+                )
             }
             .onChange(of: items, perform: { newValue in
                 active = (newValue.isEmpty == false)
@@ -235,7 +228,7 @@ extension Select {
             var items: [Select.Multiple.Item]
             var disable: Bool
             var onTapItem: ((Select.Multiple.Item) -> Void)?
-            
+
             var body: some View {
                 HStack {
                     ForEach(Array(items.indices), id: \.self) {
@@ -244,7 +237,7 @@ extension Select {
                             variant:.filled,
                             size: .xsmall,
                             leftIcon: item.icon,
-                            rightIcon: .close,
+                            rightIcon: .closeThick,
                             text: item.text,
                             iconColor: iconColor(item),
                             backgroundColor: backgroundColor(item),
@@ -258,7 +251,7 @@ extension Select {
                     }
                 }
             }
-            
+
             private func iconColor(_ item: Select.Multiple.Item) -> SwiftUI.Color {
                 guard disable == false else { return .alias(.labelDisable) }
                 switch item.state {

--- a/Sources/Montage/Components/Select/MultipleSelect.swift
+++ b/Sources/Montage/Components/Select/MultipleSelect.swift
@@ -112,14 +112,14 @@ extension Select {
         }
 
         private var strokeColor: SwiftUI.Color {
-            if disable == false {
+            if disable {
+                .alias(.lineNeutral)
+            } else {
                 if variant == .normal {
                     focus ? .alias(.primaryNormal).opacity(0.43) : .alias(.lineNeutral)
                 } else {
                     .alias(.statusNegative).opacity(0.28)
                 }
-            } else {
-                .alias(.lineNeutral)
             }
         }
 
@@ -206,7 +206,7 @@ extension Select {
                 )
                 .overlay {
                     RoundedRectangle(cornerRadius: 12)
-                        .inset(by: focus ? 2 : 1)
+                        .inset(by: -0.5)
                         .stroke(strokeColor, lineWidth: focus ? 2 : 1)
                 }
                 .shadow(

--- a/Sources/Montage/Components/Select/MultipleSelect.swift
+++ b/Sources/Montage/Components/Select/MultipleSelect.swift
@@ -1,0 +1,316 @@
+//
+//  MultipleSelect.swift
+//  Montage
+//
+//  Created by Sanghoon Ahn on 8/12/24.
+//
+
+import SwiftUI
+
+extension Select {
+    /// 드롭다운(dropdown) 메뉴와 같이 여러 옵션 중 하나를 확인하고 고르는 용도로 사용합니다.
+    public struct Multiple: View {
+        public struct Item: Identifiable, Equatable {
+            public enum State {
+                case normal
+                case negative
+            }
+            
+            public var id: String { text }
+            public let state: State
+            public let text: String
+            public var icon: Icon?
+            
+            public init(
+                state: State = .normal,
+                text: String,
+                icon: Icon? = nil
+            ) {
+                self.state = state
+                self.text = text
+                self.icon = icon
+            }
+        }
+        
+        /// MultipleSelect에 표시될 내용의 형태를 결정하는 열거형입니다.
+        public enum Render {
+            case normal
+            case chip
+        }
+        
+        /// MultipleSelect의 외관을 결정하는 열거형입니다.
+        public enum Variant {
+            case normal
+            case negative
+        }
+        
+        /// MultipleSelect의 포커싱 여부입니다.
+        /// 외부에서 포커싱 여부를 변경할 수 있습니다.
+        @Binding var focus: Bool
+        
+        /// MultipleSelect의 활성화(=값이 있는지) 여부입니다.
+        @State private var active: Bool = true
+        
+        /// MultipleSelect의 표시될 내용의 형태입니다.
+        private let render: Render
+        
+        /// MultipleSelect에 표시될 내용들입니다.
+        private let items: [Item]
+        
+        /// MultipleSelect의 외관입니다.
+        private let variant: Variant
+        
+        /// MultipleSelect의 텍스트가 없는 경우 나타낼 placeholder입니다.
+        private let placeholder: String
+        
+        /// MultipleSelect의 사용가능 여부입니다.
+        private let disable: Bool
+        
+        /// MultipleSelect의 제목입니다.
+        /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
+        private let heading: String?
+        
+        /// MultipleSelect의 필수 표시 노출 여부입니다.
+        /// > 기본값은 false입니다.
+        private let requiredBadge: Bool
+        
+        /// MultipleSelect의 왼쪽 컨텐츠입니다.
+        /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
+        private var leftContent: (() -> any View)?
+        
+        /// MultipleSelect의 chip item을 터치했을 때의 handler 입니다.
+        /// > render가 normal인 경우에는 동작하지 않습니다.
+        private var onTapItem: ((Select.Multiple.Item) -> Void)?
+        
+        /// MultipleSelect의 Tap에 대한 handler 입니다.
+        private var onTap: (() -> Void)?
+        
+        public init(
+            items: [Item] = [],
+            focus: Binding<Bool>,
+            render: Render = .normal,
+            variant: Variant = .normal,
+            placeholder: String,
+            disable: Bool = false,
+            heading: String? = nil,
+            requiredBadge: Bool = false,
+            leftContent: (() -> any View)? = nil,
+            onTapItem: ((Select.Multiple.Item) -> Void)? = nil,
+            onTap: (() -> Void)? = nil
+        ) {
+            self.items = items
+            self._focus = focus
+            self.render = render
+            self.variant = variant
+            self.placeholder = placeholder
+            self.disable = disable
+            self.heading = heading
+            self.requiredBadge = requiredBadge
+            self.leftContent = leftContent
+            self.onTapItem = onTapItem
+            self.onTap = onTap
+        }
+
+        private var strokeColor: SwiftUI.Color {
+            if disable == false {
+                if variant == .normal {
+                    focus ? .alias(.primaryNormal).opacity(0.43) : .alias(.lineNeutral)
+                } else {
+                   .alias(.statusNegative).opacity(0.43)
+                }
+            } else {
+                .alias(.lineNeutral)
+            }
+        }
+
+        public var body: some View {
+            VStack(alignment: .leading) {
+                if let heading {
+                    HStack(spacing: 4) {
+                        Text(heading)
+                            .montage(
+                                variant: .label1,
+                                weight: .bold,
+                                alias: .labelNormal
+                            )
+                        if requiredBadge {
+                            Text("*")
+                                .montage(
+                                    variant: .label1,
+                                    weight: .medium,
+                                    alias: .statusNegative
+                                )
+                        }
+                    }
+                }
+                
+                HStack(spacing: 8) {
+                    if let leftContent {
+                        AnyView(leftContent())
+                    }
+                    
+                    ZStack {
+                        HStack {
+                            if items.isEmpty {
+                                Text(placeholder)
+                                    .montage(
+                                        variant: .body1,
+                                        weight: .regular,
+                                        alias: disable ? .labelDisable : .labelAlternative
+                                    )
+                                    .paragraph(variant: .body1)
+                            } else {
+                                if render == .normal {
+                                    Text(items.map { $0.text }.joined(separator: ", "))
+                                        .montage(
+                                            variant: .body1,
+                                            weight: .regular,
+                                            alias: disable ? .labelDisable :
+                                                    .labelNormal
+                                        )
+                                        .paragraph(variant: .body1)
+                                } else {
+                                    Chip(
+                                        items: items,
+                                        disable: disable,
+                                        onTapItem: onTapItem
+                                    )
+                                }
+                            }
+                            Spacer()
+                        }
+                        .padding(.horizontal, 4)
+                        .contentShape(Rectangle())
+                    }
+                                    
+                    if active, variant == .negative {
+                        Image.montage(.circleExclamationFill)
+                            .resizable()
+                            .frame(width: 22, height: 22)
+                            .foregroundStyle(SwiftUI.Color.alias(.statusNegative))
+                    }
+                    
+                    Button.IconButton(
+                        variant: .normal(size: 16),
+                        icon: .chevronDownThickSmall,
+                        iconColor: disable ? SwiftUI.Color.alias(.labelDisable) : .alias(.labelAlternative)
+                    ) {
+                        onTap?()
+                    }
+                }
+                .padding(.all, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
+                )
+                .overlay {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .inset(by: focus ? 2 : 1)
+                            .stroke(strokeColor, lineWidth: focus ? 2 : 1)
+                        
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(.clear)
+                            .background(.black.opacity(0))
+                            .shadow(
+                                color: .black.opacity(0.03),
+                                radius: 1,
+                                x: 0,
+                                y: 1
+                            )
+                            .blur(radius: 2)
+                    }
+                }
+            }
+            .onChange(of: items, perform: { newValue in
+                active = (newValue.isEmpty == false)
+            })
+            .allowsHitTesting(disable == false)
+            .onTapGesture {
+                onTap?()
+            }
+        }
+        
+        private struct Chip: View {
+            var items: [Select.Multiple.Item]
+            var disable: Bool
+            var onTapItem: ((Select.Multiple.Item) -> Void)?
+            
+            var body: some View {
+                HStack {
+                    ForEach(Array(items.indices), id: \.self) {
+                        let item = items[$0]
+                        Montage.Chip.ActionChipController(
+                            variant:.filled,
+                            size: .xsmall,
+                            leftIcon: item.icon,
+                            rightIcon: .close,
+                            text: item.text,
+                            iconColor: iconColor(item),
+                            backgroundColor: backgroundColor(item),
+                            fontColor: fontColor(item)
+                        )
+                        .fixedSize()
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            onTapItem?(item)
+                        }
+                    }
+                }
+            }
+            
+            private func iconColor(_ item: Select.Multiple.Item) -> SwiftUI.Color {
+                guard disable == false else { return .alias(.labelDisable) }
+                switch item.state {
+                case .normal:
+                        return .alias(.labelAlternative)
+                case .negative:
+                       return  .alias(.statusNegative)
+                }
+            }
+
+            private func backgroundColor(_ item: Select.Multiple.Item) -> SwiftUI.Color? {
+                guard disable == false else { return nil }
+                switch item.state {
+                case .normal:
+                        return nil
+                case .negative:
+                        return .alias(.statusNegative).opacity(0.05)
+                }
+            }
+
+            private func fontColor(_ item: Select.Multiple.Item) -> SwiftUI.Color {
+                guard disable == false else { return .alias(.labelDisable) }
+                switch item.state {
+                case .normal:
+                    return .alias(.labelNormal)
+                case .negative:
+                    return .alias(.statusNegative)
+                }
+            }
+        }
+    }
+}
+
+struct MultipleSelect_Preview: PreviewProvider {
+    static var previews: some View {
+        Select.Multiple(
+            items: [
+                .init(state: .normal, text: "텍스트", icon: nil),
+                .init(state: .negative, text: "텍스트", icon: nil),
+                .init(state: .normal, text: "텍스트", icon: nil),
+            ],
+            focus: .constant(false),
+            render: .chip,
+            variant: .normal,
+            placeholder: "선택해주세요.",
+            disable: false,
+            heading: "제목",
+            requiredBadge: true,
+            leftContent: nil,
+            onTapItem: { _ in print("아이템 터치") }
+        ) {
+            print("컴포넌트 터치")
+        }
+    }
+}

--- a/Sources/Montage/Components/Select/NormalSelect.swift
+++ b/Sources/Montage/Components/Select/NormalSelect.swift
@@ -47,6 +47,12 @@ extension Select {
         /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
         private let icon: Icon?
         
+        /// NormalSelect의 shadow 배경색입니다.
+        /// > 기본값은 systemBackgroundColor 입니다.
+        /// >
+        /// > shadow 배경색 변경이 필요할때 사용합니다.
+        private let shadowBackgroundColor: SwiftUI.Color
+        
         /// NormalSelect Tap에 대한 handler 입니다.
         private var onTap: (() -> Void)?
 
@@ -59,6 +65,7 @@ extension Select {
             heading: String? = nil,
             requiredBadge: Bool = false,
             icon: Icon? = nil,
+            backgroundColor: SwiftUI.Color = .init(uiColor: UIColor.systemBackground),
             onTap: (() -> Void)? = nil
         ) {
             self.text = text
@@ -69,6 +76,7 @@ extension Select {
             self.heading = heading
             self.requiredBadge = requiredBadge
             self.icon = icon
+            self.shadowBackgroundColor = backgroundColor
             self.onTap = onTap
         }
 
@@ -105,68 +113,76 @@ extension Select {
                     }
                 }
                 
-                HStack(spacing: 8) {
-                    if let icon {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(shadowBackgroundColor)
+                        .shadow(
+                            color: .alias(.staticBlack).opacity(0.03),
+                            radius: 2,
+                            x: 0, y: 1
+                        )
+                    
+                    HStack(spacing: 8) {
+                        if let icon {
+                            ZStack {
+                                Image.montage(icon)
+                                    .resizable()
+                                    .frame(width: 22, height: 22)
+                                    .padding(.all, 1)
+                                    .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) :  SwiftUI.Color.alias(.labelAlternative))
+                            }
+                        }
+                        
                         ZStack {
-                            Image.montage(icon)
+                            HStack {
+                                if text.isEmpty {
+                                    Text(placeholder)
+                                        .montage(
+                                            variant: .body1,
+                                            weight: .regular,
+                                            alias: disable ? .labelDisable : .labelAlternative
+                                        )
+                                        .paragraph(variant: .body1)
+                                } else {
+                                    Text(text)
+                                        .montage(
+                                            variant: .body1,
+                                            weight: .regular,
+                                            alias: disable ? .labelDisable :
+                                                    .labelNormal
+                                        )
+                                        .paragraph(variant: .body1)
+                                }
+                                Spacer()
+                            }
+                            .padding(.horizontal, 4)
+                            .contentShape(Rectangle())
+                        }
+                        
+                        if active, variant == .negative {
+                            Image.montage(.circleExclamationFill)
                                 .resizable()
                                 .frame(width: 22, height: 22)
-                                .padding(.all, 1)
-                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) :  SwiftUI.Color.alias(.labelAlternative))
+                                .foregroundStyle(SwiftUI.Color.alias(.statusNegative))
                         }
-                    }
-                    
-                    ZStack {
-                        HStack {
-                            if text.isEmpty {
-                                Text(placeholder)
-                                    .montage(
-                                        variant: .body1,
-                                        weight: .regular,
-                                        alias: disable ? .labelDisable : .labelAlternative
-                                    )
-                                    .paragraph(variant: .body1)
-                            } else {
-                                Text(text)
-                                    .montage(
-                                        variant: .body1,
-                                        weight: .regular,
-                                        alias: disable ? .labelDisable :
-                                                .labelNormal
-                                    )
-                                    .paragraph(variant: .body1)
-                            }
-                            Spacer()
+                        
+                        Button.IconButton(
+                            variant: .normal(size: 16),
+                            icon: .chevronDownThickSmall,
+                            iconColor: disable ? SwiftUI.Color.alias(.labelDisable) : .alias(.labelAlternative)
+                        ) {
+                            onTap?()
                         }
-                        .padding(.horizontal, 4)
-                        .contentShape(Rectangle())
+                        .padding(.trailing, 4)
                     }
-                    
-                    if active, variant == .negative {
-                        Image.montage(.circleExclamationFill)
-                            .resizable()
-                            .frame(width: 22, height: 22)
-                            .foregroundStyle(SwiftUI.Color.alias(.statusNegative))
-                    }
-
-                    Button.IconButton(
-                        variant: .normal(size: 16),
-                        icon: .chevronDownThickSmall,
-                        iconColor: disable ? SwiftUI.Color.alias(.labelDisable) : .alias(.labelAlternative)
-                    ) {
-                        onTap?()
-                    }
-                    .padding(.trailing, 4)
-                }
-                .padding(.all, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
-                )
-                .overlay {
-                    ZStack {
+                    .padding(.all, 12)
+                    .background(
                         RoundedRectangle(cornerRadius: 12)
-                            .inset(by: -0.5)
+                            .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
+                    )
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .inset(by: 0.5)
                             .stroke(strokeColor, lineWidth: focus ? 2 : 1)
                     }
                 }

--- a/Sources/Montage/Components/Select/NormalSelect.swift
+++ b/Sources/Montage/Components/Select/NormalSelect.swift
@@ -77,7 +77,7 @@ extension Select {
                 if variant == .normal {
                     focus ? .alias(.primaryNormal).opacity(0.43) : .alias(.lineNeutral)
                 } else {
-                   .alias(.statusNegative).opacity(0.43)
+                   .alias(.statusNegative).opacity(0.28)
                 }
             } else {
                 .alias(.lineNeutral)
@@ -156,6 +156,7 @@ extension Select {
                     ) {
                         onTap?()
                     }
+                    .padding(.trailing, 4)
                 }
                 .padding(.all, 12)
                 .background(
@@ -163,23 +164,15 @@ extension Select {
                         .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
                 )
                 .overlay {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 12)
-                            .inset(by: focus ? 2 : 1)
-                            .stroke(strokeColor, lineWidth: focus ? 2 : 1)
-                        
-                        RoundedRectangle(cornerRadius: 12)
-                            .foregroundStyle(.clear)
-                            .background(.black.opacity(0))
-                            .shadow(
-                                color: .black.opacity(0.03),
-                                radius: 1,
-                                x: 0,
-                                y: 1
-                            )
-                            .blur(radius: 2)
-                    }
+                    RoundedRectangle(cornerRadius: 12)
+                        .inset(by: focus ? 2 : 1)
+                        .stroke(strokeColor, lineWidth: focus ? 2 : 1)
                 }
+                .shadow(
+                    color: .alias(.staticBlack).opacity(0.03),
+                    radius: 2,
+                    x: 0, y: 1
+                )
             }
             .onChange(of: text, perform: { newValue in
                 active = (newValue.isEmpty == false)
@@ -197,7 +190,7 @@ struct NormalSelect_Preview: PreviewProvider {
     static var previews: some View {
         Select.Normal(
             text: "",
-            focus: .constant(true),
+            focus: .constant(false),
             variant: .negative,
             placeholder: "선택해주세요.",
             disable: false,

--- a/Sources/Montage/Components/Select/NormalSelect.swift
+++ b/Sources/Montage/Components/Select/NormalSelect.swift
@@ -1,0 +1,209 @@
+//
+//  NormalSelect.swift
+//  Montage
+//
+//  Created by ahn sanghoon on 8/9/24.
+//
+
+import SwiftUI
+
+extension Select {
+    /// 드롭다운(dropdown) 메뉴와 같이 옵션을 확인하고 고르는 용도로 사용합니다.
+    public struct Normal: View {
+        /// NormalSelect의 외관을 결정하는 열거형입니다.
+        public enum Variant {
+            case normal
+            case negative
+        }
+        
+        /// NormalSelect의 포커싱 여부입니다.
+        /// 외부에서 포커싱 여부를 변경할 수 있습니다.
+        @Binding var focus: Bool
+        
+        /// NormalSelect의 활성화(=값이 있는지) 여부입니다.
+        @State private var active: Bool = true
+        
+        /// NormalSelect에 표시될 텍스트입니다.
+        private let text: String
+        
+        /// NormalSelect의 외관입니다.
+        private let variant: Variant
+        
+        /// NormalSelect의 텍스트가 없는 경우 나타낼 placeholder입니다.
+        private let placeholder: String
+        
+        /// NormalSelect의 사용가능 여부입니다.
+        private let disable: Bool
+        
+        /// NormalSelect의 제목입니다.
+        /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
+        private let heading: String?
+        
+        /// NormalSelect의 필수 표시 노출 여부입니다.
+        /// > 기본값은 false입니다.
+        private let requiredBadge: Bool
+        
+        /// NormalSelect의 왼쪽 아이콘 입니다.
+        /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
+        private let icon: Icon?
+        
+        /// NormalSelect Tap에 대한 handler 입니다.
+        private var onTap: (() -> Void)?
+
+        public init(
+            text: String,
+            focus: Binding<Bool>,
+            variant: Variant = .normal,
+            placeholder: String,
+            disable: Bool = false,
+            heading: String? = nil,
+            requiredBadge: Bool = false,
+            icon: Icon? = nil,
+            onTap: (() -> Void)? = nil
+        ) {
+            self.text = text
+            self._focus = focus
+            self.variant = variant
+            self.placeholder = placeholder
+            self.disable = disable
+            self.heading = heading
+            self.requiredBadge = requiredBadge
+            self.icon = icon
+            self.onTap = onTap
+        }
+
+        private var strokeColor: SwiftUI.Color {
+            if disable == false {
+                if variant == .normal {
+                    focus ? .alias(.primaryNormal).opacity(0.43) : .alias(.lineNeutral)
+                } else {
+                   .alias(.statusNegative).opacity(0.43)
+                }
+            } else {
+                .alias(.lineNeutral)
+            }
+        }
+
+        public var body: some View {
+            VStack(alignment: .leading) {
+                if let heading {
+                    HStack(spacing: 4) {
+                        Text(heading)
+                            .montage(
+                                variant: .label1,
+                                weight: .bold,
+                                alias: .labelNormal
+                            )
+                        if requiredBadge {
+                            Text("*")
+                                .montage(
+                                    variant: .label1,
+                                    weight: .medium,
+                                    alias: .statusNegative
+                                )
+                        }
+                    }
+                }
+                
+                HStack(spacing: 8) {
+                    if let icon {
+                        ZStack {
+                            Image.montage(icon)
+                                .resizable()
+                                .frame(width: 22, height: 22)
+                                .padding(.all, 1)
+                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) :  SwiftUI.Color.alias(.labelAlternative))
+                        }
+                    }
+                    
+                    ZStack {
+                        HStack {
+                            if text.isEmpty {
+                                Text(placeholder)
+                                    .montage(
+                                        variant: .body1,
+                                        weight: .regular,
+                                        alias: disable ? .labelDisable : .labelAlternative
+                                    )
+                                    .paragraph(variant: .body1)
+                            } else {
+                                Text(text)
+                                    .montage(
+                                        variant: .body1,
+                                        weight: .regular,
+                                        alias: disable ? .labelDisable :
+                                                .labelNormal
+                                    )
+                                    .paragraph(variant: .body1)
+                            }
+                            Spacer()
+                        }
+                        .padding(.horizontal, 4)
+                        .contentShape(Rectangle())
+                    }
+                    
+                    if active, variant == .negative {
+                        Image.montage(.circleExclamationFill)
+                            .resizable()
+                            .frame(width: 22, height: 22)
+                            .foregroundStyle(SwiftUI.Color.alias(.statusNegative))
+                    }
+
+                    Button.IconButton(
+                        variant: .normal(size: 16),
+                        icon: .chevronDownThickSmall,
+                        iconColor: disable ? SwiftUI.Color.alias(.labelDisable) : .alias(.labelAlternative)
+                    ) {
+                        onTap?()
+                    }
+                }
+                .padding(.all, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
+                )
+                .overlay {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .inset(by: focus ? 2 : 1)
+                            .stroke(strokeColor, lineWidth: focus ? 2 : 1)
+                        
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(.clear)
+                            .background(.black.opacity(0))
+                            .shadow(
+                                color: .black.opacity(0.03),
+                                radius: 1,
+                                x: 0,
+                                y: 1
+                            )
+                            .blur(radius: 2)
+                    }
+                }
+            }
+            .onChange(of: text, perform: { newValue in
+                active = (newValue.isEmpty == false)
+            })
+            .allowsHitTesting(disable == false)
+            .onTapGesture {
+                onTap?()
+            }
+        }
+    }
+
+}
+
+struct NormalSelect_Preview: PreviewProvider {
+    static var previews: some View {
+        Select.Normal(
+            text: "",
+            focus: .constant(true),
+            variant: .negative,
+            placeholder: "선택해주세요.",
+            disable: false,
+            heading: "주제",
+            requiredBadge: true,
+            icon: nil
+        )
+    }
+}

--- a/Sources/Montage/Components/Select/NormalSelect.swift
+++ b/Sources/Montage/Components/Select/NormalSelect.swift
@@ -164,15 +164,12 @@ extension Select {
                         .foregroundStyle(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
                 )
                 .overlay {
-                    RoundedRectangle(cornerRadius: 12)
-                        .inset(by: focus ? 2 : 1)
-                        .stroke(strokeColor, lineWidth: focus ? 2 : 1)
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .inset(by: -0.5)
+                            .stroke(strokeColor, lineWidth: focus ? 2 : 1)
+                    }
                 }
-                .shadow(
-                    color: .alias(.staticBlack).opacity(0.03),
-                    radius: 2,
-                    x: 0, y: 1
-                )
             }
             .onChange(of: text, perform: { newValue in
                 active = (newValue.isEmpty == false)

--- a/Sources/Montage/Components/Select/NormalSelect.swift
+++ b/Sources/Montage/Components/Select/NormalSelect.swift
@@ -43,9 +43,9 @@ extension Select {
         /// > 기본값은 false입니다.
         private let requiredBadge: Bool
         
-        /// NormalSelect의 왼쪽 아이콘 입니다.
+        /// NormalSelect의 왼쪽 컨텐츠입니다.
         /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
-        private let icon: Icon?
+        private var leftContent: (() -> any View)?
         
         /// NormalSelect의 shadow 배경색입니다.
         /// > 기본값은 systemBackgroundColor 입니다.
@@ -64,7 +64,7 @@ extension Select {
             disable: Bool = false,
             heading: String? = nil,
             requiredBadge: Bool = false,
-            icon: Icon? = nil,
+            leftContent: (() -> any View)? = nil,
             backgroundColor: SwiftUI.Color = .init(uiColor: UIColor.systemBackground),
             onTap: (() -> Void)? = nil
         ) {
@@ -75,7 +75,7 @@ extension Select {
             self.disable = disable
             self.heading = heading
             self.requiredBadge = requiredBadge
-            self.icon = icon
+            self.leftContent = leftContent
             self.shadowBackgroundColor = backgroundColor
             self.onTap = onTap
         }
@@ -123,14 +123,8 @@ extension Select {
                         )
                     
                     HStack(spacing: 8) {
-                        if let icon {
-                            ZStack {
-                                Image.montage(icon)
-                                    .resizable()
-                                    .frame(width: 22, height: 22)
-                                    .padding(.all, 1)
-                                    .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) :  SwiftUI.Color.alias(.labelAlternative))
-                            }
+                        if let leftContent {
+                            AnyView(leftContent())
                         }
                         
                         ZStack {
@@ -209,7 +203,7 @@ struct NormalSelect_Preview: PreviewProvider {
             disable: false,
             heading: "주제",
             requiredBadge: true,
-            icon: nil
+            leftContent: nil
         )
     }
 }

--- a/Sources/Montage/Components/Select/Select.swift
+++ b/Sources/Montage/Components/Select/Select.swift
@@ -1,0 +1,10 @@
+//
+//  Select.swift
+//  Montage
+//
+//  Created by Sanghoon Ahn on 8/13/24.
+//
+
+import Foundation
+
+public enum Select {}

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -274,7 +274,6 @@ public struct TextArea: View {
             .padding(.all, 12)
             .overlay {
                 RoundedRectangle(cornerRadius: 12)
-                    .inset(by: textEditorFocusState ? 2 : 1)
                     .stroke(editorStrokeColor, lineWidth: textEditorFocusState ? 2 : 1)
             }
             .background(

--- a/Sources/Montage/Components/Text/TextInput.swift
+++ b/Sources/Montage/Components/Text/TextInput.swift
@@ -210,7 +210,7 @@ public struct TextInput: View {
                     
                     if rightButton == nil {
                         RoundedRectangle(cornerRadius: 12)
-                            .inset(by: -0.5)
+                            .inset(by: 0.5)
                             .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
                             .padding(.all, textFieldFocusState ? 2 : 1)
                     } else {

--- a/Sources/Montage/Components/Text/TextInput.swift
+++ b/Sources/Montage/Components/Text/TextInput.swift
@@ -210,6 +210,7 @@ public struct TextInput: View {
                     
                     if rightButton == nil {
                         RoundedRectangle(cornerRadius: 12)
+                            .inset(by: -0.5)
                             .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
                             .padding(.all, textFieldFocusState ? 2 : 1)
                     } else {

--- a/Sources/Montage/Element/Chip/Action/ActionChip.swift
+++ b/Sources/Montage/Element/Chip/Action/ActionChip.swift
@@ -285,6 +285,7 @@ extension Chip.Action {
         leftIconView.tintColor = resolveCurrentIconColor()
         rightIconView.tintColor = resolveCurrentIconColor()
         interaction.color = resolveInteractionColor()
+        updateTextLabel()
     }
     
     private func updateIconView() {

--- a/Sources/Montage/Element/Chip/Filter/FilterChip.swift
+++ b/Sources/Montage/Element/Chip/Filter/FilterChip.swift
@@ -257,6 +257,7 @@ extension Chip.Filter {
         layer.borderWidth = variant.borderWidth
         arrowIconView.tintColor = resolveArrowIconTintColor()
         interaction.color = resolveInteractionColor()
+        updateTextLabel()
     }
     
     private func updateIconView() {

--- a/Sources/Montage/Extension/UIKit/UIColor+Montage.swift
+++ b/Sources/Montage/Extension/UIKit/UIColor+Montage.swift
@@ -5,7 +5,7 @@
 //  Created by Eunyeong Kim on 2021/04/12.
 //
 
-import UIKit
+import SwiftUI
 
 extension UIColor {
     static func load(name: String) -> UIColor {


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=16383-43905&m=dev

### 📌 작업 완료 기한
- 2024/08/25

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* Select Component를 추가합니다.
* Normal / Multiple 두가지 컴포넌트가 존재하며 각각 단일 / 복수 선택이 가능합니다.
* 각 컴포넌트에서 사용하는 데이터는 `String` / `Multiple.Item` 타입입니다.
  * Multiple.Item은 Multiple에서 사용하는 데이터 타입입니다.
  
### 시연 영상


https://github.com/user-attachments/assets/1f34508d-ef07-41cb-bcef-c018046c4c13



# 확인사항
- [X] 동작 확인 
