### PR TITLE
[Modal/Bottom] 내부 사이즈에 따른 사이즈 변화 로직 변경 (~11/6)

### DIFF
--- a/Sources/Montage/Components/Modal/Bottom/ModalBottom.swift
+++ b/Sources/Montage/Components/Modal/Bottom/ModalBottom.swift
@@ -49,16 +49,6 @@ extension Modal {
         private let content: (() -> any View)
         private let actionArea: (() -> Montage.ActionArea.Bottom.Component)?
         
-        /// Modal의 내부에 표시될 내용의 대한 SizeMeasurer입니다.
-        private var contentSizeMeasurer: some View {
-            GeometryReader(content: { proxy in
-                SwiftUI.Color.clear
-                    .onAppear {
-                        contentSize = proxy.size
-                    }
-            })
-        }
-        
         /// Modal/Bottom의 dentents입니다
         ///
         /// ContentView에 ScrollView가 있는 경우, [.fractoin(0.35), .medium, .max]로 제한됩니다.
@@ -117,7 +107,7 @@ extension Modal {
                         AnyView(actionArea())
                     }
                 }
-                .background(contentSizeMeasurer)
+                .readSize { contentSize = $0 }
                 .presentationDetents(detents)
                 .presentationDragIndicator(handle ? .visible : .hidden)
                 .presentationContentInteraction(containScrollView ? .resizes : .automatic)
@@ -136,7 +126,7 @@ extension Modal {
                         AnyView(actionArea())
                     }
                 }
-                .background(contentSizeMeasurer)
+                .readSize { contentSize = $0 }
                 .padding(.bottom, -safeAreaInsets.bottom)
             }
         }


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://github.com/wanteddev/ios/pull/6386#issuecomment-2453818558

### 📌 작업 완료 기한
- 2024/11/06

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* 유저앱 사용 중 iOS 17.4 디바이스에서 발견된 내부 컨텐츠가 제대로된 height을 가지고 표현되지 않는 이슈가 있었습니다.
* iOS 17.5 시뮬레이터 및 iOS 16.4 물리 디바이스에서도 현상이 재현되는것을 확인하여 수정을 진행합니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![image](https://github.com/user-attachments/assets/fb4c8135-dbdc-438e-8f1b-94409f7b0f49)|![IMG_CAF4A7346834-1](https://github.com/user-attachments/assets/7b7ae72e-e92d-48b9-89da-ee4f5164e272)

# 확인사항
- [x] 동작 확인 
