### PR TITLE
fix: proposedSize를 채울 수 있는 fill API 제공

### DIFF
--- a/Sources/Montage/Components/ActionArea/Bottom/ActionAreaBottom.swift
+++ b/Sources/Montage/Components/ActionArea/Bottom/ActionAreaBottom.swift
@@ -217,7 +217,7 @@ extension ActionArea {
                                 text: main.text,
                                 handler: main.action
                             )
-                            .fill(width: true, height: false)
+                            .fill(horizontal: true, vertical: false)
                         }
                         if let alternative {
                             if let customButton = alternative.custom {
@@ -229,7 +229,7 @@ extension ActionArea {
                                     text: alternative.text,
                                     handler: alternative.action
                                 )
-                                .fill(width: true, height: false)
+                                .fill(horizontal: true, vertical: false)
                             }
                         }
                         if let sub {
@@ -276,7 +276,7 @@ extension ActionArea {
                                     text: alternative.text,
                                     handler: alternative.action
                                 )
-                                .fill(width: true, height: false)
+                                .fill(horizontal: true, vertical: false)
                             }
                         }
                         if let customButton = main.custom {
@@ -288,7 +288,7 @@ extension ActionArea {
                                 text: main.text,
                                 handler: main.action
                             )
-                            .fill(width: true, height: false)
+                            .fill(horizontal: true, vertical: false)
                         }
                     }
                 }
@@ -338,7 +338,7 @@ extension ActionArea {
                             text: main.text,
                             handler: main.action
                         )
-                        .fill(width: true, height: false)
+                        .fill(horizontal: true, vertical: false)
                     }
                 }
             }

--- a/Sources/Montage/Components/ActionArea/Bottom/ActionAreaBottom.swift
+++ b/Sources/Montage/Components/ActionArea/Bottom/ActionAreaBottom.swift
@@ -210,7 +210,6 @@ extension ActionArea {
                     VStack(spacing: 8) {
                         if let customButton = main.custom {
                             AnyView(customButton())
-                                .fixedSize(horizontal: false, vertical: true)
                         } else {
                             Button.SolidButtonController(
                                 variant: .primary,
@@ -218,12 +217,11 @@ extension ActionArea {
                                 text: main.text,
                                 handler: main.action
                             )
-                            .fixedSize(horizontal: false, vertical: true)
+                            .fill(width: true, height: false)
                         }
                         if let alternative {
                             if let customButton = alternative.custom {
                                 AnyView(customButton())
-                                    .fixedSize(horizontal: false, vertical: true)
                             } else {
                                 Button.OutlinedButtonController(
                                     variant: .secondary,
@@ -231,13 +229,12 @@ extension ActionArea {
                                     text: alternative.text,
                                     handler: alternative.action
                                 )
-                                .fixedSize(horizontal: false, vertical: true)
+                                .fill(width: true, height: false)
                             }
                         }
                         if let sub {
                             if let customButton = sub.custom {
                                 AnyView(customButton())
-                                    .fixedSize(horizontal: false, vertical: true)
                             } else {
                                 Button.TextButton(
                                     variant: .assistive,
@@ -245,7 +242,6 @@ extension ActionArea {
                                     text: sub.text,
                                     handler: sub.action
                                 )
-                                .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                     }
@@ -273,7 +269,6 @@ extension ActionArea {
                         if let alternative {
                             if let customButton = alternative.custom {
                                 AnyView(customButton())
-                                    .fixedSize(horizontal: false, vertical: true)
                             } else {
                                 Button.OutlinedButtonController(
                                     variant: .secondary,
@@ -281,12 +276,11 @@ extension ActionArea {
                                     text: alternative.text,
                                     handler: alternative.action
                                 )
-                                .fixedSize(horizontal: false, vertical: true)
+                                .fill(width: true, height: false)
                             }
                         }
                         if let customButton = main.custom {
                             AnyView(customButton())
-                                .fixedSize(horizontal: false, vertical: true)
                         } else {
                             Button.SolidButtonController(
                                 variant: .primary,
@@ -294,7 +288,7 @@ extension ActionArea {
                                 text: main.text,
                                 handler: main.action
                             )
-                            .fixedSize(horizontal: false, vertical: true)
+                            .fill(width: true, height: false)
                         }
                     }
                 }
@@ -337,7 +331,6 @@ extension ActionArea {
                 ) -> some View {
                     if let customButton = main.custom {
                         AnyView(customButton())
-                            .fixedSize(horizontal: false, vertical: true)
                     } else {
                         Button.OutlinedButtonController(
                             variant: .assistive,
@@ -345,7 +338,7 @@ extension ActionArea {
                             text: main.text,
                             handler: main.action
                         )
-                        .fixedSize(horizontal: false, vertical: true)
+                        .fill(width: true, height: false)
                     }
                 }
             }
@@ -433,7 +426,7 @@ extension ActionArea.Bottom {
     }
 }
 
-#Preview {
+#Preview("strong") {
     ActionArea.Bottom(
         model: .init(
             variant: .normal,
@@ -441,6 +434,57 @@ extension ActionArea.Bottom {
                 main: .init(text: "메인", action: {}),
                 sub: .init(text: "서브", action: {}),
                 alternative: .init(text: "대안", action: {})
+            ),
+            sticky: true
+        )
+    ) {
+        ScrollView {
+            SwiftUI.Color.red.frame(height: 1400)
+        }
+    }
+}
+
+#Preview("neutral") {
+    ActionArea.Bottom(
+        model: .init(
+            variant: .normal,
+            priority: .neutral(
+                main: .init(text: "메인", action: {}),
+                sub: .init(text: "서브", action: {}),
+                alternative: .init(text: "대안", action: {})
+            ),
+            sticky: true
+        )
+    ) {
+        ScrollView {
+            SwiftUI.Color.red.frame(height: 1400)
+        }
+    }
+}
+
+#Preview("compact") {
+    ActionArea.Bottom(
+        model: .init(
+            variant: .normal,
+            priority: .compact(
+                main: .init(text: "메인", action: {}),
+                sub: .init(text: "서브", action: {})
+            ),
+            sticky: true
+        )
+    ) {
+        ScrollView {
+            SwiftUI.Color.red.frame(height: 1400)
+        }
+    }
+}
+
+#Preview("cancel") {
+    ActionArea.Bottom(
+        model: .init(
+            variant: .normal,
+            priority: .cancel(
+                main: .init(text: "메인", action: {})
             ),
             sticky: true
         )

--- a/Sources/Montage/Components/Input/InputLabelController.swift
+++ b/Sources/Montage/Components/Input/InputLabelController.swift
@@ -34,10 +34,6 @@ public struct InputLabelController: UIViewRepresentable {
         uiView.text = text
     }
     
-    public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-        uiView.intrinsicContentSize
-    }
-    
     public func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
     }
@@ -52,6 +48,22 @@ public struct InputLabelController: UIViewRepresentable {
         public func inputDidSelected(_ input: InputLabel) {
             parent.onSelect()
         }
+    }
+    
+    public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
+        CGSize(
+            width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+            height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+        )
+    }
+    
+    private var fillWidth: Bool = false
+    private var fillHeight: Bool = false
+    public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        var zelf = self
+        zelf.fillWidth = fillWidth
+        zelf.fillHeight = fillHeight
+        return zelf
     }
 }
 

--- a/Sources/Montage/Components/Input/InputLabelController.swift
+++ b/Sources/Montage/Components/Input/InputLabelController.swift
@@ -52,17 +52,17 @@ public struct InputLabelController: UIViewRepresentable {
     
     public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
         CGSize(
-            width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-            height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+            height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
         )
     }
     
-    private var fillWidth: Bool = false
-    private var fillHeight: Bool = false
-    public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+    private var fillHorizontal: Bool = false
+    private var fillVertical: Bool = false
+    public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
         var zelf = self
-        zelf.fillWidth = fillWidth
-        zelf.fillHeight = fillHeight
+        zelf.fillHorizontal = fillHorizontal
+        zelf.fillVertical = fillVertical
         return zelf
     }
 }

--- a/Sources/Montage/Element/Badge/Content/ContentBadgeController.swift
+++ b/Sources/Montage/Element/Badge/Content/ContentBadgeController.swift
@@ -61,17 +61,17 @@ extension Badge {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
     }

--- a/Sources/Montage/Element/Badge/Content/ContentBadgeController.swift
+++ b/Sources/Montage/Element/Badge/Content/ContentBadgeController.swift
@@ -60,7 +60,19 @@ extension Badge {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
         }
     }
 }

--- a/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
@@ -29,17 +29,17 @@ extension Badge {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
     }

--- a/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
+++ b/Sources/Montage/Element/Badge/Push/PushBadgeController.swift
@@ -27,8 +27,20 @@ extension Badge {
             uiView.variant = variant
         }
         
-        public func sizeThatFits(_ proposal: ProposedViewSize, uiView: Badge.Push, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
+        public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
         }
     }
 }

--- a/Sources/Montage/Element/Button/OutlineButton/OutlinedButtonController.swift
+++ b/Sources/Montage/Element/Button/OutlineButton/OutlinedButtonController.swift
@@ -79,7 +79,19 @@ extension Button {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
         }
     }
 }

--- a/Sources/Montage/Element/Button/OutlineButton/OutlinedButtonController.swift
+++ b/Sources/Montage/Element/Button/OutlineButton/OutlinedButtonController.swift
@@ -80,17 +80,17 @@ extension Button {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
     }

--- a/Sources/Montage/Element/Button/SolidButton/SolidButtonController.swift
+++ b/Sources/Montage/Element/Button/SolidButton/SolidButtonController.swift
@@ -73,7 +73,19 @@ extension Button {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
         }
     }
 }

--- a/Sources/Montage/Element/Button/SolidButton/SolidButtonController.swift
+++ b/Sources/Montage/Element/Button/SolidButton/SolidButtonController.swift
@@ -74,17 +74,17 @@ extension Button {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
     }

--- a/Sources/Montage/Element/Chip/Action/ActionChipController.swift
+++ b/Sources/Montage/Element/Chip/Action/ActionChipController.swift
@@ -93,7 +93,19 @@ extension Chip {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
         }
     }
 }

--- a/Sources/Montage/Element/Chip/Action/ActionChipController.swift
+++ b/Sources/Montage/Element/Chip/Action/ActionChipController.swift
@@ -94,17 +94,17 @@ extension Chip {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
     }

--- a/Sources/Montage/Element/Chip/Filter/FilterChipController.swift
+++ b/Sources/Montage/Element/Chip/Filter/FilterChipController.swift
@@ -77,7 +77,19 @@ extension Chip {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
         }
     }
 }

--- a/Sources/Montage/Element/Chip/Filter/FilterChipController.swift
+++ b/Sources/Montage/Element/Chip/Filter/FilterChipController.swift
@@ -78,17 +78,17 @@ extension Chip {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
     }

--- a/Sources/Montage/Element/Control/Check/CheckController.swift
+++ b/Sources/Montage/Element/Control/Check/CheckController.swift
@@ -52,8 +52,8 @@ extension Control {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
@@ -76,12 +76,12 @@ extension Control {
             }
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
         

--- a/Sources/Montage/Element/Control/Check/CheckController.swift
+++ b/Sources/Montage/Element/Control/Check/CheckController.swift
@@ -51,13 +51,10 @@ extension Control {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
-        }
-        
-        public func disable(_ isDisable: Bool = true) -> Self {
-            var view = self
-            view.isDisable = isDisable
-            return view
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
         }
         
         public func makeCoordinator() -> Coordinator {
@@ -77,6 +74,21 @@ extension Control {
                 state = check.state
                 onTap(check)
             }
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
+        }
+        
+        public func disable(_ isDisable: Bool = true) -> Self {
+            var view = self
+            view.isDisable = isDisable
+            return view
         }
     }
 }

--- a/Sources/Montage/Element/Control/Checkbox/CheckboxController.swift
+++ b/Sources/Montage/Element/Control/Checkbox/CheckboxController.swift
@@ -52,8 +52,8 @@ extension Control {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
@@ -76,12 +76,12 @@ extension Control {
             }
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
         

--- a/Sources/Montage/Element/Control/Checkbox/CheckboxController.swift
+++ b/Sources/Montage/Element/Control/Checkbox/CheckboxController.swift
@@ -51,13 +51,10 @@ extension Control {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
-        }
-        
-        public func disable(_ isDisable: Bool = true) -> Self {
-            var view = self
-            view.isDisable = isDisable
-            return view
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
         }
         
         public func makeCoordinator() -> Coordinator {
@@ -77,6 +74,21 @@ extension Control {
                 state = checkbox.state
                 onTap(checkbox)
             }
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
+        }
+        
+        public func disable(_ isDisable: Bool = true) -> Self {
+            var view = self
+            view.isDisable = isDisable
+            return view
         }
     }
 }

--- a/Sources/Montage/Element/Control/Radio/RadioController.swift
+++ b/Sources/Montage/Element/Control/Radio/RadioController.swift
@@ -51,13 +51,10 @@ extension Control {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
-        }
-        
-        public func disable(_ isDisable: Bool = true) -> Self {
-            var view = self
-            view.isDisable = isDisable
-            return view
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
         }
         
         public func makeCoordinator() -> Coordinator {
@@ -77,6 +74,21 @@ extension Control {
                 state = radio.state
                 onTap(radio)
             }
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
+        }
+        
+        public func disable(_ isDisable: Bool = true) -> Self {
+            var view = self
+            view.isDisable = isDisable
+            return view
         }
     }
 }

--- a/Sources/Montage/Element/Control/Radio/RadioController.swift
+++ b/Sources/Montage/Element/Control/Radio/RadioController.swift
@@ -52,8 +52,8 @@ extension Control {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
@@ -76,12 +76,12 @@ extension Control {
             }
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
         

--- a/Sources/Montage/Element/Control/RoundCheckbox/RoundCheckboxController.swift
+++ b/Sources/Montage/Element/Control/RoundCheckbox/RoundCheckboxController.swift
@@ -52,8 +52,8 @@ extension Control {
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
             CGSize(
-                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
-                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+                width: fillHorizontal ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillVertical ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
             )
         }
         
@@ -76,12 +76,12 @@ extension Control {
             }
         }
         
-        private var fillWidth: Bool = false
-        private var fillHeight: Bool = false
-        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+        private var fillHorizontal: Bool = false
+        private var fillVertical: Bool = false
+        public func fill(horizontal fillHorizontal: Bool, vertical fillVertical: Bool) -> Self {
             var zelf = self
-            zelf.fillWidth = fillWidth
-            zelf.fillHeight = fillHeight
+            zelf.fillHorizontal = fillHorizontal
+            zelf.fillVertical = fillVertical
             return zelf
         }
         

--- a/Sources/Montage/Element/Control/RoundCheckbox/RoundCheckboxController.swift
+++ b/Sources/Montage/Element/Control/RoundCheckbox/RoundCheckboxController.swift
@@ -51,13 +51,10 @@ extension Control {
         }
         
         public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIViewType, context: Context) -> CGSize? {
-            uiView.intrinsicContentSize
-        }
-        
-        public func disable(_ isDisable: Bool = true) -> Self {
-            var view = self
-            view.isDisable = isDisable
-            return view
+            CGSize(
+                width: fillWidth ? proposal.width ?? 0 : uiView.intrinsicContentSize.width,
+                height: fillHeight ? proposal.height ?? 0 : uiView.intrinsicContentSize.height
+            )
         }
         
         public func makeCoordinator() -> Coordinator {
@@ -77,6 +74,21 @@ extension Control {
                 state = checkbox.state
                 onTap(checkbox)
             }
+        }
+        
+        private var fillWidth: Bool = false
+        private var fillHeight: Bool = false
+        public func fill(width fillWidth: Bool, height fillHeight: Bool) -> Self {
+            var zelf = self
+            zelf.fillWidth = fillWidth
+            zelf.fillHeight = fillHeight
+            return zelf
+        }
+        
+        public func disable(_ isDisable: Bool = true) -> Self {
+            var view = self
+            view.isDisable = isDisable
+            return view
         }
     }
 }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : 

### 📌 작업 완료 기한
- 2024/11/28

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
UIKit으로 만들어진 컴포넌트들이 기본적으로 intrinsicContentSize로 그려지도록 변경됨에 따라
의도적으로 주어진 ProposedSize를 모두 채워서 그려지도록 하는 방법이 필요해져서 fill(width:height) 메소드를 추가하였습니다.
예) SolidButton, OutlinedButton 등의 경우


# 확인사항
- [x] 동작 확인 
