### PR TITLE
Modal/Bottom이 컨텐츠 크기보다 크게 표현되어 홈바와 ActionArea/Bottom 사이에 발생하는 여백제거

### DIFF
--- a/Sources/Montage/3 Component/8 Presentation/Modal/Bottom/ModalBottom.swift
+++ b/Sources/Montage/3 Component/8 Presentation/Modal/Bottom/ModalBottom.swift
@@ -60,9 +60,12 @@ extension Modal {
             if containScrollView {
                 [ .fraction(0.35), .medium, .max ]
             } else if handle {
-                [ .height(contentSize.height) ]
+                [ .height(max(.zero, contentSize.height - safeAreaInsets.bottom)) ]
             } else {
-                resize == .fill ? [ .max ] : [ .height(contentSize.height) ]
+                resize == .fill ? [ .max ] : [ .height(max(
+                    .zero,
+                    contentSize.height - safeAreaInsets.bottom
+                )) ]
             }
         }
 


### PR DESCRIPTION


# 개요

### 📌 작업 완료 기한
- 2024/01/22

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
* https://wantedlab.atlassian.net/browse/PI-71548 에서 발생한 Bottom Sheet의 하단 ActionArea와 iOS의 홈바 사이의 여백이 너무 큰 현상이 발생했습니다.
* 원인은 Bottom Sheet을 표현해야하는 크기(실제 전달받은 컨텐츠의 크기)보다 더 큰 크기로 표현하려다 보니 생긴 여백이였습니다.
* 컨텐츠가 가진 크기로만 표시될 수 있도록 수정하였습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![IMG_0263](https://github.com/user-attachments/assets/8f6b53c5-4241-4a02-9b25-836bd39e8a0c)|![image](https://github.com/user-attachments/assets/7ac28591-70ee-44fa-99f8-50d29b72db80)

# 확인사항
- [X] 동작 확인 
