### PR TITLE
fix: Pull to Refresh 피드백 대응

### DIFF
--- a/Sources/Montage/3 Component/5 Loading/PullToRefreshModifier.swift
+++ b/Sources/Montage/3 Component/5 Loading/PullToRefreshModifier.swift
@@ -9,40 +9,20 @@ import SwiftUI
 import Lottie
 
 public struct PullToRefreshModifier: ViewModifier {
-    @Binding private var externalScrollYOffset: CGFloat
+    @Binding private var scrollYOffset: CGFloat
     private let refresh: () async -> Void
-    private let isUsingInternalScrollView: Bool
     
     public init(scrollYOffset: Binding<CGFloat>, refresh: @escaping () async -> Void) {
-        self._externalScrollYOffset = scrollYOffset
+        self._scrollYOffset = scrollYOffset
         self.refresh = refresh
-        self.isUsingInternalScrollView = false
-    }
-    
-    public init(refresh: @escaping () async -> Void) {
-        self._externalScrollYOffset = Binding(get: { .zero }, set: { _ in })
-        self.refresh = refresh
-        self.isUsingInternalScrollView = true
-    }
-    
-    @State private var internalScrollYOffset: CGFloat = .zero
-    private var scrollYOffset: Binding<CGFloat> {
-        Binding {
-            isUsingInternalScrollView ? internalScrollYOffset : externalScrollYOffset
-        } set: {
-            if isUsingInternalScrollView {
-                internalScrollYOffset = $0
-            } else {
-                externalScrollYOffset = $0
-            }
-        }
     }
     
     @State private var phase: AnimatingLogo.Phase = .idle
     @State private var task: Task<Void, Never>?
     
-    // 리프레시를 트리거링 할 가능성이 있는 '트리거링 스크롤'이 진행중임을 의미하는 플래그
-    @State private var isTriggeringScrollStarted: Bool = false
+    @State private var isScrolling: Bool = false
+    // 리프레시를 트리거링 할 가능성이 있는 '트리거스크롤'이 진행중임을 의미하는 플래그
+    @State private var isTriggerScrolling: Bool = false
     // 스크롤 옵셋을 임의로 조정하기 위한 '투명뷰'의 필요 여부를 나타내는 플래그
     @State private var isClearRectNeeded: Bool = false
     
@@ -52,6 +32,8 @@ public struct PullToRefreshModifier: ViewModifier {
     private var animationThreshold: CGFloat { logoHeight / 2 }
     // 리프레시가 트리거되는 스크롤 옵셋 쓰레숄드(최초 셋팅 이후 고정값)
     private var refreshThreshold: CGFloat { logoHeight * 4 }
+    // 리프레시 중에 스크롤이 멈춰있는 높이
+    private var hangingHeight: CGFloat { logoHeight * 2 }
     
     // 로고와 패딩을 포함한 높이(최대: thresholdToRefresh)
     @State private var pullToRefreshViewHeight: CGFloat = .zero
@@ -60,7 +42,7 @@ public struct PullToRefreshModifier: ViewModifier {
     
     // 스크롤뷰가 얼마나 당겨졌는지 0에서 시작해서 thresholdToRefresh까지를 1로 계산한 비율값
     private var pullDownRatio: CGFloat {
-        max(0, scrollYOffset.wrappedValue - animationThreshold) / max(1, refreshThreshold - animationThreshold)
+        max(0, scrollYOffset - animationThreshold) / max(1, refreshThreshold - animationThreshold)
     }
     
     public func body(content: Content) -> some View {
@@ -74,88 +56,64 @@ public struct PullToRefreshModifier: ViewModifier {
                 .frame(maxWidth: .infinity)
                 .clipped()
             
-            Group {
-                let scrollView: some View = {
-                    Group {
-                        if isUsingInternalScrollView {
-                            OffsettableScrollView(onOffsetChanged: { offset in
-                                scrollYOffset.wrappedValue = offset.y
-                            }) {
-                                content
-                            }
-                        } else {
-                            content
-                        }
-                    }
-                }()
-                VStack(spacing: 0) {
-                    if isClearRectNeeded {
-                        SwiftUI.Color.clear
-                            .frame(height: clearRectHeight)
-                    }
-                    
-                    scrollView
+            VStack(spacing: 0) {
+                if isClearRectNeeded {
+                    SwiftUI.Color.clear
+                        .frame(height: clearRectHeight)
                 }
+                
+                content
             }
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0.1, coordinateSpace: .local)
-                    .onChanged({ state in
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .local)
+                    .onChanged({ value in
+                        isScrolling = true
+                        
                         if phase.beforeRefreshing {
-                            // 현재 스크롤이 트리거링 스크롤임
-                            isTriggeringScrollStarted = true
-                        }
-                        // 리프레시가 끝나기 전에 다시 스크롤 하는 경우
-                        if !isTriggeringScrollStarted {
-                            // 스크롤 옵셋 복귀 애니메이션 시작점을 업데이트
-                            clearRectHeight = logoHeight + state.translation.height / 2
-                        }
-                        // 리프레시 중에 위로 스크롤 하는 경우
-                        if phase.isRefreshing && state.translation.height < 0 {
-                            // 리프레시를 취소
-                            phase = .ending
+                            // 현재 스크롤이 트리거스크롤임
+                            isTriggerScrolling = true
                         }
                     })
                     .onEnded({ value in
-                        // 리프레시를 트리거한 후 트리거링 스크롤이 끝났을 때
-                        if isTriggeringScrollStarted && !phase.beforeRefreshing {
-                            isTriggeringScrollStarted = false
-                            
-                            if !phase.isEnding {
-                                // 리프레시 시작과 트리거링 스크롤 종료, 두가지 조건 중 하나라도 만족되지 않았을때 투명뷰를 추가하면 스크롤 옵셋이 튀어버린다.
-                                // 또, 트리거링 스크롤이 끝난 시점에 이미 엔딩 단계라면 (엔딩처리시 플래그를 끄고 있기 때문에) 다시 켜지 않아야 한다.
-                                isClearRectNeeded = true
-                            }
-                            
+                        // 리프레시가 시작된 후 스크롤이 끝났을 때
+                        if phase.isRefreshing {
+                            // 투명뷰를 추가한다.
+                            isClearRectNeeded = true
                             // 스크롤 옵셋이 천천히 되돌아가도록 하기 위한 애니메이션
-                            withAnimation(.easeInOut(duration: 0.5)) {
-                                clearRectHeight = phase.isEnding ? 0 : logoHeight
-                            }
-                            
-                            // 스크롤 애니메이션 종료 시점에 이미 엔딩 단계라면 idle단계로 변경한다.
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                if phase.isEnding {
-                                    phase = .idle
-                                }
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                // 로고와 패딩 영역이 천천히 줄어들도록 하기 위함
+                                pullToRefreshViewHeight = hangingHeight
+                                clearRectHeight = hangingHeight
                             }
                         }
                         
-                        // 리프레시 중에 스크롤이 끝났을 때
-                        if phase.isRefreshing {
-                            withAnimation(.easeInOut(duration: 0.5)) {
-                                // 로고와 패딩 영역이 천천히 줄어들도록 하기 위함
-                                pullToRefreshViewHeight = logoHeight
-                                // 스크롤 옵셋이 천천히 되돌아가도록 하기 위함
-                                clearRectHeight = logoHeight
-                            }
+                        // 리프레시가 끝나기 전에 스크롤을 드래그하여 위로 던지는 경우
+                        if phase.isRefreshing && (value.predictedEndTranslation.height < 0 || scrollYOffset < 0) {
+                            task?.cancel()
                         }
+                        
+                        // 리프레시가 끝난 후 스크롤이 끝났을 때
+                        if phase.isWaitingToEnd {
+                            // 스크롤 옵셋 복귀 애니메이션 시작점 설정
+                            clearRectHeight = hangingHeight + value.translation.height / 2
+                            // 엔딩 애니메이션 수행
+                            phase = .ending
+                        }
+                        
+                        isTriggerScrolling = false
+                        isScrolling = false
                     })
             )
         }
-        .onChange(of: scrollYOffset.wrappedValue) { scrollPosition in
-            // 트리거링 스크롤이 끝날때까지
-            if isTriggeringScrollStarted {
+        .onChange(of: scrollYOffset) { scrollPosition in
+            // 트리거스크롤이 끝날때까지
+            if isTriggerScrolling {
                 // 스크롤 옵셋 복귀 애니메이션 시작점을 업데이트
                 clearRectHeight = scrollPosition
+                // 트리거스크롤 중에 리프레시 시작되었는데 스크롤 포지션이 다시 쓰레숄드 아래로 내려가는 경우
+                if phase.isRefreshing && scrollPosition < refreshThreshold {
+                    task?.cancel()
+                }
             }
             
             // 리프레시 시작전까지만
@@ -177,20 +135,32 @@ public struct PullToRefreshModifier: ViewModifier {
                 task?.cancel()
                 task = Task {
                     await refresh()
-                    self.phase = .ending
+                    do {
+                        try Task.checkCancellation()
+                    } catch {
+                        if error is CancellationError {
+                            if isTriggerScrolling {
+                                self.phase = .pulledDown(ratio: pullDownRatio)
+                                return
+                            }
+                        }
+                    }
+                    if isScrolling {
+                        // 스크롤 끝나는 시점에 엔딩 애니메이션을 수행하기 위해 대기시킨다.
+                        self.phase = .waitingToEnd
+                    } else {
+                        self.phase = .ending
+                    }
                 }
+            case .waitingToEnd: break
             case .ending:
-                task?.cancel()
-                withAnimation(.easeInOut(duration: 0.5)) {
+                withAnimation(.easeInOut(duration: 0.2)) {
                     isClearRectNeeded = false
                     pullToRefreshViewHeight = 0
                     clearRectHeight = 0
                 }
-                if !isTriggeringScrollStarted {
-                    // 엔딩 애니메이션이 끝날 때까지 트리거링 스크롤이 끝나지 않은 경우는 트리거링 스크롤이 끝나는 시점에 제어하기 위해 엔딩 단계로 남겨둔다.
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        self.phase = .idle
-                    }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.phase = .idle
                 }
             }
         }
@@ -199,7 +169,7 @@ public struct PullToRefreshModifier: ViewModifier {
 
 private struct AnimatingLogo: View {
     enum Phase: Equatable {
-        case idle, pulledDown(ratio: CGFloat), refreshing, ending
+        case idle, pulledDown(ratio: CGFloat), refreshing, waitingToEnd, ending
         
         var beforeRefreshing: Bool {
             switch self {
@@ -211,6 +181,13 @@ private struct AnimatingLogo: View {
         var isRefreshing: Bool {
             switch self {
             case .refreshing: return true
+            default: return false
+            }
+        }
+        
+        var isWaitingToEnd: Bool {
+            switch self {
+            case .waitingToEnd: return true
             default: return false
             }
         }
@@ -266,6 +243,7 @@ private struct AnimatingLogo: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                         playbackMode = .playing(.fromProgress(0, toProgress: 1, loopMode: .loop))
                     }
+                case .waitingToEnd: break
                 case .ending:
                     withAnimation(.timingCurve(0.25, 0.1, 0.25, 1, duration: 0.5)) {
                         opacity = 0

--- a/Sources/Montage/Extension/SwiftUI/View+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/View+Montage.swift
@@ -261,8 +261,4 @@ extension View {
     public func pullToRefresh(scrollYOffset: Binding<CGFloat>, refresh: @escaping () async -> Void) -> some View {
         modifier(PullToRefreshModifier(scrollYOffset: scrollYOffset, refresh: refresh))
     }
-    
-    public func pullToRefresh(refresh: @escaping () async -> Void) -> some View {
-        modifier(PullToRefreshModifier(refresh: refresh))
-    }
 }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : 

### 📌 작업 완료 기한
- 2024/12/27

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* 풀투리프레시 영역 높이를 요소의 2배로(=0.5씩 상하 여백 있도록) 업데이트
* 추가 버그 발견으로 인한 수정(리프레시 중에 스크롤을 내렸다가 올리면 스크롤뷰 컨텐츠가 가려지는 현상)

### 미리보기
작업 전

https://github.com/user-attachments/assets/c4a83873-fada-4ea5-8499-4ebee0785cd8

작업 후

https://github.com/user-attachments/assets/884f7b78-5cff-48cf-bf94-601702299a41

# 확인사항
- [x] 동작 확인 
