### PR TITLE
[PI-78179] DotPagination 점 간격 수정

### DIFF
--- a/Sources/Montage/1 Components/6 Navigations/DotPagination.swift
+++ b/Sources/Montage/1 Components/6 Navigations/DotPagination.swift
@@ -85,11 +85,19 @@ public struct DotPagination: View {
     }
     
     private func leadingPadding(at index: Int) -> CGFloat {
-        !visibleAreaIndices.contains(index) || index == visibleAreaIndices.first ? 0 : 5
+        if !visibleAreaIndices.contains(index) || index == visibleAreaIndices.first {
+            0
+        } else {
+            size == .normal ? 5 : 3
+        }
     }
     
     private func trailingPadding(at index: Int) -> CGFloat {
-        !visibleAreaIndices.contains(index) || index == visibleAreaIndices.last ? 0 : 5
+        if !visibleAreaIndices.contains(index) || index == visibleAreaIndices.last {
+            0
+        } else {
+            size == .normal ? 5 : 3
+        }
     }
 
     private var visibleAreaIndices: [Int] {


### PR DESCRIPTION
# 개요
- JIRA 이슈 링크 : PI-78179

# 수정사항
DotPagination Size가 .small 일 경우의 점 간격을 수정했습니다.

- 사이즈가 .small일 경우 6포인트 / .normal일 경우 10포인트

# 미리보기
작업 전|작업 후
---|---
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 11 18 42" src="https://github.com/user-attachments/assets/c271867c-5d78-4aba-a762-93cea010d9f4" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 11 15 09" src="https://github.com/user-attachments/assets/059c11bb-06ab-436c-99c4-c6df1e1161fd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 도트 페이지네이션 간격을 재조정했습니다. 가장 앞/뒤 도트와 화면 밖 인덱스에는 패딩 0을 적용하고, 나머지는 크기별 간격(일반 5, 스몰 3)을 사용합니다. 다양한 화면에서 도트 정렬과 가독성이 개선되어 탐색 시 시각적 균형과 사용성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->