### PR TITLE
fix: iOS 16.4 이하 버전에서 Model.Bottom이 FullScreen으로 뜨지 않도록 수정

### DIFF
--- a/Sources/Montage/3 Component/8 Presentation/Modal/Bottom/ModalBottom.swift
+++ b/Sources/Montage/3 Component/8 Presentation/Modal/Bottom/ModalBottom.swift
@@ -10,10 +10,6 @@ import SwiftUI
 extension Modal {
     /// Modal/Bottom Component입니다.
     ///
-    /// > iOS 15 이하에서는 BottomSheet 형태가 아닌 FullScreen 형태로 표시됩니다.
-    /// >
-    /// > iOS 16.4 이하에서는 handle이 표시되지 않습니다.
-    ///
     /// .sheet(isPresented:content:)와 함께 사용하며 content안쪽에 Component를 위치시킵니다.
     /// ```
     /// .sheet(
@@ -128,6 +124,8 @@ extension Modal {
                     }
                 }
                 .onGeometryChange(for: CGSize.self, of: { $0.size }, action: { contentSize = $0 })
+                .presentationDetents(detents)
+                .presentationDragIndicator(handle ? .visible : .hidden)
                 .padding(.bottom, -safeAreaInsets.bottom)
             }
         }


### PR DESCRIPTION
# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
**iOS 16.4 이하** 버전에서 `Model.Bottom`이 FullScreen으로 뜨는 이슈를 수정했습니다.
추가로 handle 표시도 iOS 16.4 이하에서도 가능해서 적용되도록 수정했습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 14 Pro - 2025-01-22 at 15 46 29](https://github.com/user-attachments/assets/e8fec5a9-ce31-49e1-abd1-7f7502d9ee95)|![Simulator Screenshot - iPhone 14 Pro - 2025-01-22 at 15 50 20](https://github.com/user-attachments/assets/2f7c13b1-39a6-4321-9008-056d1b75d4b1)

# 확인사항
- [x] 동작 확인 
