### PR TITLE
스크롤 뷰 성능 개선 및 simultaneousGesture 이슈 수정

### DIFF
--- a/Sources/Montage/3 Component/3 Selection And Input/Slider/Slider.swift
+++ b/Sources/Montage/3 Component/3 Selection And Input/Slider/Slider.swift
@@ -94,7 +94,7 @@ public struct Slider: View {
                 )
                 .zIndex(focusedThumb == 1 ? 1 : 0)
                 .offset(x: max(0, lineLength * thumbRatio1))
-                .gesture(
+                .simultaneousGesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged {
                             thumbRatio1 = thumbRatio(from: $0.location.x)
@@ -112,7 +112,7 @@ public struct Slider: View {
                 )
                 .zIndex(focusedThumb == 2 ? 1 : 0)
                 .offset(x: max(0, lineLength * thumbRatio2))
-                .gesture(
+                .simultaneousGesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged {
                             thumbRatio2 = thumbRatio(from: $0.location.x)

--- a/Sources/Montage/3 Component/5 Loading/PullToRefreshModifier.swift
+++ b/Sources/Montage/3 Component/5 Loading/PullToRefreshModifier.swift
@@ -8,6 +8,7 @@
 import Lottie
 import SwiftUI
 
+@available(iOS 18, *)
 public struct PullToRefreshModifier: ViewModifier {
     @Binding private var scrollYOffset: CGFloat
     private let refresh: () async -> Void
@@ -65,7 +66,7 @@ public struct PullToRefreshModifier: ViewModifier {
                 content
             }
             .simultaneousGesture(
-                DragGesture(minimumDistance: 0, coordinateSpace: .local)
+                DragGesture(minimumDistance: 1)
                     .onChanged { _ in
                         isScrolling = true
                         

--- a/Sources/Montage/Common/Intrenal/ScrollView.swift
+++ b/Sources/Montage/Common/Intrenal/ScrollView.swift
@@ -9,25 +9,23 @@ import SwiftUI
 
 public struct ScrollView: View {
     // MARK: - Initializer
-    @Binding private var scrollStatus: ScrollStatus
+    private var externalScrollStatus: Binding<ScrollStatus>?
     private let onOffsetChanged: (CGPoint) -> Void
     private let content: () -> any View
 
     public init(
-        scrollStatus: Binding<ScrollStatus> = .constant(.init()),
+        scrollStatus: Binding<ScrollStatus>? = nil,
         onOffsetChanged: @escaping (CGPoint) -> Void = { _ in },
         @ViewBuilder content: @escaping () -> any View
     ) {
         self.onOffsetChanged = onOffsetChanged
-        _scrollStatus = scrollStatus
+        externalScrollStatus = scrollStatus
         self.content = content
     }
 
     // MARK: - Body
-
-    @State private var scrollViewSize: CGSize = .zero
-    @State private var contentSize: CGSize = .zero
-    @State private var contentOffset: CGPoint = .zero
+    
+    @State private var defaultScrollStatus = ScrollStatus()
 
     public var body: some View {
         SwiftUI.ScrollView(axisSet, showsIndicators: !hidesIndicators) {
@@ -42,29 +40,24 @@ public struct ScrollView: View {
                 VStack {
                     AnyView(content())
                 }
+                .onGeometryChange(for: CGSize.self, of: { $0.size }, for: .milliseconds(100), action: {
+                    scrollStatus.wrappedValue.contentSize = $0
+                })
             }
-            .onGeometryChange(for: CGSize.self, of: { $0.size }, for: .milliseconds(100), action: {
-                contentSize = $0
-            })
         }
         .onGeometryChange(for: CGSize.self, of: { $0.size }, for: .milliseconds(100), action: {
-            scrollViewSize = $0
+            scrollStatus.wrappedValue.scrollViewSize = $0
         })
         .coordinateSpace(name: "ScrollViewOrigin")
-        .onChange(of: "\(axis)\(contentSize)\(scrollViewSize)\(contentOffset)") { _ in
-            scrollStatus = .init(
-                axis: axis,
-                scrollViewSize: scrollViewSize,
-                contentSize: contentSize,
-                contentOffset: contentOffset
-            )
+        .onChange(of: axis) {
+            scrollStatus.wrappedValue.axis = $0
         }
         .onPreferenceChange(OffsetPreferenceKey.self) {
-            contentOffset = $0
+            scrollStatus.wrappedValue.contentOffset = $0
             onOffsetChanged($0)
         }
         .if(onRefresh != nil) {
-            $0.pullToRefresh(scrollYOffset: $contentOffset.y) {
+            $0.pullToRefresh(scrollYOffset: scrollStatus.contentOffset.y) {
                 await onRefresh?()
             }
         }
@@ -95,10 +88,10 @@ public struct ScrollView: View {
 
     // MARK: - Types
 
-    public struct ScrollStatus {
-        public let axis: Axis
-        public let scrollViewSize: CGSize
-        public let contentSize: CGSize
+    public struct ScrollStatus: Equatable {
+        public var axis: Axis
+        public var scrollViewSize: CGSize
+        public var contentSize: CGSize
         public var contentOffset: CGPoint
 
         public init(
@@ -129,5 +122,9 @@ private extension ScrollView {
         case .horizontal: .horizontal
         case .vertical: .vertical
         }
+    }
+    
+    var scrollStatus: Binding<ScrollStatus> {
+        externalScrollStatus ?? $defaultScrollStatus
     }
 }

--- a/Sources/Montage/Common/Intrenal/ScrollView.swift
+++ b/Sources/Montage/Common/Intrenal/ScrollView.swift
@@ -57,8 +57,14 @@ public struct ScrollView: View {
             onOffsetChanged($0)
         }
         .if(onRefresh != nil) {
-            $0.pullToRefresh(scrollYOffset: scrollStatus.contentOffset.y) {
-                await onRefresh?()
+            if #available(iOS 18, *) {
+            	$0.pullToRefresh(scrollYOffset: scrollStatus.contentOffset.y) {
+                    await onRefresh?()
+                }
+            } else {
+                $0.refreshable {
+                    await onRefresh?()
+                }
             }
         }
     }

--- a/Sources/Montage/Extension/SwiftUI/View+Montage.swift
+++ b/Sources/Montage/Extension/SwiftUI/View+Montage.swift
@@ -266,6 +266,7 @@ extension View {
 // MARK: Pull To Refresh
 
 extension View {
+    @available(iOS 18, *)
     public func pullToRefresh(
         scrollYOffset: Binding<CGFloat>,
         refresh: @escaping () async -> Void


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-74225
- Slack 링크 : https://wantedx.slack.com/archives/C0136G84N87/p1743505360976579

### 📌 작업 완료 기한
- 2025/04/04

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대한 설명을 작성합니다. -->
- 스크롤 뷰 성능 개선
- simultaneousGesture 이슈 수정
  - Slider: iOS 17에서 Slider의 thumb이 움직이지 않음 -> thumb의 인터랙션을 위한 제스쳐와 슬라이딩을 위한 제스쳐를 모두 simultaneousGesture로 사용하여 해결. 스크롤뷰에 슬라이더를 올렷을 때는 thumb 위에서 스크롤이 안되는 문제가 발생할 수 있으나 thumb이 워낙 작기 때문에 큰 문제는 안될 듯
  - PullToRefrechModifier: Montage.ScrollView에 onRefresh()를 사용하는 경우 활성화되고 있어서 이 경우 iOS 17 에서 스크롤이 안되는 문제를 일으킴 -> iOS 17이하에서는 시스템의 refreshable로 대체
  - PressActionDetectingModifier: 버튼, 셀 등의 인터랙션에 사용되지만 OS에 따라 분기하고 있어서 문제없음

# 확인사항
- [x] 동작 확인 
