### PR TITLE
[PI-68876] Chip Component의 내부 여백 변경 (~10/30)

### DIFF
--- a/Sources/Montage/Element/Chip/Action/ActionChip.swift
+++ b/Sources/Montage/Element/Chip/Action/ActionChip.swift
@@ -117,6 +117,8 @@ extension Chip {
         
         private lazy var textLabel = UILabel()
         
+        private let textLabelWrapperView = UIView()
+        
         private lazy var rightIconView = UIImageView()
         
         private lazy var interaction = Decorate.Interaction()
@@ -126,6 +128,8 @@ extension Chip {
         private var iconViewContraints: [NSLayoutConstraint] = []
         
         private var stackViewConstraints: [NSLayoutConstraint] = []
+        
+        private var textLabelWrapperViewConstraints: [NSLayoutConstraint] = []
         
         public init() {
             super.init(frame: .zero)
@@ -157,13 +161,14 @@ extension Chip {
         override public var intrinsicContentSize: CGSize {
             let textSize = getAttributedText().size()
             let iconSize = size.iconSize
-            let edgeInsets = size.edgeInsets
+            let edgeInsets = size.contentsEdgeInsets
             let iconCount = [leftIcon, rightIcon].filter({ $0 != nil }).count
             let iconWidths = iconSize.width * CGFloat(iconCount)
-            let spacings = size.gap * CGFloat(iconCount)
+            let spacings = size.contentsGap * CGFloat(iconCount)
+            let textLabelPaddings = size.textLabelPadding * 2
             
             return .init(
-                width: iconWidths + spacings + textSize.width + edgeInsets.horizontal,
+                width: iconWidths + spacings + textSize.width + edgeInsets.horizontal + textLabelPaddings,
                 height: max(iconSize.height, textSize.height) + edgeInsets.vertical
             )
         }
@@ -195,10 +200,12 @@ extension Chip.Action {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = size.gap
+        stackView.spacing = size.contentsGap
         stackView.addArrangedSubview(leftIconView)
-        stackView.addArrangedSubview(textLabel)
+        stackView.addArrangedSubview(textLabelWrapperView)
         stackView.addArrangedSubview(rightIconView)
+        
+        textLabelWrapperView.addSubview(textLabel)
     }
     
     private func setupInteraction() {
@@ -210,7 +217,8 @@ extension Chip.Action {
     private func setupUpdateableConstraints() {
         setupIconViewConstraints()
         setupStackViewConstraints()
-        stackView.spacing = size.gap
+        setupTextLabelConstraints()
+        stackView.spacing = size.contentsGap
         updateConstraints()
         setupLayer()
     }
@@ -246,7 +254,7 @@ extension Chip.Action {
         
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
-        let insets = size.edgeInsets
+        let insets = size.contentsEdgeInsets
         
         let constraints = [
             stackView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor, constant: insets.left),
@@ -259,6 +267,24 @@ extension Chip.Action {
         constraints.forEach({ $0.priority = .defaultLow })
         NSLayoutConstraint.activate(constraints)
         stackViewConstraints = constraints
+    }
+    
+    private func setupTextLabelConstraints() {
+        NSLayoutConstraint.deactivate(textLabelWrapperViewConstraints)
+        
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let padding = size.textLabelPadding
+        
+        let constraints = [
+            textLabel.leftAnchor.constraint(equalTo: textLabelWrapperView.leftAnchor, constant: padding),
+            textLabel.rightAnchor.constraint(equalTo: textLabelWrapperView.rightAnchor, constant: -padding),
+            textLabel.topAnchor.constraint(equalTo: textLabelWrapperView.topAnchor),
+            textLabel.bottomAnchor.constraint(equalTo: textLabelWrapperView.bottomAnchor)
+        ]
+        
+        NSLayoutConstraint.activate(constraints)
+        textLabelWrapperViewConstraints = constraints
     }
     
     private func setupLayer() {
@@ -485,29 +511,38 @@ extension Chip.Action.Size {
         }
     }
     
-    var edgeInsets: UIEdgeInsets {
+    var contentsEdgeInsets: UIEdgeInsets {
         switch self {
         case .large:
             return .init(top: 9, left: 12, bottom: 9, right: 12)
         case .normal:
-            return .init(top: 7, left: 12, bottom: 7, right: 12)
+            return .init(top: 7, left: 11, bottom: 7, right: 11)
         case .small:
-            return .init(top: 6, left: 10, bottom: 6, right: 10)
+            return .init(top: 6, left: 8, bottom: 6, right: 8)
         case .xsmall:
-            return .init(top: 4, left: 6, bottom: 4, right: 6)
+            return .init(top: 4, left: 7, bottom: 4, right: 7)
         }
     }
     
-    var gap: CGFloat {
+    var contentsGap: CGFloat {
         switch self {
         case .large:
-            return 6
+            return 3
         case .normal:
-            return 4
+            return 3
         case .small:
-            return 4
+            return 2
         case .xsmall:
-            return 4
+            return 2
+        }
+    }
+    
+    var textLabelPadding: CGFloat {
+        switch self {
+        case .large: 2.0
+        case .normal: 2.0
+        case .small: 2.0
+        case .xsmall: 1.0
         }
     }
     

--- a/Sources/Montage/Element/Chip/Filter/FilterChip.swift
+++ b/Sources/Montage/Element/Chip/Filter/FilterChip.swift
@@ -102,6 +102,8 @@ extension Chip {
 
         public var handler: (() -> Void)?
         
+        private let contentsWrapperView = UIView()
+        
         private lazy var stackView = UIStackView()
         
         private lazy var textLabel = UILabel()
@@ -113,6 +115,8 @@ extension Chip {
         private var longPressRecognizer: UILongPressGestureRecognizer?
         
         private var iconViewContraints: [NSLayoutConstraint] = []
+        
+        private var contentsWrapperViewConstraints: [NSLayoutConstraint] = []
         
         private var stackViewConstraints: [NSLayoutConstraint] = []
         
@@ -146,11 +150,12 @@ extension Chip {
         override public var intrinsicContentSize: CGSize {
             let textSize = getAttributedText().size()
             let iconSize = size.iconSize
-            let edgeInsets = size.edgeInsets
-            let spacings = size.gap
+            let edgeInsets = size.contentsEdgeInsets
+            let spacings = size.contentsGap
+            let paddings = size.contentsPadding * 2
             
             return .init(
-                width: iconSize.width + spacings + textSize.width + edgeInsets.horizontal,
+                width: iconSize.width + spacings + textSize.width + edgeInsets.horizontal + paddings,
                 height: max(iconSize.height, textSize.height) + edgeInsets.vertical
             )
         }
@@ -159,8 +164,9 @@ extension Chip {
 
 extension Chip.Filter {
     private func setupViews() {
-        addSubview(stackView)
+        addSubview(contentsWrapperView)
         addSubview(interaction)
+        contentsWrapperView.addSubview(stackView)
         
         setupStackView()
         setupInteraction()
@@ -180,7 +186,7 @@ extension Chip.Filter {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = size.gap
+        stackView.spacing = size.contentsGap
         stackView.addArrangedSubview(textLabel)
         stackView.addArrangedSubview(arrowIconView)
     }
@@ -192,9 +198,10 @@ extension Chip.Filter {
     }
     
     private func setupUpdateableConstraints() {
-        setupIconViewConstraints()
+        setupContentsWrapperViewConstraints()
         setupStackViewConstraints()
-        stackView.spacing = size.gap
+        setupIconViewConstraints()
+        stackView.spacing = size.contentsGap
         updateConstraints()
         setupLayer()
     }
@@ -222,22 +229,39 @@ extension Chip.Filter {
         iconViewContraints = constraints
     }
     
+    private func setupContentsWrapperViewConstraints() {
+        NSLayoutConstraint.deactivate(contentsWrapperViewConstraints)
+        
+        contentsWrapperView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let insets = size.contentsEdgeInsets
+        
+        let constraints = [
+            contentsWrapperView.leftAnchor.constraint(equalTo: leftAnchor, constant: insets.left),
+            contentsWrapperView.rightAnchor.constraint(equalTo: rightAnchor, constant: -insets.right),
+            contentsWrapperView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
+            contentsWrapperView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -insets.bottom)
+        ]
+        
+        constraints.forEach({ $0.priority = .defaultLow })
+        NSLayoutConstraint.activate(constraints)
+        contentsWrapperViewConstraints = constraints
+    }
+    
     private func setupStackViewConstraints() {
         NSLayoutConstraint.deactivate(stackViewConstraints)
         
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
-        let insets = size.edgeInsets
+        let contentsPadding = size.contentsPadding
         
         let constraints = [
-            stackView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor, constant: insets.left),
-            stackView.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -insets.right),
-            stackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: insets.top),
-            stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -insets.bottom),
-            stackView.centerXAnchor.constraint(equalTo: centerXAnchor)
+            stackView.leftAnchor.constraint(equalTo: contentsWrapperView.leftAnchor, constant: contentsPadding),
+            stackView.rightAnchor.constraint(equalTo: contentsWrapperView.rightAnchor, constant: -contentsPadding),
+            stackView.topAnchor.constraint(equalTo: contentsWrapperView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: contentsWrapperView.bottomAnchor)
         ]
         
-        constraints.forEach({ $0.priority = .defaultLow })
         NSLayoutConstraint.activate(constraints)
         stackViewConstraints = constraints
     }
@@ -465,29 +489,38 @@ extension Chip.Filter.Size {
         }
     }
     
-    var edgeInsets: UIEdgeInsets {
+    var contentsEdgeInsets: UIEdgeInsets {
         switch self {
         case .large:
-            return .init(top: 9, left: 12, bottom: 9, right: 8)
+            return .init(top: 9, left: 12, bottom: 9, right: 10)
         case .normal:
-            return .init(top: 7, left: 12, bottom: 7, right: 8)
+            return .init(top: 7, left: 11, bottom: 7, right: 9)
         case .small:
-            return .init(top: 6, left: 10, bottom: 6, right: 8)
+            return .init(top: 6, left: 8, bottom: 6, right: 6)
         case .xsmall:
-            return .init(top: 4, left: 8, bottom: 4, right: 6)
+            return .init(top: 4, left: 7, bottom: 4, right: 5)
         }
     }
     
-    var gap: CGFloat {
+    var contentsGap: CGFloat {
         switch self {
         case .large:
-            return 5.0
-        case .normal:
-            return 5.0
-        case .small:
-            return 4.0
-        case .xsmall:
             return 2.0
+        case .normal:
+            return 2.0
+        case .small:
+            return 1.0
+        case .xsmall:
+            return 1.0
+        }
+    }
+    
+    var contentsPadding: CGFloat {
+        switch self {
+        case .normal: 2.0
+        case .small: 2.0
+        case .large: 2.0
+        case .xsmall: 1.0
         }
     }
     


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=3369-19244&node-type=section&m=dev

### 📌 작업 완료 기한
- 2024/10/30

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* Chip Action/Filter 컴포넌트의 내부 여백을 조정합니다.
  * 내부 뷰 구조에 Wrapper View를 추가하거나, StackView를 감싸는 Wrapper View를 추가하고 세부 여백을 재조정하였습니다.
* Chip/Filter의 경우, 내부 텍스트 <-> 숫자 간의 여백이 생겼지만, iOS 기존 구조를 변경해야 하여 내부 여백은 Space 문자열로 대체하는것으로 결정되었습니다. ([참고](https://wantedx.slack.com/archives/C068KCRS2LD/p1729241011235399?thread_ts=1729234870.604269&cid=C068KCRS2LD))


### 미리보기
📱|Filter 작업 전|Filter 작업 후
---|---|---
iPhone|![image](https://github.com/user-attachments/assets/3b1a01bb-e1cb-4d43-90c7-210ea278bb0f)|![image](https://github.com/user-attachments/assets/02dde9bf-b0b6-4d79-a625-045b277fdd55)


📱|Action 작업 전|Action 작업 후
---|---|---
iPhone|![image](https://github.com/user-attachments/assets/81872a9b-5103-4298-9ffe-5b846e287a02)|![image](https://github.com/user-attachments/assets/07941a12-0165-46f9-9ddb-ddf3954ec3ed)


# 확인사항
- [ ] 동작 확인 
