### PR TITLE
[PI-66965] TextArea 디자인 추가 수정 반영 (~9/4)

### DIFF
--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -32,41 +32,51 @@ public struct TextArea: View {
     // MARK: - Uninitialised properties
     
     /// TextArea의 resize 여부 입니다.
-    public var resize: Resize = .normal
+    public let resize: Resize
     
     /// TextArea의 외관입니다.
-    public var variant: Variant = .normal
+    public let variant: Variant
     
     /// TextArea의 포커싱 여부입니다.
-    public var focus: Bool = false
+    public let focus: Bool
     
     /// TextArea의 사용가능 여부입니다.
-    public var disable: Bool = false
+    public let disable: Bool
     
     /// TextArea의 제목입니다.
     /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
-    public var heading: String? = nil
+    public let heading: String?
     
     /// TextArea의 필수 표시 노출 여부입니다.
-    public var requiredBadge: Bool = false
+    public let requiredBadge: Bool
     
     /// TextArea의 하단 영역 노출 여부입니다.
     /// - 하단 영역 : 글자수 / 제한 글자수 / 버튼
-    public var bottom: Bool = false
+    public let bottom: Bool
     
     /// TextArea 하단 설명입니다.
     /// > 기본값은 nil이며, 값이 없는 경우 노출되지 않습니다.
-    public var description: String? = nil
+    public let description: String?
     
     /// TextArea에 입력된 텍스트가 없을 때 노출되는 placeholder입니다.
     ///  > 값을 지정하지 않으면 노출되지 않습니다.
-    public var placeholder: String? = nil
+    public let placeholder: String?
     
     /// TextArea 하단 좌측의 컴포넌트입니다.
-    public var leftResource: Resource? = nil
+    /// > 최대 3개까지 사용할 수 있습니다.
+    public let leftResource: [Resource]
+    
+    /// TextArea 하단 좌측의 컴포넌트들의 여백입니다.
+    /// > 기본값은 24입니다.
+    public let leftResourceSpacing: CGFloat
     
     /// TextArea 하단 우측의 컴포넌트입니다.
-    public var rightResource: Resource? = nil
+    /// > 최대 3개까지 사용할 수 있습니다.
+    public let rightResource: [Resource]
+    
+    /// TextArea 하단 우측의 컴포넌트들의 여백입니다.
+    /// > 기본값은 24입니다.
+    public let rightResourceSpacing: CGFloat
     
     public init(
         text: Binding<String>,
@@ -79,8 +89,10 @@ public struct TextArea: View {
         bottom: Bool = false,
         description: String? = nil,
         placeholder: String? = nil,
-        leftResource: Resource? = nil,
-        rightResource: Resource? = nil
+        leftResource: [Resource] = [],
+        leftResourceSpacing: CGFloat = 24,
+        rightResource: [Resource] = [],
+        rightResourceSpacing: CGFloat = 24
     ) {
         self._text = text
         self.resize = resize
@@ -92,8 +104,10 @@ public struct TextArea: View {
         self.bottom = bottom
         self.description = description
         self.placeholder = placeholder
-        self.leftResource = leftResource
-        self.rightResource = rightResource
+        self.leftResource = Array(leftResource.prefix(3))
+        self.leftResourceSpacing = leftResourceSpacing
+        self.rightResource = Array(rightResource.prefix(3))
+        self.rightResourceSpacing = rightResourceSpacing
     }
     
     // MARK: - Computed properties
@@ -122,7 +136,9 @@ public struct TextArea: View {
                 placeholder,
                 bottom,
                 leftResource,
-                rightResource
+                leftResourceSpacing,
+                rightResource,
+                rightResourceSpacing
             )
             if let description {
                 Text(description)
@@ -145,8 +161,10 @@ public struct TextArea: View {
         private let disable: Bool
         private let placeholder: String?
         private let bottom: Bool
-        private let leftResource: TextArea.Resource?
-        private let rightResource: TextArea.Resource?
+        private let leftResource: [TextArea.Resource]
+        private let leftResourceSpacing: CGFloat
+        private let rightResource: [TextArea.Resource]
+        private let rightResourceSpacing: CGFloat
         
         init(
             _ text: Binding<String>,
@@ -156,8 +174,10 @@ public struct TextArea: View {
             _ disable: Bool,
             _ placeholder: String?,
             _ bottom: Bool,
-            _ leftResource: TextArea.Resource? = nil,
-            _ rightResource: TextArea.Resource? = nil
+            _ leftResource: [TextArea.Resource],
+            _ leftResourceSpacing: CGFloat,
+            _ rightResource: [TextArea.Resource],
+            _ rightResourceSpacing: CGFloat
         ) {
             self._text = text
             self.resize = resize
@@ -167,7 +187,9 @@ public struct TextArea: View {
             self.placeholder = placeholder
             self.bottom = bottom
             self.leftResource = leftResource
+            self.leftResourceSpacing = leftResourceSpacing
             self.rightResource = rightResource
+            self.rightResourceSpacing = rightResourceSpacing
         }
 
         private var editorStrokeColor: SwiftUI.Color {
@@ -267,7 +289,9 @@ public struct TextArea: View {
                         variant,
                         disable,
                         leftResource,
-                        rightResource
+                        leftResourceSpacing,
+                        rightResource,
+                        rightResourceSpacing
                     )
                 }
             }
@@ -291,46 +315,67 @@ public struct TextArea: View {
             
             private let variant: Variant
             private let disable: Bool
-            private let leftResource: TextArea.Resource?
-            private let rightResource: TextArea.Resource?
+            private let leftResources: [TextArea.Resource]
+            private let leftResourceSpacing: CGFloat
+            private let rightResources: [TextArea.Resource]
+            private let rightResourceSpacing: CGFloat
             
             init(
                 typedCharacters: Binding<Int>,
                 _ variant: Variant,
                 _ disable: Bool,
-                _ leftResource: TextArea.Resource? = nil,
-                _ rightResource: TextArea.Resource? = nil
+                _ leftResources: [TextArea.Resource],
+                _ leftResourceSpacing: CGFloat,
+                _ rightResources: [TextArea.Resource],
+                _ rightResourceSpacing: CGFloat
             ) {
                 self._typedCharacters = typedCharacters
                 self.variant = variant
                 self.disable = disable
-                self.leftResource = leftResource
-                self.rightResource = rightResource
+                self.leftResources = leftResources
+                self.leftResourceSpacing = leftResourceSpacing
+                self.rightResources = rightResources
+                self.rightResourceSpacing = rightResourceSpacing
             }
 
             var body: some View {
                 HStack {
-                    if let leftResource {
-                        component(leftResource)
+                    if leftResources.isEmpty == false {
+                        HStack(spacing: leftResourceSpacing) {
+                            ForEach(leftResources.indices, id: \.self) { index in
+                                component(leftResources[index])
+                            }
+                        }
                     }
                     Spacer()
-                    if let rightResource {
-                        if variant == .normal {
-                            if 
-                                case .characterCount(_) = leftResource,
-                                case .characterCount(_) = rightResource
-                            {
-                                EmptyView()
-                            } else {
-                                component(rightResource)
+                    if rightResources.isEmpty == false {
+                        HStack(spacing: rightResourceSpacing) {
+                            ForEach(rightResources.indices, id: \.self) { index in
+                                if variant == .normal {
+                                    let rightResource = rightResources[index]
+                                    if
+                                        leftResources.contains(where: { leftResource in
+                                            if case .characterCount(_) = leftResource {
+                                                return true
+                                            } else {
+                                                return false
+                                            }
+                                        }),
+                                        case .characterCount(_) = rightResource
+                                    {
+                                        EmptyView()
+                                    } else {
+                                        component(rightResource)
+                                    }
+                                } else {
+                                    Button.IconButton(
+                                        icon: .circleExclamationFill,
+                                        iconColor:
+                                            disable ? .alias(.labelDisable) : .alias(.statusNegative)
+                                    )
+                                    .fixedSize()
+                                }
                             }
-                        } else {
-                            Button.IconButton(
-                                icon: .circleExclamationFill,
-                                iconColor:
-                                    disable ? .alias(.labelDisable) : .alias(.statusNegative)
-                            )
-                            .fixedSize()
                         }
                     }
                 }
@@ -384,7 +429,6 @@ public struct TextArea: View {
                         icon: icon,
                         handler: handler
                     )
-                    .fixedSize()
                 case let .icon(icon):
                     Image.montage(icon)
                         .resizable()

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -294,15 +294,6 @@ public struct TextArea: View {
             private let leftResource: TextArea.Resource?
             private let rightResource: TextArea.Resource?
             
-            private var leadingOffset: CGFloat {
-                if let leftResource {
-                    guard case .textButton(_, _, _, _) = leftResource else { return .zero }
-                    return 6
-                } else {
-                    return .zero
-                }
-            }
-            
             init(
                 typedCharacters: Binding<Int>,
                 _ variant: Variant,
@@ -318,7 +309,7 @@ public struct TextArea: View {
             }
 
             var body: some View {
-                HStack(spacing: 16) {
+                HStack {
                     if let leftResource {
                         component(leftResource)
                     }
@@ -343,7 +334,6 @@ public struct TextArea: View {
                         }
                     }
                 }
-                .padding(.leading, 6 - leadingOffset)
             }
 
             @ViewBuilder
@@ -360,6 +350,7 @@ public struct TextArea: View {
                                 .paragraph(variant: .label2)
                         }
                     }
+                    .padding(.horizontal, 4)
                 case let .textButton(placement, variant, title, handler):
                     Button.TextButton(
                         variant: {
@@ -376,7 +367,8 @@ public struct TextArea: View {
                         text: title,
                         handler: handler
                     )
-                    .fixedSize()
+                    .frame(maxHeight: 24)
+                    .padding(.horizontal, 4)
                 case let .iconButton(placement, variant, icon, handler):
                     Button.IconButton(
                         variant: {

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -187,7 +187,7 @@ public struct TextArea: View {
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
-                                .frame(minHeight: 36, maxHeight: 250)
+                                .frame(minHeight: 36, maxHeight: 320)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .onChange(of: text) { result in
                                     typedCharacters = text.count
@@ -202,7 +202,7 @@ public struct TextArea: View {
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
-                                .frame(minHeight: 36, maxHeight: 250)
+                                .frame(minHeight: 36, maxHeight: 320)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .onChange(of: text) { result in
                                     typedCharacters = text.count

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -199,6 +199,13 @@ public struct TextArea: View {
                 return textEditorFocusState ? SwiftUI.Color.alias(.primaryNormal).opacity(0.43) : SwiftUI.Color.alias(.lineNormal)
             }
         }
+        private var editorTextColor: SwiftUI.Color {
+            if disable {
+                text.isEmpty ? .alias(.labelDisable) : .alias(.labelAlternative)
+            } else {
+                .alias(.labelNormal)
+            }
+        }
         
         var body: some View {
             VStack(spacing: 12) {
@@ -207,6 +214,7 @@ public struct TextArea: View {
                         if #available(iOS 16, *) {
                             TextEditor(text: $text)
                                 .font(.montage(variant: .body1Reading))
+                                .foregroundStyle(editorTextColor)
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
                                 .frame(minHeight: 36, maxHeight: 320)
@@ -221,6 +229,7 @@ public struct TextArea: View {
                                 .padding(.bottom, -6)
                         } else {
                             TextEditor(text: $text)
+                                .foregroundStyle(editorTextColor)
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
@@ -240,7 +249,7 @@ public struct TextArea: View {
                     } else {
                         if #available(iOS 16, *) {
                             TextEditor(text: $text)
-                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
+                                .foregroundStyle(editorTextColor)
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
@@ -256,7 +265,7 @@ public struct TextArea: View {
                                 .padding(.bottom, -6)
                         } else {
                             TextEditor(text: $text)
-                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
+                                .foregroundStyle(editorTextColor)
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
@@ -276,7 +285,7 @@ public struct TextArea: View {
                     }
                     if $text.wrappedValue.isEmpty && textEditorFocusState == false, let placeholder {
                         Text(placeholder)
-                            .montage(variant: .body1Reading, alias: .labelAssistive)
+                            .montage(variant: .body1Reading, alias: disable ? .labelDisable : .labelAssistive)
                             .paragraph(variant: .body1Reading)
                             .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
                             .allowsHitTesting(false)
@@ -414,7 +423,7 @@ public struct TextArea: View {
                     )
                     .frame(maxHeight: 24)
                     .padding(.horizontal, 4)
-                case let .iconButton(placement, variant, icon, handler):
+                case let .iconButton(placement, variant, icon, tintColor, handler):
                     Button.IconButton(
                         variant: {
                             if let variant {
@@ -427,12 +436,14 @@ public struct TextArea: View {
                             }
                         }(),
                         icon: icon,
+                        iconColor: tintColor,
                         handler: handler
                     )
-                case let .icon(icon):
+                case let .icon(icon, tintColor):
                     Image.montage(icon)
                         .resizable()
-                        .frame(width: 24, height: 24)
+                        .foregroundColor(tintColor)
+                        .frame(width: 22, height: 22)
                 case let .actionChip(variant, title, handler):
                     Chip.ActionChipController(
                         variant: variant,
@@ -483,9 +494,13 @@ extension TextArea {
             placement: Placement = .left,
             variant: Button.IconButton.Variant? = .solid(size: .small),
             icon: Icon,
+            tintColor: SwiftUI.Color = .alias(.labelAlternative),
             handler: (() -> Void)? = nil
         )
-        case icon(Icon)
+        case icon(
+            Icon,
+            tintColor: SwiftUI.Color = .alias(.labelAssistive)
+        )
         case actionChip(
             Chip.Action.Variant = .filled,
             title: String,
@@ -513,11 +528,11 @@ struct TextArea_Previews: PreviewProvider {
             disable: false,
             heading: "주제",
             requiredBadge: true,
-            bottom: false,
-            description: "?",
-            placeholder: "??",
-            leftResource: .textButton(title: "텍스트", handler: {}),
-            rightResource: .textButton(title: "텍스트", handler: {})
+            bottom: true,
+            description: "메세지에 마침표를 찍어요.",
+            placeholder: "텍스트를 입력해 주세요.",
+            leftResource: [.badge(title: "텍스트")],
+            rightResource: [.textButton(title: "텍스트", handler: {})]
         )
     }
 }

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -405,6 +405,14 @@ public struct TextArea: View {
                         handler: handler
                     )
                     .fixedSize()
+                case let .badge(variant, title):
+                    Badge.ContentBadgeController(
+                        variant: variant,
+                        size: .medium,
+                        color: .neutral,
+                        text: title
+                    )
+                    .fixedSize()
                 }
             }
         }
@@ -443,6 +451,10 @@ extension TextArea {
             Chip.Filter.Variant = .filled,
             title: String,
             handler: (() -> Void)? = nil
+        )
+        case badge(
+            Badge.Content.Variant = .filled,
+            title: String
         )
     }
 }

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -392,7 +392,7 @@ public struct TextArea: View {
                 case let .actionChip(variant, title, handler):
                     Chip.ActionChipController(
                         variant: variant,
-                        size: .xsmall,
+                        size: .small,
                         text: title,
                         handler: handler
                     )
@@ -400,7 +400,7 @@ public struct TextArea: View {
                 case let .filterChip(variant, title, handler):
                     Chip.FilterChipController(
                         variant: variant,
-                        size: .xsmall,
+                        size: .small,
                         text: title,
                         handler: handler
                     )


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=2447-8397&node-type=SECTION&m=dev
- 🎨  디자인 링크 : https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=14854-44981&t=gXbimi9rzXkiCYQt-4

### 📌 작업 완료 기한
- 2024/09/04

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* Resource의 여백을 수정하였습니다.
* Resource의 chip 사이즈를 변경하고, Badge/Content를 추가하였습니다.
* Resource가 이제 여러 항목을 가질 수 있습니다. (단 최대 3개까지만 가질 수 있습니다)
  * 항목의 여백은 직접 커스텀할 수 있으며, 기본값은 24 입니다.
* Resize case에서 limit이 최대 8줄 제한에서 12줄 제한으로 변경됩니다.
* 기타 디자인 수정사항을 반영합니다.

### 미리보기
📱|참고 1|참고 2
---|---|---
iPhone|<img width="435" alt="image" src="https://github.com/user-attachments/assets/e87e4028-6eac-4c07-b4ce-a59d8a47cf74">|![image](https://github.com/user-attachments/assets/84f14826-7f29-4f6c-9dd2-4c786b2a1d2f)

# 확인사항
- [X] 동작 확인 
