### PR TITLE
ActionArea 및 TopNaivagtionModifier 수정 (~1/20)

### DIFF
--- a/Sources/Montage/3 Component/2 Actions/ActionArea/Bottom/ActionAreaBottom.swift
+++ b/Sources/Montage/3 Component/2 Actions/ActionArea/Bottom/ActionAreaBottom.swift
@@ -71,25 +71,41 @@ extension ActionArea {
                 if showExtraContents {
                     [
                         .clear,
+                        .alias(.backgroundElevated).opacity(0),
                         .alias(.backgroundElevated).opacity(0.14),
-                        .alias(.backgroundElevated).opacity(0.29),
-                        .alias(.backgroundElevated).opacity(0.34),
-                        .alias(.backgroundElevated).opacity(0.40),
-                        .alias(.backgroundElevated).opacity(0.54),
-                        .alias(.backgroundElevated).opacity(0.74),
+                        .alias(.backgroundElevated).opacity(0.27),
+                        .alias(.backgroundElevated).opacity(0.38),
+                        .alias(.backgroundElevated).opacity(0.48),
+                        .alias(.backgroundElevated).opacity(0.57),
+                        .alias(.backgroundElevated).opacity(0.65),
+                        .alias(.backgroundElevated).opacity(0.71),
+                        .alias(.backgroundElevated).opacity(0.77),
+                        .alias(.backgroundElevated).opacity(0.82),
                         .alias(.backgroundElevated).opacity(0.86),
+                        .alias(.backgroundElevated).opacity(0.9),
+                        .alias(.backgroundElevated).opacity(0.93),
+                        .alias(.backgroundElevated).opacity(0.96),
+                        .alias(.backgroundElevated).opacity(0.98),
                         .alias(.backgroundElevated)
                     ]
                 } else {
                     [
                         .clear,
+                        .alias(.backgroundNormal).opacity(0),
                         .alias(.backgroundNormal).opacity(0.14),
-                        .alias(.backgroundNormal).opacity(0.29),
-                        .alias(.backgroundNormal).opacity(0.34),
-                        .alias(.backgroundNormal).opacity(0.40),
-                        .alias(.backgroundNormal).opacity(0.54),
-                        .alias(.backgroundNormal).opacity(0.74),
+                        .alias(.backgroundNormal).opacity(0.27),
+                        .alias(.backgroundNormal).opacity(0.38),
+                        .alias(.backgroundNormal).opacity(0.48),
+                        .alias(.backgroundNormal).opacity(0.57),
+                        .alias(.backgroundNormal).opacity(0.65),
+                        .alias(.backgroundNormal).opacity(0.71),
+                        .alias(.backgroundNormal).opacity(0.77),
+                        .alias(.backgroundNormal).opacity(0.82),
                         .alias(.backgroundNormal).opacity(0.86),
+                        .alias(.backgroundNormal).opacity(0.9),
+                        .alias(.backgroundNormal).opacity(0.93),
+                        .alias(.backgroundNormal).opacity(0.96),
+                        .alias(.backgroundNormal).opacity(0.98),
                         .alias(.backgroundNormal)
                     ]
                 }
@@ -109,18 +125,6 @@ extension ActionArea {
                 }
             }
 
-            private var captionSizeMeasurer: some View {
-                GeometryReader { proxy in
-                    Text("")
-                        .onAppear {
-                            captionHeight = proxy.size.height
-                        }
-                        .onDisappear {
-                            captionHeight = .zero
-                        }
-                }
-            }
-            
             /// SafeAreaInest에 따른 Bottom Padding 입니다.
             private var safeAreaBottomPadding: CGFloat {
                 safeAreaInsets.bottom != .zero ? 14 : .zero
@@ -168,8 +172,10 @@ extension ActionArea {
                                     .montage(variant: .label2, alias: .labelAlternative)
                                     .paragraph(variant: .label2)
                                     .padding(.bottom, 16)
-                                    .background(
-                                        captionSizeMeasurer
+                                    .onGeometryChange(
+                                        for: CGSize.self,
+                                        of: { $0.size },
+                                        action: { captionHeight = $0.height }
                                     )
                             }
                             

--- a/Sources/Montage/3 Component/2 Actions/ActionArea/Bottom/ActionAreaBottom.swift
+++ b/Sources/Montage/3 Component/2 Actions/ActionArea/Bottom/ActionAreaBottom.swift
@@ -5,6 +5,7 @@
 //  Created by Ahn Sang Hoon on 7/9/24.
 //
 
+import Combine
 import SwiftUI
 
 extension ActionArea {
@@ -41,7 +42,7 @@ extension ActionArea {
         }
         
         /// 하단 영역에 노출될 Gradient, Button들이 집합된 Component입니다.
-        public struct Component: View {
+        public struct Component: View, KeyboardReadable {
             // MARK: - Environment
             
             @Environment(\.safeAreaInsets) private var safeAreaInsets
@@ -50,6 +51,7 @@ extension ActionArea {
             
             @State private var height: CGFloat = .zero
             @State private var captionHeight: CGFloat = .zero
+            @State private var isKeyboardVisible = false
             
             // MARK: - Uninitialised properties
             
@@ -119,6 +121,11 @@ extension ActionArea {
                 }
             }
             
+            /// SafeAreaInest에 따른 Bottom Padding 입니다.
+            private var safeAreaBottomPadding: CGFloat {
+                safeAreaInsets.bottom != .zero ? 14 : .zero
+            }
+            
             // MARK: - Initialisers
            
             public init(model: ActionArea.Bottom.Model) {
@@ -169,6 +176,11 @@ extension ActionArea {
                             ActionView(model.priority)
                         }
                         .padding([.top, .horizontal], 20)
+
+                        if isKeyboardVisible == false {
+                            Spacer()
+                                .frame(height: safeAreaBottomPadding)
+                        }
                     }
                     .padding(.bottom, 20)
                     
@@ -187,6 +199,7 @@ extension ActionArea {
                         }
                     }
                 }
+                .onReceive(keyboardPublisher) { isKeyboardVisible = $0 }
             }
             
             private struct ActionView: View {
@@ -431,6 +444,28 @@ extension ActionArea.Bottom {
             self.caption = caption
             extraContents = nil
         }
+    }
+}
+
+extension ActionArea.Bottom {
+    /// Publisher to read keyboard changes.
+    protocol KeyboardReadable {
+        var keyboardPublisher: AnyPublisher<Bool, Never> { get }
+    }
+}
+
+extension ActionArea.Bottom.KeyboardReadable {
+    var keyboardPublisher: AnyPublisher<Bool, Never> {
+        Publishers.Merge(
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillShowNotification)
+                .map { _ in true },
+            
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillHideNotification)
+                .map { _ in false }
+        )
+        .eraseToAnyPublisher()
     }
 }
 

--- a/Sources/Montage/3 Component/6 Navigations/Bar/TopNavigation/TopNavigation.swift
+++ b/Sources/Montage/3 Component/6 Navigations/Bar/TopNavigation/TopNavigation.swift
@@ -756,7 +756,7 @@ extension Bar.TopNavigation {
                 .onPreferenceChange(
                     OffsetPreferenceKey.self,
                     perform: {
-                        scrollOffset = $0.y + (safeAreaInsets.top - navigationHeight)
+                        scrollOffset = $0.y
                         calculateSticky()
                     }
                 )

--- a/Sources/Montage/3 Component/6 Navigations/Bar/TopNavigation/TopNavigation.swift
+++ b/Sources/Montage/3 Component/6 Navigations/Bar/TopNavigation/TopNavigation.swift
@@ -667,7 +667,9 @@ extension Bar.TopNavigation {
         @State private var containerSize: CGSize = .zero
         @State private var innerContentSize: CGSize = .zero
         @State private var navigationHeight: CGFloat = .zero
-        @State private var bottomActionHeight: CGFloat = .zero
+        @State private var originBottomActionHeight: CGFloat = .zero
+        @State private var currentBottomActionHeight: CGFloat = .zero
+        @State private var isBottomActionAreaSticky: Bool
 
         private let variant: Variant
         private let title: String
@@ -676,32 +678,6 @@ extension Bar.TopNavigation {
         private let actions: [Resource.Action]
         private let backgroundColorResolvable: ColorResolvable?
         private let model: ActionArea.Bottom.Model?
-        
-        /// TopNavigation의 사이즈를 측정하는 View입니다.
-        private var navigationSizeMeasurer: some View {
-            GeometryReader { proxy in
-                SwiftUI.Color.clear
-                    .onAppear {
-                        navigationHeight = proxy.size.height
-                    }
-                    .onChange(of: variant) { _ in
-                        navigationHeight = proxy.size.height
-                    }
-            }
-        }
-
-        /// ActionArea/Bottom의 사이즈를 측정하는 View입니다.
-        private var bottomActionSizeMeasurer: some View {
-            GeometryReader { proxy in
-                SwiftUI.Color.clear
-                    .onAppear {
-                        bottomActionHeight = proxy.size.height
-                    }
-                    .onChange(of: variant) { _ in
-                        bottomActionHeight = proxy.size.height
-                    }
-            }
-        }
 
         /// 무시할 SafeAreaEdge입니다.
         /// > ActionArea/Bottom이 존재하는 경우에 bottom SafeArea를 무시합니다.
@@ -720,22 +696,13 @@ extension Bar.TopNavigation {
             }
         }
 
-        /// ActionArea/Bottom의 sticky 속성을 결정하는 Property입니다.
-        /// > 기본적으로 스크롤이 컨텐츠의 끝(전체 컨텐츠 크기 - offset)에 도달했을 때 sticky를 사용하지 않습니다.
-        private var bottomActionSticky: Bool {
-            let contentHeightOffset: CGFloat = (model?.variant == .extra) ? 70 : 20
-            let totalContentHeight = innerContentSize.height + bottomActionHeight
-            let currentScrollOffset = containerSize.height + abs(scrollOffset)
-            return totalContentHeight - contentHeightOffset >= currentScrollOffset
-        }
-
         /// Scroll 영역이 가지는 bottom padding입니다.
         ///
         /// Scroll 영역이 ActionArea/Bottom에 가려지는것을 방지하기 위해 사용합니다.
         /// > ActionArea/Bottom과 함께 사용하는 경우에 ActionArea/Bottom의 variant에 의해 결정됩니다.
         private var scrollViewBottomPadding: CGFloat {
             if model != nil {
-                bottomActionHeight + (model?.variant == .extra ? +10 : .zero)
+                currentBottomActionHeight + (model?.variant == .extra ? +10 : .zero)
             } else {
                 .zero
             }
@@ -757,6 +724,8 @@ extension Bar.TopNavigation {
             self.backgroundColorResolvable = backgroundColorResolvable
             self.actions = actions
             self.model = model
+
+            isBottomActionAreaSticky = model != nil ? true : false
         }
         
         public func body(content: Content) -> some View {
@@ -788,6 +757,7 @@ extension Bar.TopNavigation {
                     OffsetPreferenceKey.self,
                     perform: {
                         scrollOffset = $0.y + (safeAreaInsets.top - navigationHeight)
+                        calculateSticky()
                     }
                 )
                 VStack(alignment: .leading, spacing: .zero) {
@@ -799,8 +769,10 @@ extension Bar.TopNavigation {
                         backgroundColorResolvable: backgroundColorResolvable,
                         actions: actions
                     )
-                    .background(
-                        navigationSizeMeasurer
+                    .onGeometryChange(
+                        for: CGSize.self,
+                        of: { $0.size },
+                        action: { navigationHeight = $0.height }
                     )
                     Spacer()
                 }
@@ -811,21 +783,49 @@ extension Bar.TopNavigation {
                             model: .init(
                                 variant: model.variant,
                                 priority: model.priority,
-                                sticky: bottomActionSticky,
+                                sticky: isBottomActionAreaSticky,
                                 caption: model.caption,
                                 extraContents: model.extraContents
                             )
                         )
-                        .animation(.easeInOut, value: bottomActionSticky)
-                        .background(
-                            bottomActionSizeMeasurer
+                        .onGeometryChange(
+                            for: CGFloat.self,
+                            of: { $0.size.height },
+                            action: {
+                                currentBottomActionHeight = $0
+                                originBottomActionHeight = $0
+                            }
                         )
+                        .onChange(
+                            of: isBottomActionAreaSticky,
+                            perform: { isSticky in
+                                currentBottomActionHeight += isSticky ? -20 : +20
+                            }
+                        )
+                        .animation(.easeInOut, value: isBottomActionAreaSticky)
                     }
                 }
             }
             .ignoresSafeArea(.container, edges: ignoreSafeAreaEdge)
             .onGeometryChange(for: CGSize.self, of: { $0.size }, action: { containerSize = $0 })
         }
+    }
+}
+
+extension Bar.TopNavigation.TopNavigationModifier {
+    /// 스크롤 offset에 따른 sticky 판단
+    /// > 기본적으로 스크롤이 컨텐츠의 끝(전체 컨텐츠 크기 - offset)에 도달했을 때 sticky를 사용하지 않습니다.
+    private func calculateSticky() {
+        // ActionArea의 추가 영역
+        let actionAreaExtraArea: CGFloat = (model?.variant == .extra) ? 70 : .zero
+        // 전체 컨텐츠 크기 (내부 컨텐츠 사이즈 + ActionArea + (스티키인 경우 gradient 영역))
+        let totalContentHeight = innerContentSize.height + originBottomActionHeight
+        // 계산하기 편리하게 처리된 현재 스크롤 Offset
+        let currentScrollOffsetForCalculate = containerSize.height + abs(scrollOffset.rounded())
+
+        let newValue = totalContentHeight - actionAreaExtraArea >= currentScrollOffsetForCalculate
+        guard isBottomActionAreaSticky != newValue else { return }
+        isBottomActionAreaSticky = newValue
     }
 }
 


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : https://wantedlab.atlassian.net/browse/PI-71550

### 📌 작업 완료 기한
- 2024/01/20

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
TopNavigation을 ActionArea/Bottom과 함께 사용하는 TopNavigationModifier를 사용하는 경우에 발생하는 이슈들을 해결했습니다.
* ActionArea/Bottom이 SafeArea를 무시한 채 display되어 디바이스 하단 home bar와 너무 가까운 이슈
  * ActionArea/Bottom.Component를 단독으로 사용하는 경우에는 발생하지 않았습니다.
  * <img width="300" alt="image" src="https://github.com/user-attachments/assets/e93c2403-2f8c-408f-9709-b9596f1ee19e" />
* ActionArea/Bottom이 Sticky임에도 불구하고 gradient가 노출되지 않는 현상
  * 마찬가지로 ActionArea/Bottom.Component를 단독으로 사용하는 경우에는 발생하지 않았습니다.
  * <img width="300" alt="image" src="https://github.com/user-attachments/assets/246a4b55-e7da-4dd6-9904-30b1599e2895" />



### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![바텀수정전](https://github.com/user-attachments/assets/61baec30-2ae3-4ff3-b5e0-f5722321427b)|![바텀수정후](https://github.com/user-attachments/assets/3762a98b-34ad-457b-8ef3-20bac85e394c)

### 참고영상

https://github.com/user-attachments/assets/df4feff8-8237-4b3c-87e6-7fbf875cb93c

# 확인사항
- [X] 동작 확인 
