### PR TITLE
fix: Pull to Refresh 버그 수정

### DIFF
--- a/Sources/Montage/3 Component/5 Loading/PullToRefreshModifier.swift
+++ b/Sources/Montage/3 Component/5 Loading/PullToRefreshModifier.swift
@@ -132,6 +132,11 @@ public struct PullToRefreshModifier: ViewModifier {
                     self.phase = .refreshing
                 }
             case .refreshing:
+                if !isScrolling {
+                    isClearRectNeeded = true
+                    pullToRefreshViewHeight = hangingHeight
+                    clearRectHeight = hangingHeight
+                }
                 task?.cancel()
                 task = Task {
                     await refresh()


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : 

### 📌 작업 완료 기한
- 2024/12/30

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
스크롤을 위로 올렸다가 밑으로 빠르게 던지면 로고와 스크롤 컨텐츠가 겹치는 문제

### 미리보기
작업 전

https://github.com/user-attachments/assets/59744f9c-17a4-4b13-9554-09731dc3aa30

작업 후

https://github.com/user-attachments/assets/8631836d-2704-460d-a545-2f620978db82

# 확인사항
- [x] 동작 확인 
