### PR TITLE
fix: Avatar에서 이미지 비율이 맞지 않는 이슈 수정

### DIFF
--- a/Sources/Montage/3 Component/4 Contents/Avatar/Avatar.swift
+++ b/Sources/Montage/3 Component/4 Contents/Avatar/Avatar.swift
@@ -98,7 +98,7 @@ public struct Avatar: View {
     public var body: some View {
         WebImage(url: URL(string: imageUrl)) { image in
             image.resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
                 .backgroundStyle(SwiftUI.Color.semantic(.staticWhite))
         } placeholder: {
             Image(variant.placeholderImageName, bundle: .module)


### PR DESCRIPTION
### 📌 작업 완료 기한
- 2024/03/27

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
Avatar의 이미지 비율 이슈를 수정했습니다.

### 미리보기
📱|작업 전|작업 후
---|---|---
iPhone|![Simulator Screenshot - iPhone 16 Pro - 2025-03-27 at 10 58 56](https://github.com/user-attachments/assets/b9adc146-d578-4cb8-8384-ab92f1258207)|![Simulator Screenshot - iPhone 16 Pro - 2025-03-27 at 11 00 04](https://github.com/user-attachments/assets/b75ca418-2565-4715-980e-45e042e00c8a)


# 확인사항
- [x] 동작 확인 
