### PR TITLE
fix: ContentBadge - 아이콘 있을 때 Spacing이 width로 잡히지 않는 현상 수정

### DIFF
--- a/Sources/Montage/Element/Badge/Content/ContentBadge.swift
+++ b/Sources/Montage/Element/Badge/Content/ContentBadge.swift
@@ -121,7 +121,7 @@ extension Badge {
             let iconCount = [leftIcon, rightIcon].filter({ $0 != nil }).count
             
             return .init(
-                width: iconSize.width * CGFloat(iconCount) + textSize.width + edgeInsets.horizontal,
+                width: iconSize.width * CGFloat(iconCount) + size.spacing * CGFloat(iconCount) + textSize.width + edgeInsets.horizontal,
                 height: max(iconSize.height, textSize.height) + edgeInsets.vertical
             )
         }


### PR DESCRIPTION
### 📌 작업 완료 기한
- 2024/10/16

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->

아이콘이 있는 ContentBadge를 이력서 리스트에서만 사용하고 있는데 
언제부턴가 아이콘이 Text 영역과 겹쳐보이고 있어서 확인해보던중 
ContentBadge의 width 계산하는 로직에서 Spacing이 빠져있는 것을 확인하여 수정하였습니다.

### 미리보기
작업 전|작업 후
---|---
![Simulator Screenshot - iPhone 16 Pro - 2024-10-14 at 16 08 44](https://github.com/user-attachments/assets/7a1014f8-5e1a-4a6b-9334-a15defd5bf65)|![Simulator Screenshot - iPhone 16 - 2024-10-15 at 09 47 45](https://github.com/user-attachments/assets/869f41be-9489-445e-885a-bb679aecf193)
