### PR TITLE
fix: TextInput Contents 영역 Min height 추가

### DIFF
--- a/Sources/Montage/3 Component/3 Selection And Input/Text/TextInput.swift
+++ b/Sources/Montage/3 Component/3 Selection And Input/Text/TextInput.swift
@@ -198,7 +198,7 @@ public struct TextInput: View {
                         .font(.montage(variant: .body1, weight: .regular))
                         .foregroundStyle(fieldTextColor)
                         .focused($textFieldFocusState)
-                        .frame(height: 24)
+                        .frame(minHeight: 24)
                         .padding(.horizontal, 4)
 
                         if active, textFieldFocusState {
@@ -224,39 +224,29 @@ public struct TextInput: View {
                         }
                     }
                     .padding(.all, 12)
-                    
-                    if rightButton == nil {
-                        RoundedRectangle(cornerRadius: 12)
-                            .inset(by: 0.5)
-                            .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
-                            .padding(.all, textFieldFocusState ? 2 : 1)
-                    } else {
-                        RoundedCorner(radius: 12, corners: [.topLeft, .bottomLeft])
-                            .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
-                            .padding([.top, .bottom, .leading], textFieldFocusState ? 2 : 1)
-                    }
                 }
                 
                 if case let .button(variant, title, handler) = rightButton {
-                    ZStack {
+                    HStack(spacing: 0) {
+                        Rectangle()
+                            .frame(width: 1)
+                            .foregroundStyle(fieldStrokeColor)
                         FieldButton(
                             variant: variant,
                             title: title,
                             handler: handler
                         )
-                        RoundedCorner(radius: 12, corners: [ .topRight, .bottomRight])
-                            .stroke(SwiftUI.Color.alias(.lineNeutral), lineWidth: 1)
-                            .padding([.top, .trailing, .bottom], textFieldFocusState ? 1.5 : 1)
-                            .padding(.top, 0.2) // Texfield의 boder 영역과 높낮이를 맞추기 위함
-                            .clipShape(
-                                Rectangle()
-                                    .offset(x: textFieldFocusState ? 1 : 0.7, y: .zero)
-                            )
                     }
                     .fixedSize()
                 }
             }
-            .frame(height: 48)
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .inset(by: 0.5)
+                    .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
+                    .padding(.all, textFieldFocusState ? 2 : 1)
+            }
+            .frame(minHeight: 48)
             .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
             .clipShape(
                 RoundedRectangle(cornerRadius: 12)
@@ -300,7 +290,7 @@ public struct TextInput: View {
                         .stroke(SwiftUI.Color.clear)
                 }
                 .padding(.horizontal, 19)
-                .padding(.vertical, 12)
+                .padding(.vertical, 11)
         }
     }
 }

--- a/Sources/Montage/3 Component/3 Selection And Input/Text/TextInput.swift
+++ b/Sources/Montage/3 Component/3 Selection And Input/Text/TextInput.swift
@@ -169,6 +169,8 @@ public struct TextInput: View {
             disable ? .alias(.labelAlternative) : .alias(.labelNormal)
         }
         
+        @State private var height: CGFloat = 0
+
         var body: some View {
             HStack(spacing: .zero) {
                 ZStack {
@@ -196,6 +198,7 @@ public struct TextInput: View {
                             }()
                         )
                         .font(.montage(variant: .body1, weight: .regular))
+                        .paragraph(variant: .body1)
                         .foregroundStyle(fieldTextColor)
                         .focused($textFieldFocusState)
                         .frame(minHeight: 24)
@@ -224,27 +227,40 @@ public struct TextInput: View {
                         }
                     }
                     .padding(.all, 12)
+                    .overlay {
+                        if rightButton == nil {
+                            RoundedRectangle(cornerRadius: 12)
+                                .inset(by: 0.5)
+                                .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
+                                .padding(.all, textFieldFocusState ? 2 : 1)
+                        } else {
+                            UnevenRoundedRectangle(cornerRadii: .init(topLeading: 12, bottomLeading: 12))
+                                .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
+                                .padding([.top, .bottom, .leading], textFieldFocusState ? 2 : 1)
+                        }
+                    }
+                    .onGeometryChange(for: CGFloat.self, of: { $0.size.height }, action: { height = $0 })
                 }
                 
                 if case let .button(variant, title, handler) = rightButton {
-                    HStack(spacing: 0) {
-                        Rectangle()
-                            .frame(width: 1)
-                            .foregroundStyle(fieldStrokeColor)
+                    ZStack {
                         FieldButton(
                             variant: variant,
                             title: title,
                             handler: handler
                         )
+                        UnevenRoundedRectangle(cornerRadii: .init(bottomTrailing: 12, topTrailing: 12))
+                            .stroke(SwiftUI.Color.alias(.lineNeutral), lineWidth: 1)
+                            .padding([.top, .trailing, .bottom], textFieldFocusState ? 2 : 1)
+
+                            .clipShape(
+                                Rectangle()
+                                    .offset(x: textFieldFocusState ? 1 : 0.7, y: .zero)
+                            )
+                            .frame(height: height)
                     }
-                    .fixedSize()
+                    .fixedSize(horizontal: true, vertical: false)
                 }
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 12)
-                    .inset(by: 0.5)
-                    .stroke(fieldStrokeColor, lineWidth: textFieldFocusState ? 2 : 1)
-                    .padding(.all, textFieldFocusState ? 2 : 1)
             }
             .frame(minHeight: 48)
             .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
@@ -290,7 +306,7 @@ public struct TextInput: View {
                         .stroke(SwiftUI.Color.clear)
                 }
                 .padding(.horizontal, 19)
-                .padding(.vertical, 11)
+                .padding(.vertical, 12)
         }
     }
 }


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : 

### 📌 작업 완료 기한
- 2024/01/17

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* TextInput Contents 영역 Min height 추가
* Text 크기가 커지면 TextInput 영역을 벗어나는 문제 수정

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|<img width="1146" alt="스크린샷 2025-01-15 오후 4 57 30" src="https://github.com/user-attachments/assets/1478fb11-0a37-452d-a011-4611f9e76879" />|<img width="1140" alt="스크린샷 2025-01-15 오후 4 56 48" src="https://github.com/user-attachments/assets/b8de8d24-b9bd-4874-941b-8a1d50682f04" />

# 확인사항
- [x] 동작 확인 
