### PR TITLE
fix: ContentBadge 디자인 수정사항 반영

### DIFF
--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -508,7 +508,7 @@ public struct TextArea: View {
                 case let .badge(variant, title):
                     Badge.ContentBadgeController(
                         variant: variant,
-                        size: .medium,
+                        size: .large,
                         color: .neutral,
                         text: title
                     )

--- a/Sources/Montage/Element/Badge/Content/ContentBadge.swift
+++ b/Sources/Montage/Element/Badge/Content/ContentBadge.swift
@@ -23,12 +23,12 @@ extension Badge {
         
         /// 뱃지의 사이즈를 결정하는 열거형입니다.
         public enum Size {
-            case xsmall, small, medium
+            case normal, medium, large
         }
         
         /// 뱃지의 색상을 결정하는 열거형입니다.
         public enum ColorStyle: Equatable {
-            case neutral, accent(Color.Accent)
+            case neutral, accent(_ content: Color.Accent, background: Color.Accent? = nil)
         }
         
         /// 뱃지의 외관입니다.
@@ -39,7 +39,7 @@ extension Badge {
         }
         
         /// 뱃지의 사이즈입니다.
-        public var size: Size = .small {
+        public var size: Size = .medium {
             didSet {
                 setupUpdateableConstraints()
                 updateViews()
@@ -141,7 +141,7 @@ extension Badge.Content {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = .spacing(.pt02)
+        stackView.spacing = size.spacing
         stackView.addArrangedSubview(leftIconView)
         stackView.addArrangedSubview(textLabel)
         stackView.addArrangedSubview(rightIconView)
@@ -206,11 +206,11 @@ extension Badge.Content {
     }
     
     private func updateColor() {
-        backgroundColor = variant == .filled ? resolveCurrentEncloseColor() : .alias(.backgroundNormal)
+        backgroundColor = variant == .filled ? enclosureColor : .alias(.backgroundNormal)
         layer.borderWidth = variant == .filled ? 0 : 1
-        layer.borderColor = variant == .filled ? nil : resolveCurrentEncloseColor().cgColor
-        leftIconView.tintColor = .alias(colorStyle.mainColor)
-        rightIconView.tintColor = .alias(colorStyle.mainColor)
+        layer.borderColor = variant == .filled ? nil : enclosureColor.cgColor
+        leftIconView.tintColor = .alias(colorStyle.contentColor)
+        rightIconView.tintColor = .alias(colorStyle.contentColor)
     }
     
     private func updateIconView() {
@@ -234,18 +234,18 @@ extension Badge.Content {
     }
     
     private func getAttributedText() -> NSAttributedString {
-        .montage(text, variant: size.typoVariant, weight: .bold, color: colorStyle.mainColor)
+        .montage(text, variant: size.typoVariant, weight: .bold, color: colorStyle.contentColor)
     }
 }
 
 extension Badge.Content {
-    private func resolveCurrentEncloseColor() -> UIColor {
+    private var enclosureColor: UIColor {
         switch colorStyle {
         case .neutral:
             return variant == .filled ? .component(.fillNormal) : .alias(.lineNormal)
-        case .accent(let colorStyle):
+        case let .accent(contentColor, enclosureColor):
             let opacity: CGFloat = variant == .filled ? .opacity(.p008) : .opacity(.p043)
-            return colorStyle.resolveAsUIColor().withAlphaComponent(opacity)
+            return (enclosureColor ?? contentColor).resolveAsUIColor().withAlphaComponent(opacity)
         }
     }
 }
@@ -253,56 +253,67 @@ extension Badge.Content {
 extension Badge.Content.Size {
     var iconSize: CGSize {
         switch self {
-        case .xsmall:
+        case .normal:
             return .init(width: 12, height: 12)
-        case .small:
-            return .init(width: 16, height: 16)
         case .medium:
+            return .init(width: 16, height: 16)
+        case .large:
             return .init(width: 20, height: 20)
         }
     }
     
     var typoVariant: Typography.Variant {
         switch self {
-        case .xsmall:
+        case .normal:
             return .caption2
-        case .small:
-            return .caption1
         case .medium:
+            return .caption1
+        case .large:
             return .label1
         }
     }
     
     var edgeInsets: UIEdgeInsets {
         switch self {
-        case .xsmall:
-            return .init(top: 3, left: 4, bottom: 3, right: 4)
-        case .small:
-            return .init(top: 4, left: 8, bottom: 4, right: 8)
+        case .normal:
+            return .init(top: 3, left: 6, bottom: 3, right: 6)
         case .medium:
-            return .init(top: 6, left: 12, bottom: 6, right: 12)
+            return .init(top: 4, left: 6, bottom: 4, right: 6)
+        case .large:
+            return .init(top: 7, left: 8, bottom: 7, right: 8)
         }
     }
 
     var cornerRadius: CGFloat {
         switch self {
-        case .xsmall:
-            return 4.0
-        case .small:
+        case .normal:
             return 6.0
         case .medium:
+            return 6.0
+        case .large:
             return 8.0
+        }
+    }
+    
+    var spacing: CGFloat {
+        switch self {
+        case .normal:
+            2
+        case .medium:
+            3
+        case .large:
+            4
         }
     }
 }
 
 extension Badge.Content.ColorStyle {
-    var mainColor: Color.Alias {
+    var contentColor: Color.Alias {
         switch self {
         case .neutral:
             return .labelAlternative
-        case .accent(let color):
-            return color.resolveAsAlias()
+        case let .accent(contentColor, _):
+            return contentColor.resolveAsAlias()
         }
     }
 }

--- a/Sources/Montage/Element/Badge/Content/ContentBadge.swift
+++ b/Sources/Montage/Element/Badge/Content/ContentBadge.swift
@@ -256,9 +256,9 @@ extension Badge.Content.Size {
         case .normal:
             return .init(width: 12, height: 12)
         case .medium:
-            return .init(width: 16, height: 16)
+            return .init(width: 14, height: 14)
         case .large:
-            return .init(width: 20, height: 20)
+            return .init(width: 16, height: 16)
         }
     }
     
@@ -269,7 +269,7 @@ extension Badge.Content.Size {
         case .medium:
             return .caption1
         case .large:
-            return .label1
+            return .label2
         }
     }
     
@@ -280,7 +280,7 @@ extension Badge.Content.Size {
         case .medium:
             return .init(top: 4, left: 6, bottom: 4, right: 6)
         case .large:
-            return .init(top: 7, left: 8, bottom: 7, right: 8)
+            return .init(top: 5, left: 8, bottom: 5, right: 8)
         }
     }
 

--- a/Sources/Montage/Element/Badge/Content/ContentBadgeController.swift
+++ b/Sources/Montage/Element/Badge/Content/ContentBadgeController.swift
@@ -32,7 +32,7 @@ extension Badge {
         
         public init(
             variant: Badge.Content.Variant = .filled,
-            size: Badge.Content.Size = .small,
+            size: Badge.Content.Size = .medium,
             color: Badge.Content.ColorStyle = .neutral,
             leftIcon: Icon? = nil,
             rightIcon: Icon? = nil,
@@ -82,19 +82,19 @@ fileprivate struct Preview: View {
 
             HStack {
                 Badge.ContentBadgeController(
-                    variant: .filled, size: .xsmall, text: text
+                    variant: .filled, size: .normal, text: text
                 ).fixedSize()
 
                 Badge.ContentBadgeController(
-                    variant: .outlined, size: .xsmall, text: text
+                    variant: .outlined, size: .normal, text: text
                 ).fixedSize()
 
                 Badge.ContentBadgeController(
-                    variant: .filled, size: .small, text: text
+                    variant: .filled, size: .medium, text: text
                 ).fixedSize()
 
                 Badge.ContentBadgeController(
-                    variant: .outlined, size: .small, text: text
+                    variant: .outlined, size: .medium, text: text
                 ).fixedSize()
             }
     


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : 

### 📌 작업 완료 기한
- 2024/09/13

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* 디자인이 변경되었습니다.
  * radius가 4 -> 6px로 변경되었습니다.
  * padding이 변경되었습니다.
* size variant 명칭이 변경되었습니다.
  * normal, medium, large
* accent color에 background color 지정할 수 있도록 수정

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 13 47 18](https://github.com/user-attachments/assets/ee65eb8e-6cf3-4cf7-8158-c2c6a1b0d2f6)|![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 13 36 54](https://github.com/user-attachments/assets/e6b28ee6-6474-4966-821f-9df879252102)


# 확인사항
- [x] 동작 확인 
