### PR TITLE
[ActionArea/Bottom] ExtraContents 및 disable property 추가

### DIFF
--- a/Sources/Montage/Components/ActionArea/Bottom/Bottom.swift
+++ b/Sources/Montage/Components/ActionArea/Bottom/Bottom.swift
@@ -334,24 +334,27 @@ extension ActionArea {
                     action: @escaping (() -> Void)
                 ) -> some View {
                     switch option {
-                    case .soild(let variant):
+                    case let .soild(variant, disable):
                         Button.SolidButtonController(
                             variant: variant,
                             size: .large,
                             text: text,
+                            disable: disable,
                             handler: action
                         )
-                    case .outline(let variant):
+                    case let .outline(variant, disable):
                         Button.OutlinedButtonController(
                             variant: variant,
                             size: .large,
                             text: text,
+                            disable: disable,
                             handler: action
                         )
-                    case .text(let variant):
+                    case let .text(variant, disable):
                         Button.TextButtonController(
                             variant: variant,
                             text: text,
+                            disable: disable,
                             handler: action
                         )
                     }
@@ -391,9 +394,9 @@ extension ActionArea.Bottom {
     }
     
     public enum ButtonOption {
-        case soild(Button.SolidButton.Variant = .primary)
-        case outline(Button.OutlinedButton.Variant = .assistive)
-        case text(Button.TextButton.Variant = .assistive)
+        case soild(Button.SolidButton.Variant = .primary, disable: Bool = false)
+        case outline(Button.OutlinedButton.Variant = .assistive, disable: Bool = false)
+        case text(Button.TextButton.Variant = .assistive, disable: Bool = false)
     }
     
     public struct Model {
@@ -445,8 +448,7 @@ struct Bottom_Previews: PreviewProvider {
                         variant: .normal,
                         priority: .single(
                             main: .init(text: "메인", buttonOption: .soild(.primary), action: {})
-                        ),
-                        sticky: false
+                        )
                     )
                 )
             }

--- a/Sources/Montage/Components/ActionArea/Bottom/Bottom.swift
+++ b/Sources/Montage/Components/ActionArea/Bottom/Bottom.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension ActionArea {
     public enum Bottom {
-        public struct Component<ExtraContents: View>: View {
+        public struct Component: View {
             // MARK: - Environment
             
             @Environment(\.safeAreaInsets) private var safeAreaInsets
@@ -21,7 +21,7 @@ extension ActionArea {
             
             // MARK: - Uninitialised properties
             
-            private let model: ActionArea.Bottom.Model<ExtraContents>
+            private let model: ActionArea.Bottom.Model
             
             // MARK: - Computed properties
             
@@ -84,7 +84,7 @@ extension ActionArea {
             
             // MARK: - Initialisers
            
-            public init(model: ActionArea.Bottom.Model<ExtraContents>) {
+            public init(model: ActionArea.Bottom.Model) {
                 self.model = model
             }
             
@@ -111,10 +111,12 @@ extension ActionArea {
                     
                     VStack(spacing: .zero) {
                         if model.variant == .extra, let extraContents = model.extraContents {
-                            extraContents
-                                .background(SwiftUI.Color.alias(.backgroundElevated))
-                                .padding([.top, .horizontal], 20)
-                                .padding(.bottom, 4)
+                            AnyView(
+                                extraContents()
+                            )
+                            .background(SwiftUI.Color.alias(.backgroundElevated))
+                            .padding([.top, .horizontal], 20)
+                            .padding(.bottom, 4)
                         }
                         VStack(spacing: .zero) {
                             if let caption = model.caption, enableCaption {
@@ -394,25 +396,25 @@ extension ActionArea.Bottom {
         case text(Button.TextButton.Variant = .assistive)
     }
     
-    public struct Model<ExtraContents: View> {
+    public struct Model {
         let variant: Variant
         let priority: Priority
         let sticky: Bool
         var caption: String?
-        var extraContents: ExtraContents?
+        var extraContents: (() -> any View)?
         
         public init(
             variant: Variant = .normal,
             priority: Priority,
             sticky: Bool = false,
             caption: String? = nil,
-            @ViewBuilder extraContents: () -> ExtraContents?
+            extraContents: (() -> any View)?
         ) {
             self.variant = variant
             self.priority = priority
             self.sticky = sticky
             self.caption = caption
-            self.extraContents = extraContents()
+            self.extraContents = extraContents
         }
         
         public init(
@@ -438,7 +440,7 @@ struct Bottom_Previews: PreviewProvider {
             }
             VStack {
                 Spacer()
-                ActionArea.Bottom.Component<AnyView>(
+                ActionArea.Bottom.Component(
                     model: .init(
                         variant: .normal,
                         priority: .single(

--- a/Sources/Montage/Element/Bar/TopNavigation/TopNavigation.swift
+++ b/Sources/Montage/Element/Bar/TopNavigation/TopNavigation.swift
@@ -580,7 +580,7 @@ extension Bar.TopNavigation {
         private let left: Resource.Left?
         private let actions: [Resource.Action]
         private let backgroundColorResolvable: ColorResolvable?
-        private let model: ActionArea.Bottom.Model<AnyView>?
+        private let model: ActionArea.Bottom.Model?
         
         /// TopNavigation의 사이즈를 측정하는 View입니다.
         private var navigationSizeMeasurer: some View {
@@ -648,7 +648,7 @@ extension Bar.TopNavigation {
             left: Resource.Left?,
             backgroundColorResolvable: ColorResolvable? = nil,
             actions: [Resource.Action],
-            model: ActionArea.Bottom.Model<AnyView>? = nil
+            model: ActionArea.Bottom.Model? = nil
         ) {
             self.variant = variant
             self.title = title
@@ -706,13 +706,13 @@ extension Bar.TopNavigation {
                 if let model {
                     VStack(alignment: .leading, spacing: .zero) {
                         Spacer()
-                        ActionArea.Bottom.Component<AnyView>(
+                        ActionArea.Bottom.Component(
                             model: .init(
                                 variant: model.variant,
                                 priority: model.priority,
                                 sticky: bottomActionSticky,
                                 caption: model.caption,
-                                extraContents: { model.extraContents }
+                                extraContents: model.extraContents
                             )
                         )
                         .animation(.easeInOut, value: bottomActionSticky)

--- a/Sources/Montage/Extension/SwiftUI/View+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/View+Montage.swift
@@ -134,7 +134,7 @@ extension View {
         left: Bar.TopNavigation.Resource.Left? = nil,
         backgroundColorResolvable: ColorResolvable? = nil,
         actions: [Bar.TopNavigation.Resource.Action] = [],
-        withBottom model: ActionArea.Bottom.Model<AnyView>
+        withBottom model: ActionArea.Bottom.Model
     ) -> some View {
         modifier(
             Bar.TopNavigation.TopNavigationModifier(


### PR DESCRIPTION
# 개요

### 📌 작업 완료 기한
- 2024/08/28

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* ActionArea/Bottom의 extracontents이 Generic으로 선언되어 있던 내용을 closure로 전달받도록 수정하였습니다. e753d718b96bd17ed6a7f0ecffd03ea742e5a822
* ActionArea/Bottom의 Button Option 에 disable property를 사용할 수 있도록 수정하였습니다. fe2863b13f1264b00d61426368cefb55aee556c5

# 확인사항
- [X] 동작 확인 
