### PR TITLE
feat: figma icon sync 파싱 스크립트 주체를 montage-ios로 변경

### DIFF
--- a/.github/workflows/figma-icon-sync.yml
+++ b/.github/workflows/figma-icon-sync.yml
@@ -12,6 +12,48 @@ jobs:
   sync:
     uses: wanteddev/wds/.github/workflows/figma-icon-sync.yml@main
     with:
-      platform: ios
-      pr_name: 'feat: add icons synced from figma'
+      output_dir: output
     secrets: inherit
+
+  parse:
+    runs-on: ubuntu-latest
+    needs: sync
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Restore cache
+        uses: actions/cache/restore@v4
+        with:
+          path: output
+          key: ${{ needs.sync.outputs.figma-output-cache-key }}
+
+      - name: Node.js install
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: node icon_sync.js
+
+      - run: git config user.name "github-actions[bot]"
+      - run: git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create Branch And Commit
+        run: |
+          git branch feature/code-connect/${{ github.run_id }}
+          git checkout feature/code-connect/${{ github.run_id }}
+          git add .
+          git commit -m "feat: add icons synced from figma" --no-verify
+          git push origin feature/code-connect/${{ github.run_id }}
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Create New PR
+        run: |
+          gh pr create -B ${{ steps.extract_branch.outputs.branch }} -H feature/code-connect/${{ github.run_id }} --title "feat: add icons synced from figma" --body "add icons synced from figma"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/icon_sync.js
+++ b/icon_sync.js
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const path = require('path');
+
+const outputDir = './output';
+const iconAssetsDir = './Sources/Montage/Asset/Icon.xcassets';
+const swiftFilePath = './Sources/Montage/0 Foundations/Icon.swift';
+
+const main = async () => {
+  const outputs = fs.readdirSync(outputDir);
+
+  const icons = outputs.filter((filename) => filename.endsWith('.svg'));
+
+  // clean up start
+  const iconAssets = fs
+    .readdirSync('./Sources/Montage/Asset/Icon.xcassets', 'utf8')
+    .filter((iconAsset) => iconAsset.endsWith('.imageset'));
+
+  iconAssets.forEach((iconAsset) => {
+    const iconAssetPath = path.join('./Sources/Montage/Asset/Icon.xcassets', iconAsset);
+
+    if (fs.existsSync(iconAssetPath)) {
+      fs.rmdirSync(iconAssetPath, { recursive: true, force: true });
+    }
+  });
+  // clean up end
+
+  // sync files start
+  outputs
+    .filter((filename) => filename.endsWith('.svg'))
+    .forEach((filename) => {
+      const iconName = filename.replace(/\.svg$/, '');
+
+      const svgContent = fs.readFileSync(path.join(outputDir, filename), 'utf8');
+
+      fs.mkdirSync(path.join(iconAssetsDir, `${iconName}.imageset`));
+
+      fs.writeFileSync(
+        path.join(iconAssetsDir, `${iconName}.imageset`, 'Contents.json'),
+        JSON.stringify(
+          {
+            images: [
+              {
+                filename: `${iconName}.svg`,
+                idiom: 'universal'
+              }
+            ],
+            info: {
+              author: 'xcode',
+              version: 1
+            },
+            properties: {
+              'preserves-vector-representation': true,
+              'template-rendering-intent': 'template'
+            }
+          },
+          null,
+          2
+        ).replaceAll('":', '" :')
+      );
+
+      fs.writeFileSync(
+        path.join(iconAssetsDir, `${iconName}.imageset`, `${iconName}.svg`),
+        svgContent
+          .replaceAll('width="24"', '')
+          .replaceAll('height="24"', '')
+          .replaceAll('width="12"', '')
+          .replaceAll('height="12"', '')
+          .replaceAll('fill="none"', '')
+          .replaceAll('fill="#171719"', '')
+      );
+    });
+
+  // sync files end
+
+  // swift file update start
+  let swiftFileContent = fs.readFileSync(swiftFilePath, 'utf8');
+
+  const enumCases = icons
+    .sort()
+    .map((iconAsset) => `    case ${iconAsset.replace(/\.svg$/, '')}`)
+    .join('\n');
+
+  // Icon enum의 case 선언들만 정확히 찾아 대체하고, 다른 멤버(주석, 프로퍼티 등)는 유지합니다.
+  swiftFileContent = swiftFileContent.replace(
+    /(\n\s*public enum Icon: String, CaseIterable\s*\{\s*\n)([\s\S]*?)(\n\s*(?:\/\/[^\n]*|\w+[^\n]*)\n\s*\})/,
+    (match, enumStart, existingCases, enumEnd) => {
+      // 기존 케이스들 중에서 실제 case 선언만 필터링 (주석 등 제외)
+      const oldCases = existingCases
+        .split('\n')
+        .filter((line) => line.trim().startsWith('case '))
+        .join('\n');
+      // 새로운 케이스 목록과 기존 케이스 목록이 다를 경우에만 업데이트
+      if (
+        oldCases !==
+        enumCases
+          .split('\n')
+          .map((c) => c.trim())
+          .join('\n')
+      ) {
+        return `${enumStart}${enumCases}\n${enumEnd}`;
+      }
+      // 케이스가 동일하면 원본 유지
+      return match;
+    }
+  );
+
+  fs.writeFileSync(swiftFilePath, swiftFileContent, 'utf-8');
+  // swift file update end
+
+  // remove output directory
+  fs.rmdirSync(outputDir, { recursive: true, force: true });
+
+  console.log('DONE!');
+};
+
+main();


### PR DESCRIPTION
# 개요
- Jira 링크 : 

# 수정사항

기존에는 wds repository github action에서 Figma icon sync 작업과 파싱 스크립트를 동시에 처리했으나
스크립트 수정시에 타 플랫폼 개발자분이 wds repositiory 액션을 수정해야하는 번거로움이 있으므로
wds repository에서는 icon sync 작업만 진행하고 파싱 및 PR 생성하는 부분을 montage-ios에서 처리하도록 변경합니다.


`sync` 액션과 `parse` 액션으로 나누어서 실행됩니다.

`sync` 액션은 `wanteddev/wds/.github/workflows/figma-icon-sync.yml@main` github action을 실행하여
`output_dir` 에 해당하는 디렉토리에 모든 .svg 파일이 저장됩니다.

또한 result.json도 아래와 같은 형태로 저장됩니다. 

```json
[{ "id": "(FIGMA NODE ID)", "name": "closeThick" }]
``` 

`parse` 액션에서는 파싱 처리 및 PR 생성을 담당합니다.

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SVG 아이콘 파일과 Xcode 에셋 카탈로그, Swift enum 동기화를 자동화하는 기능이 추가되었습니다.

* **Chores**
  * GitHub Actions 워크플로우에 아이콘 동기화 및 PR 자동 생성을 위한 작업이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->