### PR TITLE
fix: 아이콘 싱크 타겟 브랜치 변경

### DIFF
--- a/.github/workflows/figma-icon-sync.yml
+++ b/.github/workflows/figma-icon-sync.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync:
-    uses: wanteddev/wds/.github/workflows/figma-icon-sync.yml@feature/figma-icon-sync-fix
+    uses: wanteddev/wds/.github/workflows/figma-icon-sync.yml@main
     with:
       platform: ios
       pr_name: 'feat: add icons synced from figma'


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-77220

# 수정사항
wds 레포의 resuable workflow 를 바라보고 있는 타겟 브랜치를 main으로 변경합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Figma 아이콘 동기화 워크플로우가 최신 메인 브랜치를 사용하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->