### PR TITLE
[PI-66945] TopNavigation Floating 버튼의 background option 추가 (~9/10)

### DIFF
--- a/Sources/Montage/Element/Bar/TopNavigation/TopNavigation.swift
+++ b/Sources/Montage/Element/Bar/TopNavigation/TopNavigation.swift
@@ -178,12 +178,12 @@ extension Bar {
                         }
                         .padding(.horizontal, 4)
                     }
-                case .floating(let alternative):
+                case let .floating(alternative, background):
                     ZStack {
                         HStack(spacing: .zero) {
-                            FloatingLeft(left, alternative)
+                            FloatingLeft(left, alternative, background)
                             Spacer()
-                            FloatingAction(actions, alternative)
+                            FloatingAction(actions, alternative, background)
                         }
                     }
                 }
@@ -331,80 +331,113 @@ extension Bar {
         private struct FloatingLeft: View {
             let left: Resource.Left?
             let alternative: Bool
+            let background: Bool
             
-            init(_ left: Resource.Left?, _ alternative: Bool) {
+            init(
+                _ left: Resource.Left?,
+                _ alternative: Bool,
+                _ background: Bool
+            ) {
                 self.left = left
                 self.alternative = alternative
+                self.background = background
             }
             
             var body: some View {
                 if let left {
                     Group {
-                        if alternative {
-                            switch left {
-                            case .back(let action):
-                                Button.IconButton(
-                                    variant: .background(size: 24, isAlternative: alternative),
-                                    icon: .chevronLeftThick
-                                ) {
-                                    action()
+                        if background {
+                            if alternative {
+                                switch left {
+                                case .back(let action):
+                                    Button.IconButton(
+                                        variant: .background(size: 24, isAlternative: alternative),
+                                        icon: .chevronLeftThick
+                                    ) {
+                                        action()
+                                    }
+                                case let .icon(i, action):
+                                    Button.IconButton(
+                                        variant: .background(size: 24, isAlternative: alternative),
+                                        icon: i
+                                    ) {
+                                        action()
+                                    }
+                                case let .text(t, action):
+                                    SwiftUI.Button {
+                                        action()
+                                    } label: {
+                                        Text(t)
+                                            .montage(variant: .body2, weight: .medium, alias: .staticWhite)
+                                            .paragraph(variant: .body2)
+                                            .opacity(0.88)
+                                            .padding(.vertical, 5)
+                                            .padding(.horizontal, 10)
+                                    }
+                                    .background(
+                                        SwiftUI.Color.atomic(.globalCoolNeutral30).opacity(0.61)
+                                    )
+                                    .clipShape(RoundedRectangle(cornerRadius: 1000))
                                 }
-                            case let .icon(i, action):
-                                Button.IconButton(
-                                    variant: .background(size: 24, isAlternative: alternative),
-                                    icon: i
-                                ) {
-                                    action()
+                            } else {
+                                switch left {
+                                case .back(let action):
+                                    Button.IconButton(
+                                        variant: .background(size: 20, isAlternative: alternative),
+                                        icon: .chevronLeftThick
+                                    ) {
+                                        action()
+                                    }
+                                    .background(.regularMaterial)
+                                    .clipShape(Circle())
+                                case let .icon(i, action):
+                                    Button.IconButton(
+                                        variant: .background(size: 20, isAlternative: alternative),
+                                        icon: i
+                                    ) {
+                                        action()
+                                    }
+                                    .background(.thickMaterial)
+                                    .clipShape(Circle())
+                                case let .text(t, action):
+                                    SwiftUI.Button {
+                                        action()
+                                    } label: {
+                                        Text(t)
+                                            .montage(variant: .body2, weight: .medium, alias: .labelAlternative)
+                                            .paragraph(variant: .body2)
+                                            .blendMode(.plusDarker)
+                                            .padding(.vertical, 5)
+                                            .padding(.horizontal, 10)
+                                    }
+                                    .background(.regularMaterial)
+                                    .clipShape(RoundedRectangle(cornerRadius: 1000))
                                 }
-                            case let .text(t, action):
-                                SwiftUI.Button {
-                                    action()
-                                } label: {
-                                    Text(t)
-                                        .montage(variant: .body2, weight: .medium, alias: .staticWhite)
-                                        .paragraph(variant: .body2)
-                                        .opacity(0.88)
-                                        .padding(.vertical, 5)
-                                        .padding(.horizontal, 10)
-                                }
-                                .background(
-                                    SwiftUI.Color.atomic(.globalCoolNeutral30).opacity(0.61)
-                                )
-                                .clipShape(RoundedRectangle(cornerRadius: 1000))
                             }
                         } else {
                             switch left {
                             case .back(let action):
                                 Button.IconButton(
-                                    variant: .background(size: 20, isAlternative: alternative),
+                                    variant: .default,
                                     icon: .chevronLeftThick
                                 ) {
                                     action()
                                 }
-                                .background(.regularMaterial)
-                                .clipShape(Circle())
                             case let .icon(i, action):
                                 Button.IconButton(
-                                    variant: .background(size: 20, isAlternative: alternative),
+                                    variant: .default,
                                     icon: i
                                 ) {
                                     action()
                                 }
-                                .background(.thickMaterial)
-                                .clipShape(Circle())
                             case let .text(t, action):
                                 SwiftUI.Button {
                                     action()
                                 } label: {
                                     Text(t)
-                                        .montage(variant: .body2, weight: .medium, alias: .labelAlternative)
-                                        .paragraph(variant: .body2)
-                                        .blendMode(.plusDarker)
-                                        .padding(.vertical, 5)
-                                        .padding(.horizontal, 10)
+                                        .montage(variant: .headline2, weight: .medium, alias: .labelNormal)
+                                        .paragraph(variant: .headline2)
                                 }
-                                .background(.regularMaterial)
-                                .clipShape(RoundedRectangle(cornerRadius: 1000))
                             }
                         }
                     }
@@ -415,10 +448,16 @@ extension Bar {
         private struct FloatingAction: View {
             let actions: [Resource.Action]
             let alternative: Bool
+            let background: Bool
             
-            init(_ actions: [Resource.Action], _ alternative: Bool) {
+            init(
+                _ actions: [Resource.Action],
+                _ alternative: Bool,
+                _ background: Bool
+            ) {
                 self.actions = actions
                 self.alternative = alternative
+                self.background = background
             }
             
             var body: some View {
@@ -427,42 +466,62 @@ extension Bar {
                         ForEach(actions, id: \.self) {
                             switch $0 {
                             case let .icon(i, s, action):
-                                Button.IconButton(
-                                    variant: .background(size: 20, isAlternative: alternative),
-                                    icon: i,
-                                    showPushBadge: s
-                                ) {
-                                    action()
+                                if background {
+                                    Button.IconButton(
+                                        variant: .background(size: 20, isAlternative: alternative),
+                                        icon: i,
+                                        showPushBadge: s
+                                    ) {
+                                        action()
+                                    }
+                                } else {
+                                    Button.IconButton(
+                                        variant: .default,
+                                        icon: i,
+                                        showPushBadge: s
+                                    ) {
+                                        action()
+                                    }
                                 }
                             case let .text(t, action):
-                                if alternative {
-                                    Button.TextButton(
-                                        text: t,
-                                        contentColor: .alias(.staticWhite)
-                                    ) {
-                                        action()
-                                    }
-                                    .padding(.horizontal, 5)
-                                    .background(SwiftUI.Color.atomic(.globalCoolNeutral30).opacity(0.61))
-                                    .clipShape(RoundedRectangle(cornerRadius: 1000))
-                                } else {
-                                    Button.TextButton(
-                                        text: t,
-                                        contentColor: .alias(.labelAlternative)
-                                    ) {
-                                        action()
-                                    }
-                                    .padding(.horizontal, 5)
-                                    .background(
-                                        ZStack {
-                                            SwiftUI.Color.alias(.staticBlack)
-                                                .opacity(0.05)
-                                            SwiftUI.Color.alias(.staticWhite)
-                                                .opacity(0.35)
+                                if background {
+                                    if alternative {
+                                        Button.TextButton(
+                                            text: t,
+                                            contentColor: .alias(.staticWhite)
+                                        ) {
+                                            action()
                                         }
-                                    )
-                                    .background(.thinMaterial)
-                                    .clipShape(RoundedRectangle(cornerRadius: 1000))
+                                        .padding(.horizontal, 5)
+                                        .background(SwiftUI.Color.atomic(.globalCoolNeutral30).opacity(0.61))
+                                        .clipShape(RoundedRectangle(cornerRadius: 1000))
+                                    } else {
+                                        Button.TextButton(
+                                            text: t,
+                                            contentColor: .alias(.labelAlternative)
+                                        ) {
+                                            action()
+                                        }
+                                        .padding(.horizontal, 5)
+                                        .background(
+                                            ZStack {
+                                                SwiftUI.Color.alias(.staticBlack)
+                                                    .opacity(0.05)
+                                                SwiftUI.Color.alias(.staticWhite)
+                                                    .opacity(0.35)
+                                            }
+                                        )
+                                        .background(.thinMaterial)
+                                        .clipShape(RoundedRectangle(cornerRadius: 1000))
+                                    }
+                                } else {
+                                    SwiftUI.Button {
+                                        action()
+                                    } label: {
+                                        Text(t)
+                                            .montage(variant: .headline2, weight: .medium, alias: .labelNormal)
+                                            .paragraph(variant: .headline2)
+                                    }
                                 }
                             }
                         }
@@ -480,7 +539,7 @@ extension Bar.TopNavigation {
     public enum Variant: Equatable {
         case normal
         case extended
-        case floating(alternative: Bool = false)
+        case floating(alternative: Bool = false, background: Bool = true)
     }
     
     /// TopNavigation의 좌/우에 표시될 Resource들의 Namespace입니다.

--- a/Sources/Montage/Element/Bar/TopNavigation/TopNavigation.swift
+++ b/Sources/Montage/Element/Bar/TopNavigation/TopNavigation.swift
@@ -85,13 +85,14 @@ extension Bar {
                     left: left,
                     actions: actions
                 )
-                .padding(.vertical, 10)
-                .padding(.horizontal, 16)
+                .padding(.all, 16)
                 .background(
                     (scrolled && isFloatingVariant == false) ? backgroundColor.opacity(backgroundOpacity) : .clear
                 )
                 .background(
-                    .ultraThinMaterial.opacity(backgroundOpacity)
+                    (scrolled && isFloatingVariant == false) ?
+                    Material.ultraThinMaterial.opacity(backgroundOpacity)
+                    : Material.ultraThinMaterial.opacity(.zero)
                 )
                 .background(
                     screenWidthMeasurer
@@ -179,13 +180,12 @@ extension Bar {
                         .padding(.horizontal, 4)
                     }
                 case let .floating(alternative, background):
-                    ZStack {
-                        HStack(spacing: .zero) {
-                            FloatingLeft(left, alternative, background)
-                            Spacer()
-                            FloatingAction(actions, alternative, background)
-                        }
+                    HStack(spacing: .zero) {
+                        FloatingLeft(left, alternative, background)
+                        Spacer()
+                        FloatingAction(actions, alternative, background)
                     }
+                    .frame(height: 24)
                 }
             }
         }
@@ -237,7 +237,7 @@ extension Bar {
             
             var body: some View {
                 if actions.isEmpty == false {
-                    HStack(alignment: .center, spacing: .zero) {
+                    HStack(alignment: .center, spacing: 16) {
                         ForEach(actions, id: \.self) {
                             switch $0 {
                             case let .icon(i, s, action):
@@ -383,29 +383,24 @@ extension Bar {
                                 switch left {
                                 case .back(let action):
                                     Button.IconButton(
-                                        variant: .background(size: 20, isAlternative: alternative),
+                                        variant: .background(size: 24, isAlternative: alternative),
                                         icon: .chevronLeftThick
                                     ) {
                                         action()
                                     }
-                                    .background(.regularMaterial)
-                                    .clipShape(Circle())
                                 case let .icon(i, action):
                                     Button.IconButton(
-                                        variant: .background(size: 20, isAlternative: alternative),
+                                        variant: .background(size: 24, isAlternative: alternative),
                                         icon: i
                                     ) {
                                         action()
                                     }
-                                    .background(.thickMaterial)
-                                    .clipShape(Circle())
                                 case let .text(t, action):
                                     SwiftUI.Button {
                                         action()
                                     } label: {
                                         Text(t)
                                             .montage(variant: .body2, weight: .medium, alias: .labelAlternative)
-                                            .paragraph(variant: .body2)
                                             .blendMode(.plusDarker)
                                             .padding(.vertical, 5)
                                             .padding(.horizontal, 10)
@@ -436,7 +431,6 @@ extension Bar {
                                 } label: {
                                     Text(t)
                                         .montage(variant: .headline2, weight: .medium, alias: .labelNormal)
-                                        .paragraph(variant: .headline2)
                                 }
                             }
                         }
@@ -459,60 +453,20 @@ extension Bar {
                 self.alternative = alternative
                 self.background = background
             }
-            
+
             var body: some View {
                 if actions.isEmpty == false {
-                    HStack(alignment: .center, spacing: 8) {
+                    HStack(alignment: .center, spacing: 16) {
                         ForEach(actions, id: \.self) {
                             switch $0 {
                             case let .icon(i, s, action):
-                                if background {
-                                    Button.IconButton(
-                                        variant: .background(size: 20, isAlternative: alternative),
-                                        icon: i,
-                                        showPushBadge: s
-                                    ) {
-                                        action()
-                                    }
-                                } else {
-                                    Button.IconButton(
-                                        variant: .default,
-                                        icon: i,
-                                        showPushBadge: s
-                                    ) {
-                                        action()
-                                    }
-                                }
+                                ActionIcon(i, s, alternative, background, action)
                             case let .text(t, action):
                                 if background {
-                                    if alternative {
-                                        Button.TextButton(
-                                            text: t,
-                                            contentColor: .alias(.staticWhite)
-                                        ) {
-                                            action()
-                                        }
-                                        .padding(.horizontal, 5)
-                                        .background(SwiftUI.Color.atomic(.globalCoolNeutral30).opacity(0.61))
-                                        .clipShape(RoundedRectangle(cornerRadius: 1000))
-                                    } else {
-                                        Button.TextButton(
-                                            text: t,
-                                            contentColor: .alias(.labelAlternative)
-                                        ) {
-                                            action()
-                                        }
-                                        .padding(.horizontal, 5)
-                                        .background(
-                                            ZStack {
-                                                SwiftUI.Color.alias(.staticBlack)
-                                                    .opacity(0.05)
-                                                SwiftUI.Color.alias(.staticWhite)
-                                                    .opacity(0.35)
-                                            }
-                                        )
-                                        .background(.thinMaterial)
-                                        .clipShape(RoundedRectangle(cornerRadius: 1000))
+                                    SwiftUI.Button {
+                                        action()
+                                    } label: {
+                                        ActionText(t, alternative)
                                     }
                                 } else {
                                     SwiftUI.Button {
@@ -520,7 +474,6 @@ extension Bar {
                                     } label: {
                                         Text(t)
                                             .montage(variant: .headline2, weight: .medium, alias: .labelNormal)
-                                            .paragraph(variant: .headline2)
                                     }
                                 }
                             }
@@ -528,6 +481,87 @@ extension Bar {
                     }
                 } else {
                     EmptyView()
+                }
+            }
+            
+            private struct ActionIcon: View {
+                let i: Icon
+                let showPushBadge: Bool
+                let alternative: Bool
+                let background: Bool
+                let action: (() -> Void)
+                
+                init(
+                    _ i: Icon,
+                    _ showPushBadge: Bool,
+                    _ alternative: Bool,
+                    _ background: Bool,
+                    _ action: @escaping (() -> Void)
+                ) {
+                    self.i = i
+                    self.showPushBadge = showPushBadge
+                    self.alternative = alternative
+                    self.background = background
+                    self.action = action
+                }
+                
+                private var variant: Button.IconButton.Variant {
+                    background ? .background(size: 24, isAlternative: alternative) : .default
+                }
+                
+                var body: some View {
+                    Button.IconButton(
+                        variant: variant,
+                        icon: i,
+                        showPushBadge: showPushBadge
+                    ) {
+                        action()
+                    }
+                }
+            }
+            
+            private struct ActionText: View {
+                let t: String
+                let alternative: Bool
+                
+                init(_ t: String, _ alternative: Bool) {
+                    self.t = t
+                    self.alternative = alternative
+                }
+
+                var body: some View {
+                    Group {
+                        if alternative {
+                            text()
+                                .background(
+                                    SwiftUI.Color.atomic(.globalCoolNeutral30).opacity(0.61)
+                                )
+                        } else {
+                            text()
+                                .background(
+                                    ZStack {
+                                        SwiftUI.Color.alias(.staticBlack)
+                                            .opacity(0.05)
+                                        SwiftUI.Color.alias(.staticWhite)
+                                            .opacity(0.35)
+                                    }
+                                )
+                                .background(.thinMaterial)
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 1000))
+                }
+                
+                @ViewBuilder
+                private func text() -> some View {
+                    Text(t)
+                        .montage(
+                            variant: .body2,
+                            weight: .medium,
+                            alias: alternative ? .staticWhite : .labelAlternative
+                        )
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
                 }
             }
         }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=2436-38431&node-type=FRAME&m=dev

### 📌 작업 완료 기한
- 2024/09/10

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* TopNavigation Floating variant에 background option을 추가합니다. 
  * 기본값은 true이며, 이 경우에는 기본 background를 가집니다.
  * false인 경우 background를 가지지 않습니다.
* TopNavigation의 디테일 디자인을 수정합니다.
  * 여백 / 아이콘 사이즈 등의 상세 부분을 조정합니다.

### 미리보기
📱|background 작업 전|background 작업 후
---|---|---
iPhone|<img width="416" alt="image" src="https://github.com/user-attachments/assets/365c33c8-4203-407c-b3ee-ab738945b397">|<img width="446" alt="image" src="https://github.com/user-attachments/assets/75de15ae-8a0b-478e-a9a6-9b277f73367d">



### 미리보기
📱|여백 및 아이콘 사이즈 작업 전|여백 및 아이콘 사이즈 작업 후
---|---|---
iPhone|<img width="411" alt="image" src="https://github.com/user-attachments/assets/922a66ea-e715-439a-9f47-a6507056825f">|<img width="445" alt="image" src="https://github.com/user-attachments/assets/48657741-8d84-4a1a-b904-5283c60a3925">





# 확인사항
- [X] 동작 확인 
