### PR TITLE
fix: TextArea에서 포커스 상태가 아니어도 placeholder 표시하도록 수정

### DIFF
--- a/Sources/Montage/Components/Text/TextArea.swift
+++ b/Sources/Montage/Components/Text/TextArea.swift
@@ -325,7 +325,7 @@ public struct TextArea: View {
                                 .padding(.bottom, -6)
                         }
                     }
-                    if $text.wrappedValue.isEmpty && textEditorFocusState == false, let placeholder {
+                    if $text.wrappedValue.isEmpty, let placeholder {
                         Text(placeholder)
                             .montage(
                                 variant: .body1Reading,


### PR DESCRIPTION
### 📌 작업 완료 기한
- 2024/12/05

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
TextArea에서 포커스 상태가 아니어도 **placeholder** 표시하도록 수정했습니다. _(다른 플랫폼 동작과 맞춤)_

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 16 Plus - 2024-12-05 at 10 00 15](https://github.com/user-attachments/assets/8d60122d-b55a-4651-8d08-affad33f532a)|![Simulator Screenshot - iPhone 16 Plus - 2024-12-05 at 10 08 24](https://github.com/user-attachments/assets/6930599b-000a-45ce-9b4c-c10d77f77dde)


# 확인사항
- [x] 동작 확인 
