### PR TITLE
필요시 Toast의 위치와 Offset을 설정할 수 있도록 변경

### DIFF
--- a/Sources/Montage/Components/Toast/Toast.swift
+++ b/Sources/Montage/Components/Toast/Toast.swift
@@ -11,10 +11,16 @@ public struct Toast: View {
     public struct Model: Equatable {
         let variant: Toast.Variant
         let message: String
+        let location: Toast.Location
         
-        public init(_ variant: Toast.Variant = .message, message: String) {
+        public init(
+            _ variant: Toast.Variant = .message,
+            message: String,
+            location: Toast.Location = .bottom(offset: .zero)
+        ) {
             self.variant = variant
             self.message = message
+            self.location = location
         }
     }
 
@@ -25,23 +31,43 @@ public struct Toast: View {
         case custom(Montage.Icon, tint: Montage.Color.Alias? = nil)
     }
     
+    public enum Location: Equatable {
+        case top(offset: CGFloat = .zero)
+        case bottom(offset: CGFloat = .zero)
+    }
+    
     private let variant: Variant
     private let message: String
+    private let location: Location
     
     init(
         _ variant: Variant = .message,
-        message: String = ""
+        message: String = "",
+        _ location: Location = .bottom(offset: .zero)
     ) {
         self.variant = variant
         self.message = message
+        self.location = location
     }
     
     public var body: some View {
-        VStack {
-            Spacer()
-            Contents(variant, message)
-                .padding(.horizontal, 20)
+        switch location {
+        case .top(let offset):
+            VStack {
+                Contents(variant, message)
+                    .padding(.horizontal, 20)
+                    .padding(.top, offset)
+                Spacer()
+            }
+        case .bottom(let offset):
+            VStack {
+                Spacer()
+                Contents(variant, message)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, offset)
+            }
         }
+        
     }
     
     fileprivate struct Contents: View {
@@ -160,7 +186,7 @@ extension Toast {
         @ViewBuilder
         private func toast() -> some View {
             if let model {
-                Toast(model.variant, message: model.message)
+                Toast(model.variant, message: model.message, model.location)
             }
         }
         


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : 

### 📌 작업 완료 기한
- 2024/12/10

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* Toast Model에 필요하다면 어느 위치에 노출 될지 지정할 수 있습니다.

### 미리보기
📱|작업 전|상단(+30 여백) 작업 전|하단(+20 여백)작업 후
---|---|---|---
iPhone|![image](https://github.com/user-attachments/assets/70bd90f6-6de6-4dfc-ad59-a3051b6ece39)|![image](https://github.com/user-attachments/assets/753d858c-9736-48bc-adb9-5ed3e3bcb548)|![image](https://github.com/user-attachments/assets/c83fc758-07e7-4e35-990a-a49d712bb628)

# 확인사항
- [X] 동작 확인 
