### PR TITLE
fix: NormalCard 오버레이 캡션과 아이콘 간격 오류 수정

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Preview/NormalCardPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/NormalCardPreview.swift
@@ -59,7 +59,7 @@ struct NormalCardPreview: View {
                     } : nil)
                     .if(showOverlayCaption || showOverlayButton) {
                         $0.overlay(
-                            caption: showOverlayCaption ? "오버레이캡션" : nil,
+                            caption: showOverlayCaption ? "합격보상금 100만원" : nil,
                             buttonIcon: showOverlayButton ? (bookmarkIsOn ? .bookmarkFill : .bookmark) : nil,
                             buttonColor: bookmarkIsOn ? .semantic(.primaryNormal) : .semantic(.staticWhite),
                             onTapButton: showOverlayButton ? { bookmarkIsOn.toggle() } : nil

--- a/Sources/Montage/1 Components/4 Contents/NormalCard.swift
+++ b/Sources/Montage/1 Components/4 Contents/NormalCard.swift
@@ -257,28 +257,24 @@ extension NormalCard {
                 .if(!caption.isNilOrEmpty || buttonIcon != nil) {
                     $0.overlay(alignment: .top) {
                         ZStack {
-                            HStack(alignment: .top, spacing: 4) {
+                            HStack(alignment: .top, spacing: 0) {
                                 if let caption {
-                                    HStack(spacing: 0) {
-                                        Text(caption)
-                                            .typography(variant: .caption2, weight: .bold, semantic: .staticWhite)
-                                            .paragraph(variant: .caption2)
-                                        Spacer(minLength: 0)
-                                    }
-                                    .padding(.bottom, 6)
+                                    Text(caption)
+                                        .typography(variant: .caption2, weight: .bold, semantic: .staticWhite)
+                                        .paragraph(variant: .caption2)
+                                        .padding(.bottom, 6)
                                 }
                                 
+                                Spacer(minLength: 4)
+                                
                                 if let buttonIcon {
-                                    HStack(spacing: 0) {
-                                        Spacer(minLength: 0)
-                                        Montage.IconButton(
-                                            variant: .normal(size: 20),
-                                            icon: buttonIcon
-                                        ) {
-                                            onTapButton?()
-                                        }
-                                        .iconColor(buttonColor)
+                                    Montage.IconButton(
+                                        variant: .normal(size: 20),
+                                        icon: buttonIcon
+                                    ) {
+                                        onTapButton?()
                                     }
+                                    .iconColor(buttonColor)
                                 }
                             }
                             .padding(.all, 10)


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-77141

# 수정사항

# 미리보기
작업 전|작업 후
---|---
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-16 at 15 43 21" src="https://github.com/user-attachments/assets/15aff117-489a-463b-a983-feb9654b8dde" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-16 at 15 44 51" src="https://github.com/user-attachments/assets/6b4b186b-51bc-4c02-a8c0-2abbb34b379e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 오버레이 캡션 텍스트가 "오버레이캡션"에서 "합격보상금 100만원"으로 변경되었습니다.
  * 오버레이 내 요소 간의 간격 및 정렬이 개선되어 레이아웃이 더욱 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->