### PR TITLE
TextArea negative 상태일 때 아이콘 제거

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Preview/TextAreaPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TextAreaPreview.swift
@@ -31,7 +31,6 @@ struct TextAreaPreview: View {
     
     var resources: [TextArea.Resource?] {
         [
-            .none,
             .characterCount(limit: Int(limit), overflow: overflow),
             .textButton(
                 title: "Text",
@@ -65,8 +64,8 @@ struct TextAreaPreview: View {
     @State private var requiredBadge: Bool = false
     @State private var description: Bool = false
     @State private var placeholder: Bool = true
-    @State private var leadingResourceIndex = 0
-    @State private var trailingResourceIndex = 0
+    @State private var leadingResources = [TextArea.Resource]()
+    @State private var trailingResources = [TextArea.Resource]()
     @State private var limit: CGFloat = 10
     @State private var overflow: Bool = false
     
@@ -84,8 +83,8 @@ struct TextAreaPreview: View {
                     .heading(heading ? "제목" : nil)
                     .requiredBadge(requiredBadge)
                     .bottomResources(
-                        leading: [resources[leadingResourceIndex]].compactMap { $0 },
-                        trailing: [resources[trailingResourceIndex]].compactMap { $0 }
+                        leading: leadingResources,
+                        trailing: trailingResources
                     )
                     .description(description ? "메세지에 마침표를 찍어요." : nil)
                     .placeholder(placeholder ? "텍스트를 입력해주세요" : nil)
@@ -161,35 +160,44 @@ struct TextAreaPreview: View {
                             Text("Leading :")
                                 .typography(variant: .headline2, weight: .medium)
                             Spacer()
-                            Menu(resources[leadingResourceIndex]?.description ?? "none") {
+                            Menu("add") {
                                 ForEach(resources.indices, id: \.self) { index in
                                     Button {
-                                        leadingResourceIndex = index
+                                        if let resource = resources[index] {
+                                            leadingResources.append(resource)
+                                        }
                                     } label: {
                                         Text(resources[index]?.description ?? "none")
                                     }
                                 }
                             }
-                            .font(.font(variant: .label1))
+                            Button("reset") {
+                                leadingResources.removeAll()
+                            }
                         }
                         HStack {
                             Text("Trailing :")
                                 .typography(variant: .headline2, weight: .medium)
                             Spacer()
-                            Menu(resources[trailingResourceIndex]?.description ?? "none") {
+                            Menu("add") {
                                 ForEach(resources.indices, id: \.self) { index in
                                     Button {
-                                        trailingResourceIndex = index
+                                        if let resource = resources[index] {
+                                            trailingResources.append(resource)
+                                        }
                                     } label: {
                                         Text(resources[index]?.description ?? "none")
                                     }
                                 }
                             }
-                            .font(.font(variant: .label1))
+                            Button("reset") {
+                                trailingResources.removeAll()
+                            }
                         }
                     }
-                    if resources[leadingResourceIndex]?.isCharacterCount == true ||
-                        resources[trailingResourceIndex]?.isCharacterCount == true
+                    .font(.font(variant: .label1))
+                    if leadingResources.contains(where: { $0.isCharacterCount }) ||
+                        trailingResources.contains(where: { $0.isCharacterCount })
                     {
                         HStack {
                             Text("characterCount")

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -280,8 +280,8 @@ public struct TextArea: View {
         zelf.trailingResources = Array(trailingResources.prefix(3))
         zelf.trailingResourceSpacing = trailingResourceSpacing
         
-        let bottomResouces = leadingResources + zelf.filteredTrailingResources
-        if let characterCounter = bottomResouces.first(where: \.isCharacterCount),
+        let bottomResources = leadingResources + zelf.filteredTrailingResources
+        if let characterCounter = bottomResources.first(where: \.isCharacterCount),
            case let .characterCount(limit, overflow) = characterCounter {
             zelf.characterCounterLimit = limit
             zelf.characterCounterOverflow = overflow
@@ -444,9 +444,9 @@ public struct TextArea: View {
     }
     
     private var filteredTrailingResources: [Resource] {
-        if trailingResources.contains(where: \.isCharacterCount) &&
-            leadingResources.contains(where: \.isCharacterCount) {
-            Array(trailingResources.drop(while: \.isCharacterCount))
+        if leadingResources.contains(where: \.isCharacterCount) &&
+            trailingResources.contains(where: \.isCharacterCount) {
+            trailingResources.filter { $0.isCharacterCount == false }
         } else {
             trailingResources
         }

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -97,12 +97,12 @@ public struct TextArea: View {
         /// 텍스트 버튼
         /// - Parameters:
         ///   - placement: 버튼 위치
-        ///   - varaint: 버튼 변형 스타일
+        ///   - variant: 버튼 변형 스타일
         ///   - title: 버튼 텍스트
         ///   - handler: 버튼 클릭 핸들러
         case textButton(
             placement: Placement = .leading,
-            varaint: Button.Text.Variant? = .assistive,
+            variant: Button.Text.Variant? = .assistive,
             title: String,
             handler: (() -> Void)? = nil
         )
@@ -280,7 +280,7 @@ public struct TextArea: View {
         zelf.trailingResources = Array(trailingResources.prefix(3))
         zelf.trailingResourceSpacing = trailingResourceSpacing
         
-        let bottomResouces = leadingResources + filteredTrailingResources
+        let bottomResouces = leadingResources + zelf.filteredTrailingResources
         if let characterCounter = bottomResouces.first(where: \.isCharacterCount),
            case let .characterCount(limit, overflow) = characterCounter {
             zelf.characterCounterLimit = limit
@@ -398,7 +398,6 @@ public struct TextArea: View {
             if leadingResources.isEmpty == false || trailingResources.isEmpty == false {
                 Bottom(
                     typedCharacters: $typedCharacters,
-                    negative,
                     disable,
                     leadingResources,
                     leadingResourceSpacing,
@@ -464,7 +463,6 @@ public struct TextArea: View {
     private struct Bottom: View {
         @Binding private var typedCharacters: Int
         
-        private let negative: Bool
         private let disable: Bool
         private let leadingResources: [Resource]
         private let leadingResourceSpacing: CGFloat
@@ -473,7 +471,6 @@ public struct TextArea: View {
         
         init(
             typedCharacters: Binding<Int>,
-            _ negative: Bool,
             _ disable: Bool,
             _ leadingResources: [Resource],
             _ leadingResourceSpacing: CGFloat,
@@ -481,7 +478,6 @@ public struct TextArea: View {
             _ trailingResourceSpacing: CGFloat
         ) {
             _typedCharacters = typedCharacters
-            self.negative = negative
             self.disable = disable
             self.leadingResources = leadingResources
             self.leadingResourceSpacing = leadingResourceSpacing

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -651,12 +651,12 @@ public struct TextArea: View {
             }
 
             func textViewDidBeginEditing(_ textView: UITextView) {
-                textView.isScrollEnabled = textView.frame.height >= (maxHeight ?? .greatestFiniteMagnitude)
+                textView.isScrollEnabled = textView.contentSize.height >= (maxHeight ?? .greatestFiniteMagnitude)
             }
             
             func textViewDidChange(_ textView: UITextView) {
                 let parentText = parent.text
-                textView.isScrollEnabled = textView.frame.height >= (maxHeight ?? .greatestFiniteMagnitude)
+                textView.isScrollEnabled = textView.contentSize.height >= (maxHeight ?? .greatestFiniteMagnitude)
                 parent.text = textView.text
                 // Binding된 값이 변하지 않으면, TextView에 Binding된 값 표시
                 if parentText == parent.text {

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -651,12 +651,12 @@ public struct TextArea: View {
             }
 
             func textViewDidBeginEditing(_ textView: UITextView) {
-                textView.isScrollEnabled = textView.contentSize.height >= (maxHeight ?? .greatestFiniteMagnitude)
+                textView.isScrollEnabled = textView.contentSize.height > (maxHeight ?? .greatestFiniteMagnitude)
             }
             
             func textViewDidChange(_ textView: UITextView) {
                 let parentText = parent.text
-                textView.isScrollEnabled = textView.contentSize.height >= (maxHeight ?? .greatestFiniteMagnitude)
+                textView.isScrollEnabled = textView.contentSize.height > (maxHeight ?? .greatestFiniteMagnitude)
                 parent.text = textView.text
                 // Binding된 값이 변하지 않으면, TextView에 Binding된 값 표시
                 if parentText == parent.text {

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -455,7 +455,7 @@ public struct TextArea: View {
     }
     
     private func updateText(limit: Int?, overflow: Bool) {
-        if !overflow && text.count > limit ?? .max {
+        if !overflow && text.count > (limit ?? .max) {
             text = String(text.prefix(limit ?? .max))
         }
     }
@@ -517,7 +517,7 @@ public struct TextArea: View {
                             variant: .label2,
                             weight: .medium,
                             semantic: disable ? .labelDisable : (
-                                overflow && typedCharacters > limit ?? .max
+                                overflow && typedCharacters > (limit ?? .max)
                                 ? .statusNegative
                                 : .labelAlternative
                             )
@@ -651,12 +651,12 @@ public struct TextArea: View {
             }
 
             func textViewDidBeginEditing(_ textView: UITextView) {
-                textView.isScrollEnabled = textView.frame.height >= (maxHeight ?? 0)
+                textView.isScrollEnabled = textView.frame.height >= (maxHeight ?? .greatestFiniteMagnitude)
             }
             
             func textViewDidChange(_ textView: UITextView) {
                 let parentText = parent.text
-                textView.isScrollEnabled = textView.frame.height >= (maxHeight ?? 0)
+                textView.isScrollEnabled = textView.frame.height >= (maxHeight ?? .greatestFiniteMagnitude)
                 parent.text = textView.text
                 // Binding된 값이 변하지 않으면, TextView에 Binding된 값 표시
                 if parentText == parent.text {
@@ -671,11 +671,11 @@ public struct TextArea: View {
             context _: Context
         ) -> CGSize? {
             var newSize = uiView.sizeThatFits(
-                CGSize(width: proposal.width ?? 0, height: CGFloat.greatestFiniteMagnitude)
+                CGSize(width: proposal.width ?? uiView.bounds.width, height: CGFloat.greatestFiniteMagnitude)
             )
             newSize.height = min(max(newSize.height, minHeight ?? 0), maxHeight ?? .greatestFiniteMagnitude)
             return CGSize(
-                width: proposal.width ?? 0,
+                width: proposal.width ?? uiView.bounds.width,
                 height: newSize.height
             )
         }

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -499,19 +499,10 @@ public struct TextArea: View {
                     }
                 }
                 Spacer()
-                if negative {
-                    IconButton(
-                        variant: .default,
-                        icon: .circleExclamationFill,
-                        handler: nil
-                    )
-                    .iconColor(disable ? .semantic(.labelDisable) : .semantic(.statusNegative))
-                } else {
-                    if trailingResources.isEmpty == false {
-                        HStack(spacing: trailingResourceSpacing) {
-                            ForEach(trailingResources.indices, id: \.self) { index in
-                                component(trailingResources[index])
-                            }
+                if trailingResources.isEmpty == false {
+                    HStack(spacing: trailingResourceSpacing) {
+                        ForEach(trailingResources.indices, id: \.self) { index in
+                            component(trailingResources[index])
                         }
                     }
                 }

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -287,6 +287,7 @@ public struct TextArea: View {
             zelf.characterCounterOverflow = overflow
         } else {
             zelf.characterCounterLimit = nil
+            zelf.characterCounterOverflow = false
         }
         return zelf
     }
@@ -445,7 +446,8 @@ public struct TextArea: View {
     
     private var filteredTrailingResources: [Resource] {
         if leadingResources.contains(where: \.isCharacterCount) &&
-            trailingResources.contains(where: \.isCharacterCount) {
+            trailingResources.contains(where: \.isCharacterCount)
+        {
             trailingResources.filter { $0.isCharacterCount == false }
         } else {
             trailingResources

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -280,7 +280,7 @@ public struct TextArea: View {
         zelf.trailingResources = Array(trailingResources.prefix(3))
         zelf.trailingResourceSpacing = trailingResourceSpacing
         
-        let bottomResources = leadingResources + zelf.filteredTrailingResources
+        let bottomResources = zelf.leadingResources + zelf.filteredTrailingResources
         if let characterCounter = bottomResources.first(where: \.isCharacterCount),
            case let .characterCount(limit, overflow) = characterCounter {
             zelf.characterCounterLimit = limit
@@ -517,7 +517,7 @@ public struct TextArea: View {
                             variant: .label2,
                             weight: .medium,
                             semantic: disable ? .labelDisable : (
-                                overflow && typedCharacters > limit ?? 0
+                                overflow && typedCharacters > limit ?? .max
                                 ? .statusNegative
                                 : .labelAlternative
                             )
@@ -622,6 +622,8 @@ public struct TextArea: View {
             }
             context.coordinator.parent.limit = limit
             context.coordinator.parent.overflow = overflow
+            context.coordinator.minHeight = minHeight
+            context.coordinator.maxHeight = maxHeight
         }
         
         func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-77691

# 수정사항

# 미리보기
작업 전|작업 후
---|---
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-25 at 14 36 51" src="https://github.com/user-attachments/assets/6d7d2b21-9616-4e4e-b4ca-f5593cf72f6d" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-25 at 14 37 26" src="https://github.com/user-attachments/assets/3f2f5aaf-a38c-4eda-837b-183aec70c34d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - TextArea의 텍스트 버튼 옵션 이름을 'varaint'에서 'variant'로 바로잡아 공용 API와 문서를 정정했습니다.

- **스타일**
  - 하단의 부정 상태 아이콘 분기를 제거해 오류 전용 아이콘이 더 이상 표시되지 않습니다.
  - 하단 영역이 트레일링 리소스를 있을 경우 일관되게 오른쪽에 표시됩니다.
  - 입력 영역의 시각 피드백(색상/테두리)은 유지됩니다.

- **동작 변경**
  - 캐릭터 카운터 감지 및 우선순위 로직이 개선되어 중복 카운터가 올바르게 처리됩니다.
  - 미리보기에서 리소스 선택 방식이 단일 선택에서 누적 추가·초기화 가능한 배열 기반으로 변경되어 각 측면에 여러 리소스를 추가할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->