### PR TITLE
[TextArea] TextArea의 resize 속성에 height 케이스 추가 (~8/29)

### DIFF
--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -10,13 +10,15 @@ import SwiftUI
 public struct TextArea: View {
     // MARK: - Environment
     
-    /// TextArea의 Resize 여부에 관한 열거형입니다.
+    /// TextArea의 텍스트 영역 Resize 관한 열거형입니다.
     /// - normal : 줄 수 제한이 없으며, 줄 수에 따라 영역이 늘어납니다.
     /// - limit : 최대 8줄 노출되며 초과 영역은 Scrollable 합니다.
+    /// - height: 텍스트가 표시될 영역을 지정합니다. 초과 영역은 Scrollable 합니다.
     /// > iOS 15에서는 normal 인 경우에도 영역이 늘어나지 않는 현상이 있으니 사용시 주의하시기 바랍니다.
     public enum Resize {
         case normal
         case limit
+        case height(min: CGFloat, max: CGFloat)
     }
     
     /// TextArea의 외관을 결정하는 열거형입니다.
@@ -181,7 +183,44 @@ public struct TextArea: View {
         var body: some View {
             VStack(spacing: 12) {
                 ZStack(alignment: .topLeading) {
-                    if resize == .limit {
+                    switch resize {
+                    case .normal:
+                        if #available(iOS 16, *) {
+                            TextEditor(text: $text)
+                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
+                                .font(.montage(variant: .body1Reading))
+                                .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
+                                .focused($textEditorFocusState)
+                                .frame(minHeight: 36)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .onChange(of: text) { result in
+                                    typedCharacters = text.count
+                                }
+                                .scrollContentBackground(.hidden)
+                                .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
+                                .padding([.horizontal], -4.5)
+                                .padding(.top, -4)
+                                .padding(.bottom, -6)
+                        } else {
+                            TextEditor(text: $text)
+                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
+                                .font(.montage(variant: .body1Reading))
+                                .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
+                                .focused($textEditorFocusState)
+                                .frame(minHeight: 36)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .onChange(of: text) { result in
+                                    typedCharacters = text.count
+                                }
+                                .onAppear {
+                                    UITextView.appearance().backgroundColor = .clear
+                                }
+                                .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
+                                .padding([.horizontal], -4.5)
+                                .padding(.top, -4)
+                                .padding(.bottom, -6)
+                        }
+                    case .limit:
                         if #available(iOS 16, *) {
                             TextEditor(text: $text)
                                 .font(.montage(variant: .body1Reading))
@@ -215,14 +254,15 @@ public struct TextArea: View {
                                 .padding(.top, -4)
                                 .padding(.bottom, -6)
                         }
-                    } else {
+                    case let .height(minimum, maximum):
+                        let min = min(minimum, maximum)
+                        let max = max(minimum, maximum)
                         if #available(iOS 16, *) {
                             TextEditor(text: $text)
-                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
-                                .frame(minHeight: 36)
+                                .frame(minHeight: min, maxHeight: max, alignment: .topLeading)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .onChange(of: text) { result in
                                     typedCharacters = text.count
@@ -234,11 +274,10 @@ public struct TextArea: View {
                                 .padding(.bottom, -6)
                         } else {
                             TextEditor(text: $text)
-                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
-                                .frame(minHeight: 36)
+                                .frame(minHeight: min, maxHeight: max, alignment: .topLeading)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .onChange(of: text) { result in
                                     typedCharacters = text.count


### PR DESCRIPTION

# 개요

### 📌 작업 완료 기한
- 2024/08/29

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
- 텍스트가 표시될 영역의 최대, 최소 높이를 직접 지정할 수 있습니다.
- 오입력 케이스를 방지하기 위해 최소 높이는 입력 값 중 가장 낮은값, 최대 높이는 입력 값 중 가장 높은값으로 지정됩니다.


### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|<img width="769" alt="image" src="https://github.com/user-attachments/assets/1181957f-e947-4a8a-9d32-b985c9cc2783">|<img width="414" alt="image" src="https://github.com/user-attachments/assets/01ebddde-0db2-495f-a1fa-69bae5c6c415">



# 확인사항
- [ ] 동작 확인 
