### PR TITLE
Thumbnail 수정이후 포지션 카드 UI 깨짐

### DIFF
--- a/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
+++ b/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
@@ -219,6 +219,6 @@ public struct Thumbnail: View {
     }
     
     private var thumbnailWidth: CGFloat {
-        min(width ?? proposedWidth, proposedWidth)
+        width ?? proposedWidth
     }
 }


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-78580

# 수정사항

# 미리보기
작업 전|작업 후
---|---
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-28 at 19 00 09" src="https://github.com/user-attachments/assets/d0d8038b-1d70-4575-b6b7-5eed1346437e" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-28 at 19 01 12" src="https://github.com/user-attachments/assets/d9983e73-42d3-41ae-b76c-8b6fa28f1cbe" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 썸네일의 명시적 가로폭을 제안된 폭보다 크게 설정할 수 있어, 더 큰 미리보기를 렌더링할 수 있습니다.
  - width를 지정하지 않으면 기존과 동일한 크기 규칙이 적용되며, 더 작은 width를 지정하면 해당 크기로 표시됩니다.
- 기타
  - 레이아웃의 비율 기반 높이, 모서리 곡률, 테두리, 플레이스홀더 동작은 변경되지 않았습니다.
  - 공개 인터페이스 변경 없음.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->