### PR TITLE
fix: TextArea에서 placeholder가 여러 줄을 표시할 수 있도록 수정

### DIFF
--- a/Sources/Montage/3 Component/3 Selection And Input/Text/TextArea.swift
+++ b/Sources/Montage/3 Component/3 Selection And Input/Text/TextArea.swift
@@ -255,7 +255,6 @@ extension TextInput {
                                 variant: .body1Reading,
                                 color: placeholderTextColor
                             )
-                            .lineLimit(1)
                             .paragraph(variant: .body1Reading)
                             .background(disable ? SwiftUI.Color.alias(.interactionDisable) : .clear)
                             .allowsHitTesting(false)


### PR DESCRIPTION
# 개요
- 🎨  디자인 링크 : 

### 📌 작업 완료 기한
- 2024/01/01

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
**TextArea**에서 placeholder에 `.lineLimit(1)` 이 적용되어 있었는데, 이를 제거해서 여러 줄의 placeholder가 표시되도록 수정했습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 16 Plus - 2025-02-21 at 13 26 43](https://github.com/user-attachments/assets/6319527c-297f-4b45-ac33-63e538252815)|![Simulator Screenshot - iPhone 16 Plus - 2025-02-21 at 13 25 46](https://github.com/user-attachments/assets/99213297-1256-4dcc-97b8-294a2dfa952b)


# 확인사항
- [x] 동작 확인 
