### PR TITLE
[Tooltip] Arrow 노출되지 않는 이슈 수정 (~8/28)

### DIFF
--- a/Sources/Montage/Components/Tooltip/Tooltip.swift
+++ b/Sources/Montage/Components/Tooltip/Tooltip.swift
@@ -21,7 +21,7 @@ public enum Tooltip {
         }
         
         public var isExtended: Bool {
-            self == .compact
+            self != .compact
         }
     }
     

--- a/Sources/Montage/Components/Tooltip/Tooltip.swift
+++ b/Sources/Montage/Components/Tooltip/Tooltip.swift
@@ -92,9 +92,7 @@ public enum Tooltip {
             position: Tooltip.Position = .top,
             inverse: Bool = false,
             showArrow: Bool = true,
-            showCloseButton: Bool = false,
-            actionTitle: String? = nil,
-            action: (() -> Void)? = nil
+            showCloseButton: Bool = false
         ) {
             self.variant = variant
             self.position = position

--- a/Sources/Montage/Extension/SwiftUI/View+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/View+Montage.swift
@@ -71,18 +71,14 @@ extension View {
         show: Binding<Bool>,
         inverse: Bool = false,
         showCloseButton: Bool = false,
-        content: String,
-        actionTitle: String? = nil,
-        action: (() -> Void)? = nil
+        content: String
     ) -> some View {
         tooltip(
             config: Tooltip.DefaultTooltipConfig(
                 variant: variant,
                 position: position,
                 inverse: inverse,
-                showCloseButton: showCloseButton,
-                actionTitle: actionTitle,
-                action: action
+                showCloseButton: showCloseButton
             ),
             show: show,
             content: content


### PR DESCRIPTION
# 개요

### 📌 작업 완료 기한
- 2024/08/28

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
- https://github.com/wanteddev/montage-ios/pull/108/commits/4fe5812c9eb28dbcb276c5a116e8abb67dd72e99 이후 Arrow가 정상적으로 노출되지 않는 이슈를 수정합니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|<img width="414" alt="image" src="https://github.com/user-attachments/assets/98e4d6a3-5e8d-4da4-9fc8-c79c805c676c">|<img width="387" alt="image" src="https://github.com/user-attachments/assets/20d0a92a-8f8b-430a-83d4-19b2b28951e4">


# 확인사항
- [x] 동작 확인 
