### PR TITLE
[PI-67464, PI-67554] Select, TextInput, TextArea Placeholder, Disable 상태의 텍스트 컬러 변경 (~9/6)

### DIFF
--- a/Sources/Montage/Components/Select/MultipleSelect.swift
+++ b/Sources/Montage/Components/Select/MultipleSelect.swift
@@ -139,6 +139,14 @@ extension Select {
                 }
             }
         }
+        
+        private var placeholderTextColor: SwiftUI.Color {
+            disable ? .alias(.labelDisable) : .alias(.labelAssistive)
+        }
+        
+        private var textColor: SwiftUI.Color {
+            disable ? .alias(.labelAlternative) : .alias(.labelNormal)
+        }
 
         public var body: some View {
             VStack(alignment: .leading, spacing: 8) {
@@ -186,7 +194,7 @@ extension Select {
                                         .montage(
                                             variant: .body1,
                                             weight: .regular,
-                                            alias: disable ? .labelDisable : .labelAlternative
+                                            color: placeholderTextColor
                                         )
                                         .paragraph(variant: .body1)
                                 } else {
@@ -195,8 +203,7 @@ extension Select {
                                             .montage(
                                                 variant: .body1,
                                                 weight: .regular,
-                                                alias: disable ? .labelDisable :
-                                                        .labelNormal
+                                                color: textColor
                                             )
                                             .paragraph(variant: .body1)
                                     } else {

--- a/Sources/Montage/Components/Select/SingleSelect.swift
+++ b/Sources/Montage/Components/Select/SingleSelect.swift
@@ -100,6 +100,14 @@ extension Select {
                 .alias(.lineNeutral)
             }
         }
+        
+        private var placeholderTextColor: SwiftUI.Color {
+            disable ? .alias(.labelDisable) : .alias(.labelAssistive)
+        }
+        
+        private var textColor: SwiftUI.Color {
+            disable ? .alias(.labelAlternative) : .alias(.labelNormal)
+        }
 
         public var body: some View {
             VStack(alignment: .leading, spacing: 8) {
@@ -144,7 +152,7 @@ extension Select {
                                         .montage(
                                             variant: .body1,
                                             weight: .regular,
-                                            alias: disable ? .labelDisable : .labelAssistive
+                                            color: placeholderTextColor
                                         )
                                         .paragraph(variant: .body1)
                                 } else {
@@ -152,8 +160,7 @@ extension Select {
                                         .montage(
                                             variant: .body1,
                                             weight: .regular,
-                                            alias: disable ? .labelDisable :
-                                                    .labelNormal
+                                            color: textColor
                                         )
                                         .paragraph(variant: .body1)
                                 }

--- a/Sources/Montage/Components/Select/SingleSelect.swift
+++ b/Sources/Montage/Components/Select/SingleSelect.swift
@@ -144,7 +144,7 @@ extension Select {
                                         .montage(
                                             variant: .body1,
                                             weight: .regular,
-                                            alias: disable ? .labelDisable : .labelAlternative
+                                            alias: disable ? .labelDisable : .labelAssistive
                                         )
                                         .paragraph(variant: .body1)
                                 } else {

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -326,7 +326,10 @@ public struct TextArea: View {
                     }
                     if $text.wrappedValue.isEmpty && textEditorFocusState == false, let placeholder {
                         Text(placeholder)
-                            .montage(variant: .body1Reading, alias: disable ? .labelDisable : .labelAssistive)
+                            .montage(
+                                variant: .body1Reading,
+                                alias: disable ? .labelDisable : .labelAssistive
+                            )
                             .paragraph(variant: .body1Reading)
                             .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
                             .allowsHitTesting(false)

--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -201,12 +201,13 @@ public struct TextArea: View {
                 return textEditorFocusState ? SwiftUI.Color.alias(.primaryNormal).opacity(0.43) : SwiftUI.Color.alias(.lineNormal)
             }
         }
+        
+        private var placeholderTextColor: SwiftUI.Color {
+            disable ? .alias(.labelDisable) : .alias(.labelAssistive)
+        }
+        
         private var editorTextColor: SwiftUI.Color {
-            if disable {
-                text.isEmpty ? .alias(.labelDisable) : .alias(.labelAlternative)
-            } else {
-                .alias(.labelNormal)
-            }
+            disable ? .alias(.labelAlternative) : .alias(.labelNormal)
         }
         
         var body: some View {
@@ -216,7 +217,7 @@ public struct TextArea: View {
                     case .normal:
                         if #available(iOS 16, *) {
                             TextEditor(text: $text)
-                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
+                                .foregroundStyle(editorTextColor)
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
@@ -232,7 +233,7 @@ public struct TextArea: View {
                                 .padding(.bottom, -6)
                         } else {
                             TextEditor(text: $text)
-                                .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : SwiftUI.Color.alias(.labelNormal))
+                                .foregroundStyle(editorTextColor)
                                 .font(.montage(variant: .body1Reading))
                                 .lineSpacing(Typography.Variant.body1Reading.lineSpacing)
                                 .focused($textEditorFocusState)
@@ -328,7 +329,7 @@ public struct TextArea: View {
                         Text(placeholder)
                             .montage(
                                 variant: .body1Reading,
-                                alias: disable ? .labelDisable : .labelAssistive
+                                color: placeholderTextColor
                             )
                             .paragraph(variant: .body1Reading)
                             .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)

--- a/Sources/Montage/Components/Text/TextInput.swift
+++ b/Sources/Montage/Components/Text/TextInput.swift
@@ -161,6 +161,7 @@ public struct TextInput: View {
             }
         }
         
+        
         var body: some View {
             HStack(spacing: .zero) {
                 ZStack {
@@ -176,7 +177,12 @@ public struct TextInput: View {
                             text: $text,
                             prompt: {
                                 if let placeholder {
-                                    return Text(placeholder).montage(variant: .body1, weight: .regular, alias: .labelAlternative)
+                                    return Text(placeholder)
+                                        .montage(
+                                            variant: .body1,
+                                            weight: .regular,
+                                            alias: disable ? .labelDisable : .labelAssistive
+                                        )
                                 } else {
                                     return nil
                                 }

--- a/Sources/Montage/Components/Text/TextInput.swift
+++ b/Sources/Montage/Components/Text/TextInput.swift
@@ -143,7 +143,7 @@ public struct TextInput: View {
         var rightButton: Resource.Button?
         var rightContent: (() -> any View)?
 
-        var fieldStrokeColor: SwiftUI.Color {
+        private var fieldStrokeColor: SwiftUI.Color {
             if textFieldFocusState {
                 switch variant {
                 case .normal, .positive:
@@ -160,7 +160,13 @@ public struct TextInput: View {
                 }
             }
         }
+        private var placeholderTextColor: SwiftUI.Color {
+            disable ? .alias(.labelDisable) : .alias(.labelAssistive)
+        }
         
+        private var fieldTextColor: SwiftUI.Color {
+            disable ? .alias(.labelAlternative) : .alias(.labelNormal)
+        }
         
         var body: some View {
             HStack(spacing: .zero) {
@@ -181,7 +187,7 @@ public struct TextInput: View {
                                         .montage(
                                             variant: .body1,
                                             weight: .regular,
-                                            alias: disable ? .labelDisable : .labelAssistive
+                                            color: placeholderTextColor
                                         )
                                 } else {
                                     return nil
@@ -189,7 +195,7 @@ public struct TextInput: View {
                             }()
                         )
                         .font(.montage(variant: .body1, weight: .regular))
-                        .foregroundStyle(disable ? SwiftUI.Color.alias(.labelDisable) : .alias(.labelNormal))
+                        .foregroundStyle(fieldTextColor)
                         .focused($textFieldFocusState)
                         .frame(height: 24)
                         .padding(.horizontal, 4)


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=2098-25568&node-type=CANVAS&t=rGNAyc6QDvqra1T3-11
- 🔗 JIRA 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-67464
- 🔗 JIRA 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-67554

### 📌 작업 완료 기한
- 2024/09/06

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* placeholder의 텍스트 컬러를 변경합니다.
* disable 상태일때의 텍스트 컬러를 변경합니다.

### 미리보기
📱|작업 후 & 전
---|---
iPhone|<img width="933" alt="스크린샷 2024-09-05 오전 11 31 32" src="https://github.com/user-attachments/assets/970c4480-bc06-4602-b690-74ca0d1c8f61">

### 미리보기
📱|작업 후 & 전
---|---
iPhone|<img width="933" alt="스크린샷 2024-09-05 오전 11 32 06" src="https://github.com/user-attachments/assets/09a22d4c-7290-4e15-a9f6-7eb10b434a99">

### 미리보기
📱|작업 후 & 전
---|---
iPhone|<img width="933" alt="스크린샷 2024-09-05 오전 11 36 36" src="https://github.com/user-attachments/assets/6ccad80a-d5c2-4f39-b4b5-dfece95c0e91">

### 미리보기
📱|작업 후 & 전
---|---
iPhone|<img width="933" alt="스크린샷 2024-09-05 오전 11 36 53" src="https://github.com/user-attachments/assets/b0313fc6-6659-4653-ba69-e8aa2784906b">

### 미리보기
📱|작업 후 & 전
---|---
iPhone|<img width="933" alt="스크린샷 2024-09-05 오전 11 37 40" src="https://github.com/user-attachments/assets/f696e346-2e4b-4241-90ff-cd6552a17bb8">

### 미리보기
📱|작업 후 & 전
---|---
iPhone|<img width="933" alt="스크린샷 2024-09-05 오전 11 38 42" src="https://github.com/user-attachments/assets/cfbe70fe-4c28-453a-b8c8-7b8e5292a168">


# 확인사항
- [X] 동작 확인 
