### PR TITLE
iOS 16.4 및 17에서 버튼 액션 동작하지 않는 문제

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,24 @@
         "revision" : "d5053acbffff52628576c40138d7719953d9a0b9",
         "version" : "0.5.0"
       }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "cac9a55a3ae92478a2c95042dcc8d9695d2129ca",
+        "version" : "5.21.0"
+      }
+    },
+    {
+      "identity" : "sdwebimageswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI.git",
+      "state" : {
+        "revision" : "451c6dfd5ecec2cf626d1d9ca81c2d4a60355172",
+        "version" : "3.1.3"
+      }
     }
   ],
   "version" : 2

--- a/Sources/Montage/3 Component/2 Actions/Button/Button.swift
+++ b/Sources/Montage/3 Component/2 Actions/Button/Button.swift
@@ -278,18 +278,9 @@ public struct Button: View {
             .padding(.vertical, -interactionVerticalOffset)
             .padding(.horizontal, -interactionHorizontalOffset)
         }
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { value in
-                    isPressed = value.translation == .zero
-                }
-                .onEnded { _ in
-                    isPressed = false
-                }
-        )
-        .onTapGesture {
+        .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
             handler?()
-        }
+        })
         .allowsHitTesting(disable == false)
     }
 }

--- a/Sources/Montage/3 Component/2 Actions/Button/IconButton.swift
+++ b/Sources/Montage/3 Component/2 Actions/Button/IconButton.swift
@@ -169,23 +169,14 @@ public struct IconButton: View {
                         .stroke(_strokeColor, lineWidth: variant.borderWidth)
                 }
             )
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { value in
-                        isPressed = value.translation == .zero
-                    }
-                    .onEnded { _ in
-                        isPressed = false
-                    }
-            )
-            .onTapGesture {
-                handler?()
-            }
             .frame(
                 width: variant.iconSize.width + variant.backgroundOffset + padding,
                 height: variant.iconSize.height + variant.backgroundOffset + padding
             )
             .allowsHitTesting(disable == false)
+            .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
+                handler?()
+            })
     }
 }
 

--- a/Sources/Montage/3 Component/3 Selection And Input/Control/Control.swift
+++ b/Sources/Montage/3 Component/3 Selection And Input/Control/Control.swift
@@ -157,21 +157,12 @@ public struct Control: View {
             .clipShape(Circle())
             .frame(width: interactionSize.width, height: interactionSize.height)
         }
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { value in
-                    isPressed = value.translation == .zero
-                }
-                .onEnded { _ in
-                    isPressed = false
-                }
-        )
-        .onTapGesture {
+        .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
             let newState: State = state.isUnchecked ? .checked : .unchecked
             stateBinding?.wrappedValue = newState
             checkedBinding?.wrappedValue = state.isUnchecked
             onSelect?(newState)
-        }
+        })
         .disabled(disable)
     }
     

--- a/Sources/Montage/3 Component/3 Selection And Input/Text/TextField.swift
+++ b/Sources/Montage/3 Component/3 Selection And Input/Text/TextField.swift
@@ -478,18 +478,9 @@ private extension TextInput.TextField {
                         color: .labelNormal
                     )
                 )
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { value in
-                            isPressed = value.translation == .zero
-                        }
-                        .onEnded { _ in
-                            isPressed = false
-                        }
-                )
-                .onTapGesture {
+                .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
                     handler?()
-                }
+                })
         }
         
         var textColor: Color.Semantic {

--- a/Sources/Montage/3 Component/4 Contents/Accordion/Accordion.swift
+++ b/Sources/Montage/3 Component/4 Contents/Accordion/Accordion.swift
@@ -177,20 +177,11 @@ public struct Accordion: View {
                     fillWidth: fillWidth,
                     interactionPadding: 12
                 ))
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { value in
-                            isPressed = value.translation == .zero
-                        }
-                        .onEnded { value in
-                            isPressed = false
-                            if value.translation == .zero {
-                                withAnimation(.timingCurve(0.25, 0.1, 0.25, 1, duration: 0.3)) {
-                                    isExpanded.toggle()
-                                }
-                            }
-                        }
-                )
+                .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
+                    withAnimation(.timingCurve(0.25, 0.1, 0.25, 1, duration: 0.3)) {
+                        isExpanded.toggle()
+                    }
+                })
                 
                 if isExpanded {
                     VStack(alignment: .leading, spacing: 0) {

--- a/Sources/Montage/3 Component/4 Contents/Avatar/Avatar.swift
+++ b/Sources/Montage/3 Component/4 Contents/Avatar/Avatar.swift
@@ -125,18 +125,9 @@ public struct Avatar: View {
                 .clipShape(RoundedRectangle(cornerRadius: variant.interactionCornerRadius(size: size)))
             }
         }
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { value in
-                    isPressed = value.translation == .zero
-                }
-                .onEnded { _ in
-                    isPressed = false
-                }
-        )
-        .onTapGesture {
+        .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
             onTap?()
-        }
+        })
     }
     
     private var pushBadge = false

--- a/Sources/Montage/3 Component/4 Contents/Cell/Cell.swift
+++ b/Sources/Montage/3 Component/4 Contents/Cell/Cell.swift
@@ -133,18 +133,9 @@ public struct Cell: View {
         ))
         .contentShape(Rectangle())
         .allowsHitTesting(disable == false)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { value in
-                    isPressed = value.translation == .zero
-                }
-                .onEnded { _ in
-                    isPressed = false
-                }
-        )
-        .onTapGesture {
+        .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
             onTap?()
-        }
+        })
     }
     
     // MARK: - Modifiers

--- a/Sources/Montage/3 Component/7 Feedback/SnackBar/SnackBar.swift
+++ b/Sources/Montage/3 Component/7 Feedback/SnackBar/SnackBar.swift
@@ -160,18 +160,9 @@ public struct SnackBar: View {
                     .padding(.horizontal, -7)
                     .padding(.vertical, -4)
                 )
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { value in
-                            isPressed = value.translation == .zero
-                        }
-                        .onEnded { _ in
-                            isPressed = false
-                        }
-                )
-                .onTapGesture {
+                .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
                     handler?()
-                }
+                })
         }
     }
     

--- a/Sources/Montage/Common/Intrenal/PressActionDetectingModifier.swift
+++ b/Sources/Montage/Common/Intrenal/PressActionDetectingModifier.swift
@@ -1,0 +1,70 @@
+//
+//  PressActionDetectingModifier.swift
+//  Views
+//
+//  Created by 김삼열 on 3/31/25.
+//  Copyright © 2025 WantedLab Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct PressActionDetectingModifier: ViewModifier {
+    @Binding var isPressed: Bool
+    private let action: () -> Void
+    
+    init(isPressed: Binding<Bool>, action: @escaping () -> Void) {
+        self._isPressed = isPressed
+        self.action = action
+    }
+    
+    func body(content: Content) -> some View {
+        /// pressed 상태를 감지하는 방법을 변경할 때는 다음 사항을 테스트해야 한다.
+        /// 1. 버튼의 액션이 잘 동작하는가?
+        /// 2. 버튼을 빠르게 눌렀을 때 버튼의 외관이 잘 변경되는가?
+        /// 3. 버튼이 스크롤뷰에 올라가 있을 때 버튼위에서 스크롤을 시작하면 스크롤이 되는가?
+        /// 4. 버튼 아래에 다른 버튼이 있을 때 불필요하게 아래 버튼으로 제스처가 전달되지는 않는가?
+        ///
+        /// 이 기준으로 판단했을 때 simultaneousGesture를 사용하는 것이 가장 모든 조건을 완벽하게 만족하는 방법이다.
+        /// 하지만 iOS 17 이하에서는 이 방법을 사용할 경우 1, 3번 조건을 만족하지 못한다.
+        /// 이에 대안을 찾고자 ButtonStyle을 사용하는 방법을 사용했다. 이 방법은 2번 조건을 만족하지 못하지만
+        /// 천천히 눌렀을 때는 버튼의 외관이 잘 변경되고 빠르게 눌렀을 때만 안되는 것이기에 크리티컬하지는 않다고 판단하여 이렇게 구현했다.
+        
+        if #available(iOS 18.0, *) {
+            content
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            isPressed = value.translation == .zero
+                        }
+                        .onEnded { _ in
+                            isPressed = false
+                        }
+                )
+                .onTapGesture {
+                    action()
+                }
+        } else {
+            SwiftUI.Button {
+                action()
+            } label: {
+                content
+            }
+            .buttonStyle(PressDetectingButtonStyle(isPressed: $isPressed))
+        }
+    }
+    
+    struct PressDetectingButtonStyle: ButtonStyle {
+        @Binding var isPressed: Bool
+        
+        init(isPressed: Binding<Bool> = .constant(false)) {
+            self._isPressed = isPressed
+        }
+        
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .onChange(of: configuration.isPressed) { newValue in
+                    isPressed = newValue
+                }
+        }
+    }
+}


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-74329

### 📌 작업 완료 기한
- 2025/03/31

# 수정사항

## 수정 내용
- 이슈 영향범위: iOS 17에서도 탭 인터랙션(press 효과)을 표시하는 아래 모든 컴포넌트에 동일한 문제가 있음
  - Button
  - IconButton
  - Cell
  - Accordion
  - Control
  - TextField(TrailingButton)
  - Avatar
  - SnackBar
- 원인: simultaneousGesture의 동작이 iOS 18과 그 이전 사이의 차이가 있어서 발생한 문제
- 해결방법
  - 지금으로서는 완벽한 해결책은 발견하지 못함
  - 대안으로 17이하에서는 예전에 상훈님이 구현해주셨던 ButtonStyle을 활용하는 방안을 활용하기로 함.
  - 그렇게 했을 때 문제점은 17 이하에서는 위에서 언급한 컴포넌트들을 빠르게 클릭할 경우 인터랙션 효과가 나타나지 않는다는 것인데 이는 크리티컬하지는 않다고 생각됨. 

# 확인사항
- [x] 동작 확인 
