### PR TITLE
[PI-69807] Modal/Bottom 수정 (~11/21)

### DIFF
--- a/Sources/Montage/Components/Modal/Bottom/ModalBottom.swift
+++ b/Sources/Montage/Components/Modal/Bottom/ModalBottom.swift
@@ -28,7 +28,7 @@ extension Modal {
     /// ```
     ///
     /// - Parameters:
-    ///     - handle: Content 표시 영역을 변경시킬 수 있는 handle의 여부 입니다. 기본값은 false입니다.
+    ///     - handle: Content 표시 영역을 변경시킬 수 있는 handle의 여부 입니다. 기본값은 true입니다.
     ///     - resize: Content가 표시될 영역의 사이즈 입니다. 기본값은 .hug입니다.
     ///     - containScrollView: Content에 ScrollView 가 삽입된 경우 전달합니다. 기본값은 false입니다.
     public struct Bottom: View {
@@ -41,7 +41,7 @@ extension Modal {
         @Environment(\.safeAreaInsets) private var safeAreaInsets
         @State private var contentSize: CGSize = .zero
 
-        private var handle: Bool = false
+        private var handle: Bool = true
         private var resize: Modal.Bottom.Resize = .hug
         private var containScrollView: Bool = false
         
@@ -60,7 +60,7 @@ extension Modal {
             if containScrollView {
                  [ .fraction(0.35), .medium, .max ]
             } else if handle {
-                [ .height(contentSize.height), .max ]
+                [ .height(contentSize.height) ]
             } else {
                 resize == .fill ? [ .max ] : [ .height(contentSize.height) ]
             }
@@ -111,6 +111,7 @@ extension Modal {
                 .presentationDetents(detents)
                 .presentationDragIndicator(handle ? .visible : .hidden)
                 .presentationContentInteraction(containScrollView ? .resizes : .automatic)
+                .presentationCornerRadius(12)
                 .padding(.bottom, -safeAreaInsets.bottom)
             } else {
                 VStack(spacing: .zero) {


### PR DESCRIPTION


# 개요


### 📌 작업 완료 기한
- 2024/11/21

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
- handle을 기본값으로 가지고 있도록 변경
- handle이 있어도 최대로는 가지고 있는 컨텐츠의 크기만큼만 모달 크기를 지정
- Modal/Botton의 radius를 기본값에서 12로 변경


### 미리보기

미리보기에는 handle을 숨김처리 해두었습니다.

📱|radius 작업 전|radius 작업 후
---|---|---
iPhone|![image](https://github.com/user-attachments/assets/929e8296-09e1-4aec-8163-fe064ad144d9)|![image](https://github.com/user-attachments/assets/a8fbf43d-30bf-4801-8f2a-6b62284052d3)


# 확인사항
- [ ] 동작 확인 
