### PR TITLE
임시 이름 변경: typography -> typographyNew, paragraph -> paragraphNew

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Preview/DotPaginationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/DotPaginationPreview.swift
@@ -36,7 +36,7 @@ struct DotPaginationPreview: View {
                         }
                     }
                     Text("\(selectedPage)/\(totalPages)")
-                        .typography(variant: .caption1)
+                        .typographyNew(variant: .caption1)
                 }
                 
                 HStack {

--- a/Sources/Blueprint/Sources/Scene/Preview/SnackBarPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/SnackBarPreview.swift
@@ -34,11 +34,11 @@ struct SnackBarPreview: View {
                     TextField(text: $description)
                     Toggle(isOn: $showExtraContents) {
                         Text("extral contents(icon)")
-                            .typography(semantic: .labelAssistive)
+                            .typographyNew(semantic: .labelAssistive)
                     }
                     Toggle(isOn: $showPlaceholder) {
                         Text("show snackBar placeholder")
-                            .typography(semantic: .labelAssistive)
+                            .typographyNew(semantic: .labelAssistive)
                     }
                 }
                 .padding(.horizontal, 20)

--- a/Sources/Blueprint/Sources/Scene/Preview/TextAreaPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TextAreaPreview.swift
@@ -95,7 +95,7 @@ struct TextAreaPreview: View {
                     HStack {
                         HStack {
                             Text("Resize :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Menu(resize.description) {
                                 ForEach(Resize.allCases, id: \.self) { r in
@@ -109,7 +109,7 @@ struct TextAreaPreview: View {
                         }
                         HStack {
                             Text("Placeholder :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Switch($placeholder)
                         }
@@ -117,7 +117,7 @@ struct TextAreaPreview: View {
                     HStack {
                         HStack {
                             Text("Focus :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Switch($focus) {
                                 focusState = $0
@@ -125,7 +125,7 @@ struct TextAreaPreview: View {
                         }
                         HStack {
                             Text("Disable :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Switch($disable)
                         }
@@ -133,13 +133,13 @@ struct TextAreaPreview: View {
                     HStack {
                         HStack {
                             Text("Heading :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Switch($heading)
                         }
                         HStack {
                             Text("RequiredBadge :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Switch($requiredBadge)
                         }
@@ -147,19 +147,19 @@ struct TextAreaPreview: View {
                     HStack {
                         HStack {
                             Text("Description :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Switch($description)
                         }
                         Text("Negative :")
-                            .typography(variant: .headline2, weight: .medium)
+                            .typographyNew(variant: .headline2, weight: .medium)
                         Spacer()
                         Switch($negative)
                     }
                     HStack {
                         HStack {
                             Text("Leading :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Menu(resources[leadingResourceIndex]?.description ?? "none") {
                                 ForEach(resources.indices, id: \.self) { index in
@@ -174,7 +174,7 @@ struct TextAreaPreview: View {
                         }
                         HStack {
                             Text("Trailing :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Spacer()
                             Menu(resources[trailingResourceIndex]?.description ?? "none") {
                                 ForEach(resources.indices, id: \.self) { index in

--- a/Sources/Blueprint/Sources/Scene/Preview/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TextFieldPreview.swift
@@ -56,13 +56,13 @@ struct TextFieldPreview: View {
             case .text:
                 return {
                     Text("텍스트")
-                        .paragraph(variant: .body1, weight: .medium, semantic: .labelAssistive)
+                        .paragraphNew(variant: .body1, weight: .medium, semantic: .labelAssistive)
                 }
             case .timer:
                 return {
                     let second = 431
                     return Text(String(format: "%02d:%02d", (second / 60), (second % 60)))
-                        .paragraph(variant: .label1, weight: .bold, semantic: .primaryNormal)
+                        .paragraphNew(variant: .label1, weight: .bold, semantic: .primaryNormal)
                         .monospacedDigit()
                 }
             case .badge:
@@ -182,7 +182,7 @@ struct TextFieldPreview: View {
                     
                     HStack {
                         Text("Status :")
-                            .typography(variant: .headline2, weight: .medium)
+                            .typographyNew(variant: .headline2, weight: .medium)
                         Menu(variant.selectableTitle) {
                             ForEach(Variant.allCases, id: \.self) { v in
                                 Button {
@@ -195,7 +195,7 @@ struct TextFieldPreview: View {
                         Spacer()
                         HStack {
                             Text("Disable :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Button {
                                 disable.toggle()
                             } label: {
@@ -206,7 +206,7 @@ struct TextFieldPreview: View {
                     HStack {
                         HStack {
                             Text("Heading :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Button {
                                 heading.toggle()
                             } label: {
@@ -216,7 +216,7 @@ struct TextFieldPreview: View {
                         Spacer()
                         HStack {
                             Text("RequiredBadge :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Button {
                                 requiredBadge.toggle()
                             } label: {
@@ -227,7 +227,7 @@ struct TextFieldPreview: View {
                     HStack {
                         HStack {
                             Text("Icon :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Button {
                                 icon.toggle()
                             } label: {
@@ -237,7 +237,7 @@ struct TextFieldPreview: View {
                         Spacer()
                         HStack {
                             Text("Placeholder :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Button {
                                 placeholder.toggle()
                             } label: {
@@ -248,7 +248,7 @@ struct TextFieldPreview: View {
                     HStack {
                         HStack {
                             Text("TrailingButton :")
-                                .typography(variant: .headline2, weight: .medium)
+                                .typographyNew(variant: .headline2, weight: .medium)
                             Button {
                                 trailingButton.toggle()
                             } label: {
@@ -257,7 +257,7 @@ struct TextFieldPreview: View {
                         }
                         Spacer()
                         Text("TrailingContent :")
-                            .typography(variant: .headline2, weight: .medium)
+                            .typographyNew(variant: .headline2, weight: .medium)
                         Menu(trailingContent.selectableTitle) {
                             ForEach(Content.allCases, id: \.self) { c in
                                 Button {
@@ -270,7 +270,7 @@ struct TextFieldPreview: View {
                     }
                     HStack {
                         Text("AutoComplete :")
-                            .typography(variant: .headline2, weight: .medium)
+                            .typographyNew(variant: .headline2, weight: .medium)
                         Button {
                             usingSuggestions.toggle()
                         } label: {

--- a/Sources/Blueprint/Sources/Scene/Preview/TooltipPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TooltipPreview.swift
@@ -186,7 +186,7 @@ struct TooltipPreview: View {
         VStack(alignment: .leading) {
             Text("Options").bold()
             Text("iOS 16.4 이상에서는 position 값 유무에 따라 툴팁의 동작이나 가능한 옵션이 현저히 다릅니다. position 값이 nil인 경우 시스템 API를 사용하여 툴팁을 표시하기 때문입니다.")
-                .typography(variant: .caption1, color: .semantic(.labelAlternative))
+                .typographyNew(variant: .caption1, color: .semantic(.labelAlternative))
             VStack(alignment: .leading, spacing: 12) {
                 if #available(iOS 16.4, *) {
                     HStack {
@@ -197,10 +197,10 @@ struct TooltipPreview: View {
                 
                 if usingSystemAPI() {
                     Text("position은 nil인 경우 anchor가 되는 뷰의 위치에 따라 iOS 시스템이 툴팁의 위치를 자동으로 결정합니다.\n또한, showArrow는 항상 true로 동작하고, zIndex를 조정할 필요가 없습니다.")
-                        .typography(variant: .caption1, color: .semantic(.labelAlternative))
+                        .typographyNew(variant: .caption1, color: .semantic(.labelAlternative))
                 } else {
                     Text("주어진 position 값에 따라 툴팁의 위치가 결정되며, showArrow 옵션을 false 로 주면 화살표가 사라집니다.\n또한, position이 .trailing이거나 .bottom인 경우 zIndex를 조정해야 툴팁이 주변 뷰에 가려지지 않습니다.")
-                        .typography(variant: .caption1, color: .semantic(.labelAlternative))
+                        .typographyNew(variant: .caption1, color: .semantic(.labelAlternative))
                 }
                 
                 if usingSystemAPI() {

--- a/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
@@ -114,7 +114,7 @@ struct TopNavigationPreview: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Varint :")
-                    .typography(variant: .headline2, weight: .medium)
+                    .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Menu(variant.selectableTitle) {
                     ForEach(Variant.allCases, id: \.self) { v in
@@ -129,7 +129,7 @@ struct TopNavigationPreview: View {
             if case .floating = variant {
                 HStack {
                     Text("Alternative :")
-                        .typography(variant: .headline2, weight: .medium)
+                        .typographyNew(variant: .headline2, weight: .medium)
                     Spacer()
                     Button {
                         alternative.toggle()
@@ -139,7 +139,7 @@ struct TopNavigationPreview: View {
                 }
                 HStack {
                     Text("Background :")
-                        .typography(variant: .headline2, weight: .medium)
+                        .typographyNew(variant: .headline2, weight: .medium)
                     Spacer()
                     Button {
                         background.toggle()
@@ -150,7 +150,7 @@ struct TopNavigationPreview: View {
             }
             HStack {
                 Text("LeadingButton :")
-                    .typography(variant: .headline2, weight: .medium)
+                    .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Menu(leading.selectableTitle) {
                     ForEach(LeadingButton.allCases, id: \.self) { action in
@@ -164,7 +164,7 @@ struct TopNavigationPreview: View {
             }
             HStack {
                 Text("Add TrailingButton: ")
-                    .typography(variant: .headline2, weight: .medium)
+                    .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Menu("추가") {
                     ForEach(TrailingButton.allCases, id: \.self) { action in
@@ -178,7 +178,7 @@ struct TopNavigationPreview: View {
             }
             HStack {
                 Text("TrailingButton Disable: ")
-                    .typography(variant: .headline2, weight: .medium)
+                    .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Button {
                     trailingButtonDisable.toggle()
@@ -188,7 +188,7 @@ struct TopNavigationPreview: View {
             }
             HStack {
                 Text("BackgroundColor: ")
-                    .typography(variant: .headline2, weight: .medium)
+                    .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Picker(
                     "BackgroundColor",
@@ -203,7 +203,7 @@ struct TopNavigationPreview: View {
             }
             HStack {
                 Text("ActionArea:")
-                    .typography(variant: .headline2, weight: .medium)
+                    .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Button {
                     actionArea.toggle()

--- a/Sources/Blueprint/Sources/Scene/Preview/TypographyPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TypographyPreview.swift
@@ -37,7 +37,7 @@ struct TypographyPreview: View {
                 HStack(spacing: 4) {
                     VStack{
                         Text("\(variant)")
-                            .typography(weight: .bold)
+                            .typographyNew(weight: .bold)
                         Text("lineSpacing:\(String(format: "%.1f", variant.lineSpacing))")
                         Text("fontHeight:\(String(format: "%.1f", variant.fontHeight))")
                         Text("lineHeight:\(String(format: "%.1f", variant.lineHeight))")
@@ -47,12 +47,12 @@ struct TypographyPreview: View {
                     
                     HStack(spacing: 1) {
                         Text([String](repeating: " ", count: Int(lineCount)).joined(separator: "\n"))
-                            .paragraph(variant: variant)
+                            .paragraphNew(variant: variant)
                             .fixedSize(horizontal: false, vertical: true)
                             .frame(width: 30)
                             .dimensioning(axis: .vertical, drawOnPreviewOnly: false)
                         Text([String](repeating: "AA", count: Int(lineCount)).joined(separator: "\n"))
-                            .paragraph(variant: variant)
+                            .paragraphNew(variant: variant)
                             .frame(width: 69)
                             .fixedSize(horizontal: false, vertical: true)
                             .border(.red, width: 1 / UIScreen.main.scale)

--- a/Sources/Blueprint/Sources/Scene/Preview/VerticalProgressTrackerPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/VerticalProgressTrackerPreview.swift
@@ -68,7 +68,7 @@ struct VerticalProgressTrackerPreview: View {
                                 HStack {
                                     Spacer(minLength: 0)
                                     Text("뭐라 뭐라 디스크립션")
-                                        .typography(variant: .caption1)
+                                        .typographyNew(variant: .caption1)
                                 }
                             )
                             : AnyView(EmptyView())

--- a/Sources/Montage/0 Foundations/Typography.swift
+++ b/Sources/Montage/0 Foundations/Typography.swift
@@ -407,7 +407,7 @@ public extension Text {
     ///   - weight: 폰트 두께
     ///   - color: 색상
     /// - Returns: 스타일이 적용된 Text 인스턴스
-    func typography(
+    func typographyNew(
         variant: Typography.Variant = .body1,
         weight: Typography.Weight = .regular,
         color: SwiftUI.Color
@@ -424,12 +424,12 @@ public extension Text {
     ///   - weight: 폰트 두께
     ///   - semantic: 시맨틱 색상
     /// - Returns: 스타일이 적용된 Text 인스턴스
-    func typography(
+    func typographyNew(
         variant: Typography.Variant = .body1,
         weight: Typography.Weight = .regular,
         semantic: Color.Semantic = .labelNormal
     ) -> Text {
-        typography(variant: variant, weight: weight, color: .semantic(semantic))
+        typographyNew(variant: variant, weight: weight, color: .semantic(semantic))
     }
     
     /// 타이포그래피 변형에 따른 단락 스타일을 적용합니다.
@@ -439,12 +439,12 @@ public extension Text {
     ///   - weight: 폰트 두께
     ///   - color: 색상
     /// - Returns: 단락 스타일이 적용된 View
-    func paragraph(
+    func paragraphNew(
         variant: Typography.Variant = .body1,
         weight: Typography.Weight = .regular,
         color: SwiftUI.Color
     ) -> some View {
-        typography(variant: variant, weight: weight, color: color)
+        typographyNew(variant: variant, weight: weight, color: color)
             .adjustLineHeight(variant: variant)
     }
     
@@ -455,12 +455,12 @@ public extension Text {
     ///   - weight: 폰트 두께
     ///   - semantic: 시맨틱 색상
     /// - Returns: 단락 스타일이 적용된 View
-    func paragraph(
+    func paragraphNew(
         variant: Typography.Variant = .body1,
         weight: Typography.Weight = .regular,
         semantic: Color.Semantic = .labelNormal
     ) -> some View {
-        typography(variant: variant, weight: weight, color: .semantic(semantic))
+        typographyNew(variant: variant, weight: weight, color: .semantic(semantic))
             .adjustLineHeight(variant: variant)
     }
 }

--- a/Sources/Montage/1 Components/2 Actions/ActionArea.swift
+++ b/Sources/Montage/1 Components/2 Actions/ActionArea.swift
@@ -31,7 +31,7 @@ import SwiftUI
 /// ))
 /// .extra({ 
 ///     Text("추가 정보")
-///         .typography(variant: .label2) 
+///         .typographyNew(variant: .label2) 
 /// })
 /// ```
 ///
@@ -267,7 +267,7 @@ private extension ActionArea {
         Group {
             if let caption = caption, variant.isCaptionAvailable {
                 Text(caption)
-                    .paragraph(variant: .label2, semantic: .labelAlternative)
+                    .paragraphNew(variant: .label2, semantic: .labelAlternative)
             }
         }
     }

--- a/Sources/Montage/1 Components/2 Actions/ActionChip.swift
+++ b/Sources/Montage/1 Components/2 Actions/ActionChip.swift
@@ -91,7 +91,7 @@ public struct ActionChip: View {
             }
             
             Text(text)
-                .paragraph(variant: typoVariant, weight: .medium, color: fontColor)
+                .paragraphNew(variant: typoVariant, weight: .medium, color: fontColor)
                 .padding(.horizontal, textPadding)
             
             if let trailingImage = trailingImage {

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -489,7 +489,7 @@ public struct Button: View {
                 }
                 if let text {
                     SwiftUI.Text(text)
-                        .typography(
+                        .typographyNew(
                             variant: fontVariant ?? typoVariant,
                             weight: fontWeight ?? typoWeight,
                             color: foregroundColor

--- a/Sources/Montage/1 Components/3 Selection And Input/FilterChip.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/FilterChip.swift
@@ -94,7 +94,7 @@ public struct FilterChip: View {
     public var body: some View {
         HStack(spacing: contentSpacing) {
             Text(active ? (activeLabel ?? text) : text)
-                .paragraph(variant: typoVariant, weight: .medium, color: fontColor)
+                .paragraphNew(variant: typoVariant, weight: .medium, color: fontColor)
                 .padding(.horizontal, textPadding)
             
             Image.icon(state.wrappedValue == .normal ? .caretDown : .caretUp)

--- a/Sources/Montage/1 Components/3 Selection And Input/Input.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Input.swift
@@ -202,7 +202,7 @@ public struct Input: View {
 
             ZStack {
                 Text(text)
-                    .paragraph(
+                    .paragraphNew(
                         variant: titleTypography.variant,
                         weight: isBold ? .bold : titleTypography.weight
                     )
@@ -214,7 +214,7 @@ public struct Input: View {
                     .accessibilityHidden(true)
                     
                 Text(text)
-                    .paragraph(
+                    .paragraphNew(
                         variant: titleTypography.variant,
                         weight: isBold ? .bold : titleTypography.weight,
                         color: titleTypography.color

--- a/Sources/Montage/1 Components/3 Selection And Input/SegmentedControl.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/SegmentedControl.swift
@@ -123,7 +123,7 @@ public struct SegmentedControl: View {
                             .padding(.vertical, 2)
                         
                         Text(items[index].title)
-                            .paragraph(
+                            .paragraphNew(
                                 variant: buttonTitleFont,
                                 weight: .medium,
                                 color: buttonForegroundColor(isSelected: selectedIndex == index)

--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -239,14 +239,14 @@ public struct Select: View {
             if !heading.isEmpty {
                 HStack(spacing: 4) {
                     Text(heading)
-                        .typography(
+                        .typographyNew(
                             variant: .label1,
                             weight: .bold,
                             semantic: .labelNormal
                         )
                     if requiredBadge {
                         Text("*")
-                            .typography(
+                            .typographyNew(
                                 variant: .label1,
                                 weight: .medium,
                                 semantic: .statusNegative
@@ -293,7 +293,7 @@ public struct Select: View {
                         HStack {
                             if selectedItems.isEmpty {
                                 Text(placeholder)
-                                    .paragraph(
+                                    .paragraphNew(
                                         variant: .body1,
                                         weight: .regular,
                                         color: placeholderTextColor
@@ -304,7 +304,7 @@ public struct Select: View {
                                 case .single:
                                     if let text = selectedItems.first?.text {
                                         Text(text)
-                                            .paragraph(
+                                            .paragraphNew(
                                                 variant: .body1,
                                                 weight: .regular,
                                                 color: textColor
@@ -315,7 +315,7 @@ public struct Select: View {
                                     Group {
                                         if render == .text {
                                             Text(selectedItems.map { $0.text }.joined(separator: ", "))
-                                                .paragraph(
+                                                .paragraphNew(
                                                     variant: .body1,
                                                     weight: .regular,
                                                     color: textColor
@@ -395,7 +395,7 @@ public struct Select: View {
             
             if !description.isEmpty {
                 Text(description)
-                    .typography(
+                    .typographyNew(
                         variant: .caption1,
                         weight: .regular,
                         semantic: negative ? .statusNegative : .labelAlternative

--- a/Sources/Montage/1 Components/3 Selection And Input/Slider.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Slider.swift
@@ -99,7 +99,7 @@ public struct Slider: View {
         VStack(spacing: 32) {
             if heading {
                 Text(headingLabel)
-                    .typography(
+                    .typographyNew(
                         variant: .headline2,
                         weight: .bold,
                         semantic: disable ? .interactionDisable : .labelNormal
@@ -406,7 +406,7 @@ public struct Slider: View {
         
         var body: some View {
             let textView = Text(title)
-                .typography(
+                .typographyNew(
                     variant: .label1,
                     weight: .medium,
                     semantic: disable ? .interactionDisable : .labelNormal

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -321,10 +321,10 @@ public struct TextArea: View {
             if let heading {
                 HStack(spacing: 4) {
                     Text(heading)
-                        .typography(variant: .label1, weight: .bold, semantic: .labelNeutral)
+                        .typographyNew(variant: .label1, weight: .bold, semantic: .labelNeutral)
                     if requiredBadge {
                         Text("*")
-                            .typography(variant: .label1, weight: .medium, semantic: .statusNegative)
+                            .typographyNew(variant: .label1, weight: .medium, semantic: .statusNegative)
                     }
                 }
             }
@@ -333,7 +333,7 @@ public struct TextArea: View {
             
             if let description {
                 Text(description)
-                    .typography(
+                    .typographyNew(
                         variant: .caption1,
                         semantic: negative ? .statusNegative : .labelAlternative
                     )
@@ -384,7 +384,7 @@ public struct TextArea: View {
                 
                 if $text.wrappedValue.isEmpty, let placeholder {
                     Text(placeholder)
-                        .paragraph(
+                        .paragraphNew(
                             variant: .body1Reading,
                             color: placeholderTextColor
                         )
@@ -523,7 +523,7 @@ public struct TextArea: View {
             case .characterCount(let limit, let overflow):
                 HStack(spacing: 0) {
                     Text(String(typedCharacters))
-                        .paragraph(
+                        .paragraphNew(
                             variant: .label2,
                             weight: .medium,
                             semantic: disable ? .labelDisable : (
@@ -534,7 +534,7 @@ public struct TextArea: View {
                         )
                     if let limit {
                         Text("/\(String(limit))")
-                            .paragraph(
+                            .paragraphNew(
                                 variant: .label2,
                                 weight: .medium,
                                 semantic: disable ? .labelDisable : .labelAlternative

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -275,10 +275,10 @@ public struct TextField: View {
             if let heading {
                 HStack(spacing: 4) {
                     Text(heading)
-                        .paragraph(variant: .label1, weight: .bold, semantic: .labelNeutral)
+                        .paragraphNew(variant: .label1, weight: .bold, semantic: .labelNeutral)
                     if requiredBadge {
                         Text("*")
-                            .typography(variant: .label1, weight: .medium, semantic: .statusNegative)
+                            .typographyNew(variant: .label1, weight: .medium, semantic: .statusNegative)
                     }
                 }
             }
@@ -290,7 +290,7 @@ public struct TextField: View {
                 case .positive(let caption), .negative(let caption), .normal(let caption):
                     if caption.isEmpty == false {
                         Text(caption)
-                            .paragraph(
+                            .paragraphNew(
                                 variant: .caption1,
                                 color: captionTextColor
                             )
@@ -320,7 +320,7 @@ private extension TextField {
                         prompt: {
                             if let placeholder {
                                 Text(placeholder)
-                                    .typography(
+                                    .typographyNew(
                                         variant: .body1,
                                         weight: .regular,
                                         color: placeholderTextColor
@@ -484,7 +484,7 @@ private extension TextField {
                                         if let title = autoCompletionDataSource.sectionTitleAt?(section) {
                                             HStack {
                                                 Text(title)
-                                                    .paragraph(
+                                                    .paragraphNew(
                                                         variant: .caption1,
                                                         weight: .bold,
                                                         semantic: .labelAlternative
@@ -585,7 +585,7 @@ private extension TextField {
         
         var body: some View {
             Text(title)
-                .paragraph(variant: .body1, weight: typoWeight, semantic: textColor)
+                .paragraphNew(variant: .body1, weight: typoWeight, semantic: textColor)
                 .padding(.horizontal, 19)
                 .padding(.vertical, 12)
                 .background(

--- a/Sources/Montage/1 Components/4 Contents/Accordion.swift
+++ b/Sources/Montage/1 Components/4 Contents/Accordion.swift
@@ -223,7 +223,7 @@ public struct Accordion: View {
                     }
                     
                     Text(title)
-                        .paragraph(
+                        .paragraphNew(
                             variant: titleTypography.variant,
                             weight: titleTypography.weight,
                             color: titleTypography.color
@@ -268,7 +268,7 @@ public struct Accordion: View {
                     VStack(alignment: .leading, spacing: 0) {
                         if let description, !description.isEmpty {
                             Text(description)
-                                .paragraph(
+                                .paragraphNew(
                                     variant: descriptionTypography.variant,
                                     weight: descriptionTypography.weight,
                                     color: descriptionTypography.color

--- a/Sources/Montage/1 Components/4 Contents/Cell.swift
+++ b/Sources/Montage/1 Components/4 Contents/Cell.swift
@@ -106,7 +106,7 @@ public struct Cell: View {
                         
                         if let caption {
                             Text(caption)
-                                .paragraph(
+                                .paragraphNew(
                                     variant: .label2,
                                     semantic: .labelAlternative
                                 )
@@ -419,7 +419,7 @@ extension Cell {
                     .adjustLineHeight(variant: titleTypography.variant)
             } else {
                 Text(title)
-                    .paragraph(
+                    .paragraphNew(
                         variant: titleTypography.variant,
                         weight: active ? .medium : titleTypography.weight,
                         semantic: normalTitleColor

--- a/Sources/Montage/1 Components/4 Contents/ContentBadge.swift
+++ b/Sources/Montage/1 Components/4 Contents/ContentBadge.swift
@@ -129,7 +129,7 @@ public struct ContentBadge: View {
                     .frame(width: iconSize.width, height: iconSize.height)
             }
             Text(text)
-                .typography(variant: typoVariant, weight: .medium, color: contentColor)
+                .typographyNew(variant: typoVariant, weight: .medium, color: contentColor)
             if let trailingIcon {
                 Image.icon(trailingIcon)
                     .resizable()

--- a/Sources/Montage/1 Components/4 Contents/GroupAvatar.swift
+++ b/Sources/Montage/1 Components/4 Contents/GroupAvatar.swift
@@ -29,7 +29,7 @@ import SwiftUI
 ///     }
 /// )
 /// .trailingContent {
-///     Text("+3").typography(variant: .body2)
+///     Text("+3").typographyNew(variant: .body2)
 /// }
 /// ```
 ///

--- a/Sources/Montage/1 Components/4 Contents/ListCard.swift
+++ b/Sources/Montage/1 Components/4 Contents/ListCard.swift
@@ -146,20 +146,20 @@ public struct ListCard: View {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
-                            .paragraph(variant: .body1, weight: .bold, semantic: .labelNormal)
+                            .paragraphNew(variant: .body1, weight: .bold, semantic: .labelNormal)
                             .lineLimit(1)
                             .skeleton(isPresented: skeleton, kind: .text(lengths: [._75]), size: CGSize(width: textAreaWidth, height: 20))
                         
                         if let caption {
                             Text(caption)
-                                .paragraph(variant: .label2, weight: .medium, semantic: .labelAlternative)
+                                .paragraphNew(variant: .label2, weight: .medium, semantic: .labelAlternative)
                                 .lineLimit(1)
                                 .skeleton(isPresented: skeleton, kind: .text(lengths: [._50]), size: CGSize(width: textAreaWidth, height: 14))
                         }
                         
                         if let extraCaption {
                             Text(extraCaption)
-                                .paragraph(variant: .label2, weight: .medium, semantic: .labelAlternative)
+                                .paragraphNew(variant: .label2, weight: .medium, semantic: .labelAlternative)
                                 .lineLimit(1)
                                 .skeleton(
                                     isPresented: skeleton,

--- a/Sources/Montage/1 Components/4 Contents/NormalCard.swift
+++ b/Sources/Montage/1 Components/4 Contents/NormalCard.swift
@@ -166,28 +166,28 @@ public struct NormalCard: View {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
-                            .paragraph(variant: .body1, weight: .bold, semantic: .labelNormal)
+                            .paragraphNew(variant: .body1, weight: .bold, semantic: .labelNormal)
                             .lineLimit(2)
                             .skeleton(isPresented: skeleton, kind: .text(lengths: [._100]), size: CGSize(width: textAreaWidth, height: 22))
                         
                         VStack(alignment: .leading, spacing: 2) {
                             if let caption {
                                 Text(caption)
-                                    .paragraph(variant: .label2, weight: .medium, semantic: .labelAlternative)
+                                    .paragraphNew(variant: .label2, weight: .medium, semantic: .labelAlternative)
                                     .lineLimit(1)
                                     .skeleton(isPresented: skeleton, kind: .text(lengths: [._50]), size: CGSize(width: textAreaWidth, height: 18))
                             }
                             
                             if let subCaption {
                                 Text(subCaption)
-                                    .paragraph(variant: .label2, weight: .medium, semantic: .labelAlternative)
+                                    .paragraphNew(variant: .label2, weight: .medium, semantic: .labelAlternative)
                                     .lineLimit(1)
                                     .skeleton(isPresented: skeleton, kind: .text(lengths: [._25]), size: CGSize(width: textAreaWidth, height: 18))
                             }
                             
                             if let extraCaption {
                                 Text(extraCaption)
-                                    .paragraph(variant: .label2, weight: .medium, semantic: .labelAlternative)
+                                    .paragraphNew(variant: .label2, weight: .medium, semantic: .labelAlternative)
                                     .lineLimit(1)
                                     .skeleton(isPresented: skeleton, kind: .text(lengths: [._25]), size: CGSize(width: textAreaWidth, height: 18))
                             }
@@ -256,7 +256,7 @@ extension NormalCard {
                             HStack(alignment: .top, spacing: 0) {
                                 if let caption {
                                     Text(caption)
-                                        .paragraph(variant: .caption2, weight: .bold, semantic: .staticWhite)
+                                        .paragraphNew(variant: .caption2, weight: .bold, semantic: .staticWhite)
                                         .padding(.bottom, 6)
                                 }
                                 

--- a/Sources/Montage/1 Components/4 Contents/SectionHeader.swift
+++ b/Sources/Montage/1 Components/4 Contents/SectionHeader.swift
@@ -77,7 +77,7 @@ public struct SectionHeader: View {
             HStack(spacing: 0) {
                 HStack(alignment: .bottom, spacing: 16) {
                     Text(title)
-                        .paragraph(variant: variant, weight: .bold, color: titleColor)
+                        .paragraphNew(variant: variant, weight: .bold, color: titleColor)
                         .multilineTextAlignment(.leading)
                         .layoutPriority(1)
                     

--- a/Sources/Montage/1 Components/6 Navigations/CounterPagination.swift
+++ b/Sources/Montage/1 Components/6 Navigations/CounterPagination.swift
@@ -54,19 +54,19 @@ public struct CounterPagination: View {
     public var body: some View {
         HStack(spacing: 4) {
             Text("\(selectedPage)")
-                .paragraph(
+                .paragraphNew(
                     variant: typography,
                     weight: .bold,
                     color: .semantic(.staticWhite).opacity(alternative ? 0.88 : 0.74)
                 )
             Text("/")
-                .paragraph(
+                .paragraphNew(
                     variant: typography,
                     weight: .regular,
                     color: .semantic(.staticWhite).opacity(alternative ? 0.52 : 0.28)
                 )
             Text("\(totalPages)")
-                .paragraph(
+                .paragraphNew(
                     variant: typography,
                     weight: .bold,
                     color: .semantic(.staticWhite).opacity(alternative ? 0.88 : 0.74)

--- a/Sources/Montage/1 Components/6 Navigations/HorizontalProgressTracker.swift
+++ b/Sources/Montage/1 Components/6 Navigations/HorizontalProgressTracker.swift
@@ -91,7 +91,7 @@ public struct HorizontalProgressTracker: View {
     
     private func text(at index: Int, alignment: TextAlignment) -> some View {
         Text(labels[index])
-            .typography(variant: .label2, weight: .bold, color: labelColor(at: index))
+            .typographyNew(variant: .label2, weight: .bold, color: labelColor(at: index))
             .multilineTextAlignment(alignment)
             .if(!labels[index].isEmpty)
     }

--- a/Sources/Montage/1 Components/6 Navigations/ProgressTracker.swift
+++ b/Sources/Montage/1 Components/6 Navigations/ProgressTracker.swift
@@ -34,7 +34,7 @@ struct ProgressTrackerStepper: View {
                     .foregroundStyle(SwiftUI.Color.semantic(.staticWhite))
             } else {
                 Text(String(step))
-                    .typography(variant: .caption1, weight: .bold, semantic: .staticWhite)
+                    .typographyNew(variant: .caption1, weight: .bold, semantic: .staticWhite)
                     .frame(height: 16, alignment: .center)
             }
         }

--- a/Sources/Montage/1 Components/6 Navigations/Tab.swift
+++ b/Sources/Montage/1 Components/6 Navigations/Tab.swift
@@ -100,7 +100,7 @@ public struct Tab: View {
                                     ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                                         ZStack {
                                             Text(item)
-                                                .typography(
+                                                .typographyNew(
                                                     variant: itemFontVariant,
                                                     weight: .bold,
                                                     semantic: index == selectedIndex ? .labelStrong :

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -202,7 +202,7 @@ public struct TopNavigation: View {
         
         private var titleView: some View {
             Text(title)
-                .paragraph(
+                .paragraphNew(
                     variant: variant.typoVariant,
                     weight: variant.typoWeight,
                     semantic: .labelStrong
@@ -348,7 +348,7 @@ public struct TopNavigation: View {
                     action()
                 } label: {
                     Text(text)
-                        .paragraph(
+                        .paragraphNew(
                             variant: .body2,
                             weight: .medium,
                             semantic: disable ? .labelDisable : (alternative ? .staticWhite : .labelAlternative)

--- a/Sources/Montage/1 Components/6 Navigations/VerticalProgressTracker.swift
+++ b/Sources/Montage/1 Components/6 Navigations/VerticalProgressTracker.swift
@@ -93,7 +93,7 @@ public struct VerticalProgressTracker: View {
         
         private var text: some View {
             Text(label)
-                .typography(variant: .label2, weight: .bold, color: labelColor)
+                .typographyNew(variant: .label2, weight: .bold, color: labelColor)
                 .lineLimit(1)
                 .fixedSize()
         }

--- a/Sources/Montage/1 Components/7 Feedback/EmptyState.swift
+++ b/Sources/Montage/1 Components/7 Feedback/EmptyState.swift
@@ -80,7 +80,7 @@ public struct EmptyState: View {
                         HStack {
                             Spacer()
                             Text(title)
-                                .paragraph(variant: .headline1, weight: .bold)
+                                .paragraphNew(variant: .headline1, weight: .bold)
                                 .multilineTextAlignment(.center)
                             Spacer()
                         }
@@ -89,7 +89,7 @@ public struct EmptyState: View {
                     HStack {
                         Spacer()
                         Text(description)
-                            .paragraph(variant: .body2, semantic: .labelAlternative)
+                            .paragraphNew(variant: .body2, semantic: .labelAlternative)
                             .multilineTextAlignment(.center)
                             .lineLimit(2)
                         Spacer()

--- a/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
+++ b/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
@@ -172,11 +172,11 @@ public struct SnackBar: View {
                         VStack(alignment: .leading, spacing: .zero) {
                             if let heading {
                                 Text(heading)
-                                    .paragraph(variant: .body2, weight: .bold, semantic: .staticWhite)
+                                    .paragraphNew(variant: .body2, weight: .bold, semantic: .staticWhite)
                             }
                             if let description {
                                 Text(description)
-                                    .paragraph(variant: .label2, weight: .regular, semantic: .staticWhite)
+                                    .paragraphNew(variant: .label2, weight: .regular, semantic: .staticWhite)
                                     .lineLimit(2)
                             }
                         }
@@ -210,7 +210,7 @@ public struct SnackBar: View {
         
         var body: some View {
             Text(action)
-                .paragraph(variant: .body2, weight: .bold, semantic: .staticWhite)
+                .paragraphNew(variant: .body2, weight: .bold, semantic: .staticWhite)
                 .background(
                     Interaction(
                         state: isPressed ? .pressed : .normal,

--- a/Sources/Montage/1 Components/7 Feedback/Toast.swift
+++ b/Sources/Montage/1 Components/7 Feedback/Toast.swift
@@ -152,7 +152,7 @@ public struct Toast: View {
                 HStack(alignment: .center, spacing: 8) {
                     Icon(variant)
                     Text(message)
-                        .paragraph(variant: .body2, weight: .bold, semantic: .staticWhite)
+                        .paragraphNew(variant: .body2, weight: .bold, semantic: .staticWhite)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .padding(.vertical, 5)

--- a/Sources/Montage/1 Components/7 Feedback/Tooltip.swift
+++ b/Sources/Montage/1 Components/7 Feedback/Tooltip.swift
@@ -306,7 +306,7 @@ private extension Tooltip.Modifier {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top, spacing: 6) {
                 Text(message)
-                    .paragraph(
+                    .paragraphNew(
                         variant: .label1,
                         weight: .medium,
                         semantic: contentColor
@@ -333,7 +333,7 @@ private extension Tooltip.Modifier {
                     buttonInfo.action()
                 }, label: {
                     Text(buttonInfo.title)
-                        .paragraph(
+                        .paragraphNew(
                             variant: .label1,
                             weight: .bold,
                             semantic: .inverseLabel

--- a/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
@@ -186,7 +186,7 @@ public struct ModalNavigation: View {
                     HStack(spacing: 20) {
                         TopNavigation.LeadingButton(leadingButton)
                         Text(title)
-                            .paragraph(
+                            .paragraphNew(
                                 variant: variant.typoVariant,
                                 weight: variant.typoWeight,
                                 semantic: .labelStrong


### PR DESCRIPTION
# 개요
- 슬랙 링크 : https://wantedx.slack.com/archives/C0136G84N87/p1755826567324669

https://github.com/wanteddev/ios/pull/7226 이 PR에서 typography, paragraph가 이름은 그대로이고 기능이 바껴서 작업중인 브랜치와 병합될 때 혼동이 있을 것 같아서 이름을 typographyNew, paragraphNew로 바꿔서 다시 작업하겠습니다.
이게 머지되고 나면 기존 typography, paragraph 를 쓴 곳에서 에러가 날 거고 그러면 다음과 같이 수정해주세요
typography 단독 사용 -> typographyNew
typography, paragraph 함께 사용 -> paragraphNew
paragraph 단독 사용 -> adjustLineHeight
그리고나서 시간이 지난 뒤 New를 떼는 리네임을 다시 할게요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 텍스트 스타일에 색상 명시 설정을 지원하여 커스터마이징 범위가 확대되었습니다.
* 리팩터링
  * 앱 전반에 새로운 타이포그래피 스타일 시스템을 적용했습니다. 버튼, 칩, 입력류(TextField/TextArea/Select/Slider), 내비게이션(Tab/TopNavigation/ProgressTracker), 콘텐츠 카드/배지, 피드백(Toast/SnackBar/Tooltip/EmptyState) 등에서 라벨·플레이스홀더·캡션의 시각적 일관성을 개선했습니다.
* 문서
  * 컴포넌트 예제의 텍스트 스타일 표기를 최신 기준으로 정리했습니다.
* 작업
  * 프리뷰 화면의 텍스트 스타일 표기를 최신 기준으로 동기화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->