### PR TITLE
fix: IconButton의 showPushBadge 값이 변경되었을 때 점이 노출되거나 가려지지 않는 현상 수정

### DIFF
--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -486,9 +486,10 @@ extension TopNavigation {
             
             public func hash(into hasher: inout Hasher) {
                 switch self {
-                case let .icon(i, d, _, _):
+                case let .icon(i, d, s, _):
                     hasher.combine(i)
                     hasher.combine(d)
+                    hasher.combine(s)
                 case let .text(t, d, _):
                     hasher.combine(t)
                     hasher.combine(d)


### PR DESCRIPTION
# 개요

# 수정사항
TrailingButtonInfo의 hash 함수에 showPushBadge 값이 들어가 있지 않아, 
TopNavigation의 TrailingButton 값이 달라지지 않은 것으로 처리되는 현상을 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 상단 내비게이션 우측 버튼의 푸시 배지(알림 점) 표시 상태가 특정 상황에서 업데이트되지 않거나 잘못 표시되던 문제를 해결했습니다. 알림 설정 변경, 읽음 처리, 화면 전환 등 상태 변화 시 배지의 표시/숨김이 즉시 일관되게 반영됩니다. 이로써 헤더의 알림 상태 신뢰성과 UI 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->