### PR TITLE
EmptyState 추가

### DIFF
--- a/Sources/Montage/Components/EmptyState/EmptyState.swift
+++ b/Sources/Montage/Components/EmptyState/EmptyState.swift
@@ -1,0 +1,87 @@
+//
+//  EmptyState.swift
+//  Montage
+//
+//  Created by Sanghoon Ahn on 10/21/24.
+//
+
+import SwiftUI
+
+/// 콘텐츠가 빈 상태일 때 사용자의 이해를 돕기 위한 컴포넌트입니다.
+///
+/// > image, title과 button은 선택적으로 사용할 수 있습니다.
+///
+/// 컴포넌트가 기본적으로 화면 전체를 차지하므로 필요하다면
+/// .frame modifier를 사용하여 크기를 조절하여 사용하시길 권장합니다.
+public struct EmptyState<V: View, C: View>: View {
+    private let image: (() -> V?)
+    private let title: String?
+    private let description: String
+    private let button: (() -> C)
+    
+    public init(
+        image: @escaping (() -> V?) = { nil as AnyView? },
+        title: String? = nil,
+        description: String,
+        button: @escaping (() -> C) = { EmptyView() }
+    ) {
+        self.image = image
+        self.title = title
+        self.description = description
+        self.button = button
+    }
+    
+    public var body: some View {
+        VStack(alignment: .center, spacing: .zero) {
+            Spacer()
+            
+            if let image = image() {
+                image
+                    .padding(.bottom, 8)
+            }
+            
+            VStack(spacing: 12) {
+                if let title {
+                    HStack {
+                        Spacer()
+                        Text(title)
+                            .montage(variant: .headline1, weight: .bold)
+                            .multilineTextAlignment(.center)
+                        Spacer()
+                    }
+                }
+                
+                HStack {
+                    Spacer()
+                    Text(description)
+                        .montage(variant: .body2, alias: .labelAlternative)
+                        .paragraph(variant: .body2)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                    Spacer()
+                }
+                
+                button()
+                    .padding(.top, 12)
+            }
+            .padding(.vertical, 12)
+            
+            if image() != nil {
+                Spacer()
+                    .frame(height: 20)
+            }
+            
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    EmptyState(
+        title: "타이틀이 들어갈수도 있고, 안들어dasfasdasfasda갈 수 도 있어요.",
+        description: "상황에 대한 설명이 들어fdsasdasfasdasfasdasf asdasfasdafasd가요.\n설명은 최대 두 줄로 작성해요."
+    ) {
+        Button.OutlinedButtonController(text: "텍스트")
+            .fixedSize()
+    }
+}


### PR DESCRIPTION
# 개요
- JIRA 링크 : https://wantedlab.atlassian.net/browse/PI-68562
- 🎨  디자인 링크 : https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=22838-255809&node-type=section&m=dev

### 📌 작업 완료 기한
- 2024/10/31

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* 빈 화면이나, 빈 컨텐츠를 나타내는 컴포넌트인 EmptyState 를 추가했습니다.
* 아래와 같이 사용 가능합니다.
```swift
EmptyState(
    image: {
        /* 이미지를 표현하는 View */
        Image(.placeholder)
            .resizable()
            .frame(width: 128, height: 128)
            .clipShape(Circle())
    },
    title: /* 제목으로 사용할 String, 사용하지 않는다면 전달하지 않아도 무관합니다.*/,
    description: /* 부연설명으로 사용할 String, 필수값 입니다.*/
) {
    /* Button으로 사용될 나타낼 View */
    Button.OutlinedButtonController(text: "버튼") {
        toastModel = .init(message: "버튼 클릭")
    }
    .fixedSize()
}
```

* Image와 Button은 표현할 View 자체를 closure로 작성해주시면 됩니다.
  * Image나 Button을 사용하지 않는 경우에는 전달하지 않으면 됩니다.
* Title은 노출될 문자열을 전달해주시면 됩니다.
  * 전달하지 않을 경우 노출되지 않습니다.
* EmptyState는 기본적으로 화면에서 늘어날 수 있을 만큼 늘어납니다(가로, 세로 모두 Spacer가 포함되어있음)
  * 따라서 크기를 조절해서 사용하는 경우에는 .frame modifier를 통해 크기를 조절하여 사용하시기 바랍니다.

### 미리보기
📱|미리보기1|미리보기2|미리보기3|미리보기4
---|---|---|---|---
iPhone|![image](https://github.com/user-attachments/assets/d778e7fe-54aa-4f1e-994f-2dad54f196e5)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-21 at 15 59 09](https://github.com/user-attachments/assets/a93330f7-9a03-48e1-8ad7-0ec2079bb39e)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-21 at 15 59 01](https://github.com/user-attachments/assets/4f8e9639-2555-49ed-9708-207001f4b3a6)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-21 at 15 59 04](https://github.com/user-attachments/assets/6f24f355-24e0-4ae5-ab25-29cec52579fb)

# 확인사항
- [x] 동작 확인 
