### PR TITLE
Toast의 Negative 상태의 디자인 변경

### DIFF
--- a/Sources/Montage/1 Components/7 Feedback/Toast.swift
+++ b/Sources/Montage/1 Components/7 Feedback/Toast.swift
@@ -53,7 +53,7 @@ public struct Toast: View {
         private let id = UUID()
         let variant: Toast.Variant
         let message: String
-        
+
         /// Toast 모델을 초기화합니다.
         ///
         /// - Parameters:
@@ -75,28 +75,28 @@ public struct Toast: View {
         ///   - icon: 표시할 아이콘 (선택 사항)
         ///   - tint: 아이콘의 색상 (선택 사항)
         case normal(Montage.Icon? = nil, tint: Montage.Color.Semantic? = nil)
-        
+
         /// 성공 메시지를 위한 녹색 체크 아이콘 스타일
         case positive
-        
+
         /// 주의 메시지를 위한 주황색 경고 아이콘 스타일
         case cautionary
-        
+
         /// 오류 메시지를 위한 빨간색 경고 아이콘 스타일
         case negative
     }
-    
+
     /// 토스트 메시지가 표시될 위치를 정의하는 열거형입니다.
     public enum Location {
         /// 화면 상단에 토스트 표시
         /// - Parameter offset: 상단에서의 오프셋 값 (기본값: 0)
         case top(offset: CGFloat = .zero)
-        
+
         /// 화면 하단에 토스트 표시
         /// - Parameter offset: 하단에서의 오프셋 값 (기본값: 0)
         case bottom(offset: CGFloat = .zero)
     }
-    
+
     /// 토스트 메시지의 표시 시간을 정의하는 열거형입니다.
     public enum Duration {
         /// 짧은 표시 시간 (3초)
@@ -104,11 +104,11 @@ public struct Toast: View {
         /// 긴 표시 시간 (5초)
         case long
     }
-    
+
     private let variant: Variant
     private let message: String
     private let location: Location
-    
+
     init(
         _ variant: Variant = .normal(),
         message: String = "",
@@ -118,7 +118,7 @@ public struct Toast: View {
         self.message = message
         self.location = location
     }
-    
+
     public var body: some View {
         switch location {
         case .top(let offset):
@@ -137,16 +137,16 @@ public struct Toast: View {
             }
         }
     }
-    
+
     fileprivate struct Contents: View {
         private let variant: Variant
         private let message: String
-        
+
         init(_ variant: Variant, _ message: String) {
             self.variant = variant
             self.message = message
         }
-        
+
         var body: some View {
             ZStack(alignment: .leading) {
                 HStack(alignment: .center, spacing: 8) {
@@ -167,14 +167,14 @@ public struct Toast: View {
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
     }
-    
+
     private struct Icon: View {
         private let variant: Variant
-        
+
         init(_ variant: Variant) {
             self.variant = variant
         }
-        
+
         var body: some View {
             switch variant {
             case let .normal(icon, tint):
@@ -194,35 +194,23 @@ public struct Toast: View {
                     EmptyView()
                 }
             case .positive:
-                ZStack {
-                    Circle()
-                        .foregroundStyle(SwiftUI.Color.semantic(.staticWhite))
-                        .frame(width: 11, height: 11)
-                    Image.icon(.circleCheckFill)
-                        .resizable()
-                        .foregroundStyle(SwiftUI.Color.atomic(.green60))
-                        .frame(width: 22, height: 22)
-                }
+                badgedIcon(.circleCheckFill, .green60)
             case .cautionary:
-                ZStack {
-                    Circle()
-                        .foregroundStyle(SwiftUI.Color.semantic(.staticWhite))
-                        .frame(width: 11, height: 11)
-                    Image.icon(.triangleExclamationFill)
-                        .resizable()
-                        .foregroundStyle(SwiftUI.Color.atomic(.orange60))
-                        .frame(width: 22, height: 22)
-                }
+                badgedIcon(.triangleExclamationFill, .orange60)
             case .negative:
-                ZStack {
-                    Circle()
-                        .foregroundStyle(SwiftUI.Color.semantic(.staticWhite))
-                        .frame(width: 11, height: 11)
-                    Image.icon(.circleCloseFill)
-                        .resizable()
-                        .foregroundStyle(SwiftUI.Color.atomic(.red60))
-                        .frame(width: 22, height: 22)
-                }
+                badgedIcon(.circleCloseFill, .red60)
+            }
+        }
+
+        private func badgedIcon(_ icon: Montage.Icon, _ color: Color.Atomic) -> some View {
+            ZStack {
+                Circle()
+                    .foregroundStyle(SwiftUI.Color.semantic(.staticWhite))
+                    .frame(width: 11, height: 11)
+                Image.icon(icon)
+                    .resizable()
+                    .foregroundStyle(SwiftUI.Color.atomic(color))
+                    .frame(width: 22, height: 22)
             }
         }
     }
@@ -232,7 +220,8 @@ public struct Toast: View {
 
         var body: some View {
             ZStack {
-                SwiftUI.Color.semantic(.inverseBackground).opacity(colorScheme == .light ? 0.5 : 0.46)
+                SwiftUI.Color.semantic(.inverseBackground).opacity(
+                    colorScheme == .light ? 0.5 : 0.46)
                 SwiftUI.Color.semantic(.primaryNormal).opacity(0.05)
             }
             .background(
@@ -275,7 +264,7 @@ extension Toast {
         @Binding private var model: Toast.Model?
         private let location: Toast.Location
         private let duration: Toast.Duration
-        
+
         /// ToastModifier를 초기화합니다.
         ///
         /// - Parameters:
@@ -319,7 +308,7 @@ extension Toast {
                     }
                 }
         }
-        
+
         private var durationTime: TimeInterval {
             switch duration {
             case .short: 3

--- a/Sources/Montage/1 Components/7 Feedback/Toast.swift
+++ b/Sources/Montage/1 Components/7 Feedback/Toast.swift
@@ -218,7 +218,7 @@ public struct Toast: View {
                     Circle()
                         .foregroundStyle(SwiftUI.Color.semantic(.staticWhite))
                         .frame(width: 11, height: 11)
-                    Image.icon(.circleExclamationFill)
+                    Image.icon(.circleCloseFill)
                         .resizable()
                         .foregroundStyle(SwiftUI.Color.atomic(.red60))
                         .frame(width: 22, height: 22)


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-76868

# 수정사항

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷
<img width="1206" height="2622" alt="simulator_screenshot_0515481C-BB99-4F5A-B9D0-EC122120BBCB" src="https://github.com/user-attachments/assets/cf940dc3-5e98-4f37-86bd-00fd2b930338" />|<img width="1206" height="2622" alt="simulator_screenshot_6B0D0443-50F7-47B8-AB6B-22838551C70E" src="https://github.com/user-attachments/assets/e85fdd59-c1bd-4671-9d2c-52ff999c9064" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 긍정·주의·부정 토스트의 아이콘이 작은 흰색 배지를 가진 통일된 스타일로 표시되어 시각적 일관성 향상.
  * 부정 아이콘은 원형 닫기 아이콘으로 변경되어 의미 전달 명확화.
  * 크기, 색상, 패딩 등 레이아웃과 동작에는 변화 없음.
* **Refactor**
  * 아이콘 렌더링을 공유된 방식으로 통합하여 코드 가독성과 유지보수성 개선(동작은 동일).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->