### PR TITLE
[PI-67747] Select Description Property 추가 

### DIFF
--- a/Sources/Montage/Components/Select/MultipleSelect.swift
+++ b/Sources/Montage/Components/Select/MultipleSelect.swift
@@ -50,6 +50,9 @@ extension Select {
         
         /// MultipleSelect의 활성화(=값이 있는지) 여부입니다.
         @State private var active: Bool = true
+
+        /// MultipleSelect의 텍스트와 외곽선을 포함하는 영역의 사이즈입니다.
+        @State private var contentSize: CGSize = .zero
         
         /// MultipleSelect의 표시될 내용의 형태입니다.
         private let render: Render
@@ -73,6 +76,10 @@ extension Select {
         /// MultipleSelect의 필수 표시 노출 여부입니다.
         /// > 기본값은 false입니다.
         private let requiredBadge: Bool
+        
+        /// MultipleSelect의 설명입니다.
+        /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
+        private let description: String?
         
         /// MultipleSelect의 shadow 배경색입니다.
         /// > 기본값은 systemBackgroundColor 입니다.
@@ -100,6 +107,7 @@ extension Select {
             disable: Bool = false,
             heading: String? = nil,
             requiredBadge: Bool = false,
+            description: String? = nil,
             backgroundColor: SwiftUI.Color = .init(uiColor: UIColor.systemBackground),
             leftContent: (() -> any View)? = nil,
             onTapItem: ((Select.Multiple.Item) -> Void)? = nil,
@@ -113,6 +121,7 @@ extension Select {
             self.disable = disable
             self.heading = heading
             self.requiredBadge = requiredBadge
+            self.description = description
             self.shadowBackgroundColor = backgroundColor
             self.leftContent = leftContent
             self.onTapItem = onTapItem
@@ -132,7 +141,7 @@ extension Select {
         }
 
         public var body: some View {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 8) {
                 if let heading {
                     HStack(spacing: 4) {
                         Text(heading)
@@ -159,6 +168,10 @@ extension Select {
                             color: .alias(.staticBlack).opacity(0.03),
                             radius: 2,
                             x: 0, y: 1
+                        )
+                        .frame(
+                            width: contentSize.width,
+                            height: contentSize.height
                         )
 
                     HStack(spacing: 8) {
@@ -231,6 +244,15 @@ extension Select {
                         radius: 2,
                         x: 0, y: 1
                     )
+                }
+                
+                if let description {
+                    Text(description)
+                        .montage(
+                            variant: .caption1,
+                            weight: .regular,
+                            alias: .labelAlternative
+                        )
                 }
             }
             .onChange(of: items, perform: { newValue in
@@ -318,6 +340,7 @@ struct MultipleSelect_Preview: PreviewProvider {
             disable: false,
             heading: "제목",
             requiredBadge: true,
+            description: "메세지에 마침표를 찍어요.",
             leftContent: nil,
             onTapItem: { _ in print("아이템 터치") }
         ) {

--- a/Sources/Montage/Components/Select/SingleSelect.swift
+++ b/Sources/Montage/Components/Select/SingleSelect.swift
@@ -1,5 +1,5 @@
 //
-//  NormalSelect.swift
+//  SingleSelect.swift
 //  Montage
 //
 //  Created by ahn sanghoon on 8/9/24.
@@ -9,51 +9,58 @@ import SwiftUI
 
 extension Select {
     /// 드롭다운(dropdown) 메뉴와 같이 옵션을 확인하고 고르는 용도로 사용합니다.
-    public struct Normal: View {
-        /// NormalSelect의 외관을 결정하는 열거형입니다.
+    public struct Single: View {
+        /// SingleSelect의 외관을 결정하는 열거형입니다.
         public enum Variant {
             case normal
             case negative
         }
         
-        /// NormalSelect의 포커싱 여부입니다.
+        /// SingleSelect의 포커싱 여부입니다.
         /// 외부에서 포커싱 여부를 변경할 수 있습니다.
         @Binding var focus: Bool
         
-        /// NormalSelect의 활성화(=값이 있는지) 여부입니다.
+        /// SingleSelect의 활성화(=값이 있는지) 여부입니다.
         @State private var active: Bool = true
         
-        /// NormalSelect에 표시될 텍스트입니다.
+        /// SingleSelect의 텍스트와 외곽선을 포함하는 영역의 사이즈입니다.
+        @State private var contentSize: CGSize = .zero
+        
+        /// SingleSelect에 표시될 텍스트입니다.
         private let text: String
         
-        /// NormalSelect의 외관입니다.
+        /// SingleSelect의 외관입니다.
         private let variant: Variant
         
-        /// NormalSelect의 텍스트가 없는 경우 나타낼 placeholder입니다.
+        /// SingleSelect의 텍스트가 없는 경우 나타낼 placeholder입니다.
         private let placeholder: String
         
-        /// NormalSelect의 사용가능 여부입니다.
+        /// SingleSelect의 사용가능 여부입니다.
         private let disable: Bool
         
-        /// NormalSelect의 제목입니다.
+        /// SingleSelect의 제목입니다.
         /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
         private let heading: String?
         
-        /// NormalSelect의 필수 표시 노출 여부입니다.
+        /// SingleSelect의 필수 표시 노출 여부입니다.
         /// > 기본값은 false입니다.
         private let requiredBadge: Bool
         
-        /// NormalSelect의 왼쪽 컨텐츠입니다.
+        /// SingleSelect의 설명입니다.
+        /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
+        private let description: String?
+        
+        /// SingleSelect의 왼쪽 컨텐츠입니다.
         /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
         private var leftContent: (() -> any View)?
         
-        /// NormalSelect의 shadow 배경색입니다.
+        /// SingleSelect의 shadow 배경색입니다.
         /// > 기본값은 systemBackgroundColor 입니다.
         /// >
         /// > shadow 배경색 변경이 필요할때 사용합니다.
         private let shadowBackgroundColor: SwiftUI.Color
         
-        /// NormalSelect Tap에 대한 handler 입니다.
+        /// SingleSelect Tap에 대한 handler 입니다.
         private var onTap: (() -> Void)?
 
         public init(
@@ -64,6 +71,7 @@ extension Select {
             disable: Bool = false,
             heading: String? = nil,
             requiredBadge: Bool = false,
+            description: String? = nil,
             leftContent: (() -> any View)? = nil,
             backgroundColor: SwiftUI.Color = .init(uiColor: UIColor.systemBackground),
             onTap: (() -> Void)? = nil
@@ -75,6 +83,7 @@ extension Select {
             self.disable = disable
             self.heading = heading
             self.requiredBadge = requiredBadge
+            self.description = description
             self.leftContent = leftContent
             self.shadowBackgroundColor = backgroundColor
             self.onTap = onTap
@@ -93,7 +102,7 @@ extension Select {
         }
 
         public var body: some View {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 8) {
                 if let heading {
                     HStack(spacing: 4) {
                         Text(heading)
@@ -121,6 +130,7 @@ extension Select {
                             radius: 2,
                             x: 0, y: 1
                         )
+                        .frame(width: contentSize.width, height: contentSize.height)
                     
                     HStack(spacing: 8) {
                         if let leftContent {
@@ -180,6 +190,16 @@ extension Select {
                             .stroke(strokeColor, lineWidth: focus ? 2 : 1)
                     }
                 }
+                .readSize { contentSize = $0 }
+                
+                if let description {
+                    Text(description)
+                        .montage(
+                            variant: .caption1,
+                            weight: .regular,
+                            alias: .labelAlternative
+                        )
+                }
             }
             .onChange(of: text, perform: { newValue in
                 active = (newValue.isEmpty == false)
@@ -193,9 +213,9 @@ extension Select {
 
 }
 
-struct NormalSelect_Preview: PreviewProvider {
+struct SingleSelect_Preview: PreviewProvider {
     static var previews: some View {
-        Select.Normal(
+        Select.Single(
             text: "",
             focus: .constant(false),
             variant: .negative,
@@ -203,6 +223,7 @@ struct NormalSelect_Preview: PreviewProvider {
             disable: false,
             heading: "주제",
             requiredBadge: true,
+            description: "메세지에 마침표를 찍어요.",
             leftContent: nil
         )
     }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=16383-43905&node-type=SECTION&m=dev

### 📌 작업 완료 기한
- 2024/09/04

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* Select/Normal에서  Select/Single으로 네이밍이 변경되었습니다.
* Select/Single, Select/Multiple 컴포넌트에 description property를 추가합니다.


### 미리보기
📱|Single 작업 전|Single 작업 후
---|---|---
iPhone|![image](https://github.com/user-attachments/assets/0f3e12bc-fa06-45f1-b278-9d3aa4460aea)|![image](https://github.com/user-attachments/assets/2435d2b3-756f-47aa-9852-acedd68ecaf8)


### 미리보기
📱|Multiple 작업 전|Multiple 작업 후
---|---|---
iPhone|![image](https://github.com/user-attachments/assets/b29e1bda-902b-4e9e-bbec-497f3e18a808)|![image](https://github.com/user-attachments/assets/54b0e8b0-9883-4c4d-b508-a5780e3f48f0)

# 확인사항
- [X] 동작 확인 
