### PR TITLE
fix: Input 텍스트가 멀티라인일 때 부모 뷰의 너비가 큰 경우 Control과 텍스트 사이가 멀어지는 이슈

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Preview/InputPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/InputPreview.swift
@@ -36,7 +36,7 @@ public struct InputPreview: View {
                     Text("guide line").font(.caption)
                     Switch($guideLine)
                 }
-                HStack {
+                VStack {
                     Group {
                         Input.checkbox(
                             state: state,

--- a/Sources/Montage/1 Components/3 Selection And Input/Input.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Input.swift
@@ -221,7 +221,9 @@ public struct Input: View {
                     )
                     .paragraph(variant: titleTypography.variant)
                     .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, size == .medium ? 1 : 0)
+                    .contentShape(Rectangle())
                     .onTapGesture {
                         guard isDisable == false else { return }
                         stateBinding?.wrappedValue = state.isUnchecked ? .checked : .unchecked


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-77768

# 수정사항

# 미리보기
작업 전|작업 후
---|---
<img width="1206" height="2622" alt="1 InputPreview" src="https://github.com/user-attachments/assets/f9d6aa42-43b4-4f2c-a958-06c23b8576bc" />|<img width="1206" height="2622" alt="1 InputPreview" src="https://github.com/user-attachments/assets/e04f5b22-6a7f-45bc-b2f0-2cc13b8bc3ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **스타일**
  * 입력 컨트롤 그룹의 배열이 가로에서 세로로 변경되었습니다.
  * 체크박스 텍스트 라벨이 왼쪽 정렬로 확장되고, 전체 영역이 터치 가능하도록 개선되었습니다.

* **신규 기능**
  * 한국어 라벨과 맞춤 스타일이 적용된 체크박스 프리뷰가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->