### PR TITLE
docs: convert docc to markdown [ci skip]

### DIFF
--- a/documentation/components/actions/actionarea/ios.md
+++ b/documentation/components/actions/actionarea/ios.md
@@ -66,7 +66,7 @@ ActionArea에 표시될 버튼 정보를 정의하는 구조체입니다.
 
 <details>
 
-<summary>``static func custom((() -> any View)) -> ActionArea.ButtonInfo``</summary>
+<summary>``static func custom<V>(() -> V) -> ActionArea.ButtonInfo``</summary>
 
 커스텀 버튼 뷰를 사용하는 버튼 정보를 생성합니다.
 
@@ -94,7 +94,7 @@ ActionArea를 구성하기 위한 모델 구조체입니다.
 
 <details>
 
-<summary>``init(variant: ActionArea.Variant, backgroundVisibility: BackgroundVisibility, caption: String?, extra: (() -> any View)?, extraDivider: Bool)``</summary>
+<summary>``init<V>(variant: ActionArea.Variant, backgroundVisibility: BackgroundVisibility, caption: String?, extra: () -> V, extraDivider: Bool)``</summary>
 
 ActionArea 모델을 초기화합니다.
 
@@ -105,6 +105,20 @@ ActionArea 모델을 초기화합니다.
   | `backgroundVisibility` | 배경 가시성 설정 |
   | `caption` | 캡션 텍스트 |
   | `extra` | 추가 콘텐츠를 생성하는 클로저 |
+  | `extraDivider` | 추가 콘텐츠 위에 구분선 표시 여부 |
+</details>
+<details>
+
+<summary>``init(variant: ActionArea.Variant, backgroundVisibility: BackgroundVisibility, caption: String?, extraDivider: Bool)``</summary>
+
+ActionArea 모델을 초기화합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `variant` | 버튼 레이아웃 변형 |
+  | `backgroundVisibility` | 배경 가시성 설정 |
+  | `caption` | 캡션 텍스트 |
   | `extraDivider` | 추가 콘텐츠 위에 구분선 표시 여부 |
 </details>
 
@@ -169,7 +183,7 @@ ___
 </details>
 <details>
 
-<summary>``func extra((() -> any View)?, divider: Bool) -> ActionArea``</summary>
+<summary>``func extra<V>(() -> V, divider: Bool) -> ActionArea``</summary>
 
 버튼 위에 표시할 추가 콘텐츠를 설정합니다.
 

--- a/documentation/components/contents/accordion/ios.md
+++ b/documentation/components/contents/accordion/ios.md
@@ -49,7 +49,19 @@ Accordion(title: "커스텀 스타일")
 
 <details>
 
-<summary>``init(title: String, description: String?, content: (() -> any View)?)``</summary>
+<summary>``init(title: String, description: String?)``</summary>
+
+아코디언을 생성합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `title` | 아코디언의 제목 |
+  | `description` | 확장 시 표시될 설명 텍스트 (선택 사항) |
+</details>
+<details>
+
+<summary>``init<V>(title: String, description: String?, content: () -> V)``</summary>
 
 아코디언을 생성합니다.
 
@@ -152,7 +164,7 @@ ___
 </details>
 <details>
 
-<summary>``func trailingContent((() -> any View)?) -> Accordion``</summary>
+<summary>``func trailingContent<V>(() -> V) -> Accordion``</summary>
 
 아코디언 헤더 우측에 커스텀 컨텐츠를 추가합니다.
 

--- a/documentation/components/contents/cell/ios.md
+++ b/documentation/components/contents/cell/ios.md
@@ -222,7 +222,7 @@ ___
 </details>
 <details>
 
-<summary>``func leadingContent((() -> any View)?) -> Cell``</summary>
+<summary>``func leadingContent<V>(() -> V) -> Cell``</summary>
 
 셀 좌측에 추가 콘텐츠를 표시합니다.
 
@@ -317,14 +317,14 @@ ___
 </details>
 <details>
 
-<summary>``func trailingContent(((Bool) -> any View)?) -> Cell``</summary>
+<summary>``func trailingContent<V>((Bool) -> V) -> Cell``</summary>
 
 셀 우측에 추가 콘텐츠를 표시합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `contents` | 표시할 콘텐츠를 생성하는 클로저 (활성화 상태를 파라미터로 받음) |
+  | `contents` | 표시할 콘텐츠를 생성하는 클로저 (선택된 상태를 파라미터로 받음) |
 - **Return Value**
 
   수정된 Cell 인스턴스

--- a/documentation/components/contents/groupavatar/ios.md
+++ b/documentation/components/contents/groupavatar/ios.md
@@ -69,7 +69,7 @@ ___
 
 <details>
 
-<summary>``func trailingContent(() -> any View) -> GroupAvatar``</summary>
+<summary>``func trailingContent<V>(() -> V) -> GroupAvatar``</summary>
 
 그룹 아바타 오른쪽에 추가적인 콘텐츠를 표시합니다.
 

--- a/documentation/components/contents/listcard/ios.md
+++ b/documentation/components/contents/listcard/ios.md
@@ -58,7 +58,7 @@ ___
 
 <details>
 
-<summary>``func bottomContent((() -> any View)?) -> ListCard``</summary>
+<summary>``func bottomContent<V>(() -> V) -> ListCard``</summary>
 
 카드 하단에 표시할 콘텐츠를 설정합니다.
 
@@ -100,7 +100,7 @@ ___
 </details>
 <details>
 
-<summary>``func leadingContent((() -> any View)?) -> ListCard``</summary>
+<summary>``func leadingContent<V>(() -> V) -> ListCard``</summary>
 
 카드 왼쪽(썸네일 앞)에 표시할 콘텐츠를 설정합니다.
 
@@ -114,7 +114,7 @@ ___
 </details>
 <details>
 
-<summary>``func topContent((() -> any View)?) -> ListCard``</summary>
+<summary>``func topContent<V>(() -> V) -> ListCard``</summary>
 
 카드 상단에 표시할 콘텐츠를 설정합니다.
 
@@ -128,7 +128,7 @@ ___
 </details>
 <details>
 
-<summary>``func trailingContent((() -> any View)?) -> ListCard``</summary>
+<summary>``func trailingContent<V>(() -> V) -> ListCard``</summary>
 
 카드 오른쪽에 표시할 콘텐츠를 설정합니다.
 

--- a/documentation/components/contents/normalcard/ios.md
+++ b/documentation/components/contents/normalcard/ios.md
@@ -58,7 +58,7 @@ ___
 
 <details>
 
-<summary>``func bottomContent((() -> any View)?) -> NormalCard``</summary>
+<summary>``func bottomContent<V>(() -> V) -> NormalCard``</summary>
 
 카드 하단에 표시할 콘텐츠를 설정합니다.
 
@@ -131,7 +131,7 @@ ___
 </details>
 <details>
 
-<summary>``func topContent((() -> any View)?) -> NormalCard``</summary>
+<summary>``func topContent<V>(() -> V) -> NormalCard``</summary>
 
 카드 상단에 표시할 콘텐츠를 설정합니다.
 

--- a/documentation/components/contents/sectionheader/ios.md
+++ b/documentation/components/contents/sectionheader/ios.md
@@ -64,7 +64,7 @@ ___
 
 <details>
 
-<summary>``func headingContent((() -> any View)?) -> SectionHeader``</summary>
+<summary>``func headingContent<V>(() -> V) -> SectionHeader``</summary>
 
 헤더 타이틀 옆에 추가 콘텐츠를 표시합니다.
 
@@ -121,7 +121,7 @@ ___
 </details>
 <details>
 
-<summary>``func trailingContent((() -> any View)?) -> SectionHeader``</summary>
+<summary>``func trailingContent<V>(() -> V) -> SectionHeader``</summary>
 
 헤더의 오른쪽에 추가적인 콘텐츠를 표시합니다.
 

--- a/documentation/components/feedback/snackbar/ios.md
+++ b/documentation/components/feedback/snackbar/ios.md
@@ -55,7 +55,21 @@ SnackBar의 데이터 모델을 정의하는 구조체입니다.
 
 <details>
 
-<summary>``init(duration: Duration, heading: String?, description: String?, extraContents: (() -> any View)?, action: String)``</summary>
+<summary>``init(duration: Duration, heading: String?, description: String?, action: String)``</summary>
+
+SnackBar 모델을 초기화합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `duration` | 스낵바가 표시되는 시간 |
+  | `heading` | 스낵바의 제목 (선택 사항) |
+  | `description` | 스낵바의 설명 텍스트 (선택 사항) |
+  | `action` | 스낵바의 액션 버튼에 표시할 텍스트 |
+</details>
+<details>
+
+<summary>``init<V>(duration: Duration, heading: String?, description: String?, extraContents: () -> V, action: String)``</summary>
 
 SnackBar 모델을 초기화합니다.
 

--- a/documentation/components/presentation/bottomsheetmodal/ios.md
+++ b/documentation/components/presentation/bottomsheetmodal/ios.md
@@ -51,7 +51,7 @@ YourView()
 
 <details>
 
-<summary>``init(() -> any View)``</summary>
+<summary>``init<V>(() -> V)``</summary>
 
 바텀 시트 모달을 초기화합니다.
 

--- a/documentation/components/presentation/fullmodal/ios.md
+++ b/documentation/components/presentation/fullmodal/ios.md
@@ -55,7 +55,7 @@ YourView()
 
 <details>
 
-<summary>``init(() -> any View)``</summary>
+<summary>``init<V>(() -> V)``</summary>
 
 풀스크린 모달을 초기화합니다.
 

--- a/documentation/components/presentation/popupmodal/ios.md
+++ b/documentation/components/presentation/popupmodal/ios.md
@@ -55,7 +55,7 @@ YourView()
 
 <details>
 
-<summary>``init(() -> any View)``</summary>
+<summary>``init<V>(() -> V)``</summary>
 
 팝업 모달을 초기화합니다.
 

--- a/documentation/components/selection and input/textfield/ios.md
+++ b/documentation/components/selection and input/textfield/ios.md
@@ -57,7 +57,7 @@ TextField(text: $inputText)
 
 <details>
 
-<summary>``init(numberOfSections: Int, sectionTitleAt: ((Int) -> String)?, numberOfItemsInSection: (Int) -> Int, cellForItemAt: (IndexPath) -> any View, headerView: (() -> any View)?, footerView: (() -> any View)?, maxHeight: CGFloat)``</summary>
+<summary>``init<V>(numberOfSections: Int, sectionTitleAt: ((Int) -> String)?, numberOfItemsInSection: (Int) -> Int, cellForItemAt: (IndexPath) -> V, headerView: (() -> any View)?, footerView: (() -> any View)?, maxHeight: CGFloat)``</summary>
 
 자동완성 데이터 소스를 초기화합니다.
 
@@ -68,8 +68,6 @@ TextField(text: $inputText)
   | `sectionTitleAt` | 섹션 제목을 반환하는 클로저 |
   | `numberOfItemsInSection` | 각 섹션의 항목 수를 반환하는 클로저 |
   | `cellForItemAt` | 각 항목의 뷰를 반환하는 클로저 |
-  | `headerView` | 헤더 뷰를 반환하는 클로저 |
-  | `footerView` | 푸터 뷰를 반환하는 클로저 |
   | `maxHeight` | 자동완성 목록의 최대 높이, 기본값은 400 |
 </details>
 
@@ -254,15 +252,10 @@ ___
 - **Return Value**
 
   수정된 텍스트 필드 인스턴스
-- **Discussion**
-  >  **Note**
-  >
-  > `trailingContent`와 함께 사용될 경우 `trailingButton`이 우선적으로 표시됩니다.
-
 </details>
 <details>
 
-<summary>``func trailingContent((() -> any View)?) -> TextField``</summary>
+<summary>``func trailingContent<V>(() -> V) -> TextField``</summary>
 
 텍스트 필드 오른쪽에 표시할 커스텀 콘텐츠를 설정합니다.
 
@@ -273,11 +266,6 @@ ___
 - **Return Value**
 
   수정된 텍스트 필드 인스턴스
-- **Discussion**
-  >  **Note**
-  >
-  > `trailingButton`과 함께 사용하는 경우 `trailingContent`가 무시됩니다.
-
 </details>
 
 ___

--- a/documentation/utilities/ios/swiftuicore.md
+++ b/documentation/utilities/ios/swiftuicore.md
@@ -51,7 +51,7 @@ View를 UIImage로 변환합니다.
 </details>
 <details>
 
-<summary>``func bottomSheetModal(isPresented: Binding<Bool>, needHandle: Bool, resize: BottomSheetModal.Resize, actionAreaModel: ActionArea.Model?, () -> any View, navigation: (() -> ModalNavigation)?) -> some View``</summary>
+<summary>``func bottomSheetModal<V>(isPresented: Binding<Bool>, needHandle: Bool, resize: BottomSheetModal.Resize, actionAreaModel: ActionArea.Model?, () -> V, navigation: (() -> ModalNavigation)?) -> some View``</summary>
 
 바텀 시트 모달을 표시합니다.
 
@@ -134,7 +134,7 @@ Montage 디자인 시스템의 그림자 효과를 적용합니다.
 </details>
 <details>
 
-<summary>``func fullModal(isPresented: Binding<Bool>, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> any View, navigation: (() -> ModalNavigation)?) -> some View``</summary>
+<summary>``func fullModal<V>(isPresented: Binding<Bool>, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> V, navigation: (() -> ModalNavigation)?) -> some View``</summary>
 
 전체 화면 모달을 표시합니다.
 
@@ -182,6 +182,25 @@ Montage 디자인 시스템의 그림자 효과를 적용합니다.
 - **Return Value**
 
   변환된 View
+</details>
+<details>
+
+<summary>``func ifEmptyView((Bool) -> Void) -> some View``</summary>
+
+View의 크기가 .zero로 변경되거나 .zero가 아닌 값으로 변경될 때 액션을 수행합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `action` | 크기가 .zero로 변경되거나 .zero가 아닌 값으로 변경될 때 실행할 액션 클로져. 파라메터로는 View 크기가 .zero인지 여부가 전달됩니다. |
+- **Return Value**
+
+  수정된 View
+- **Discussion**
+  >  **Note**
+  >
+  > opacity(0), hidden() 등 시각적으로 비어 보이지만 사이즈를 가지는 케이스는 감지되지 않습니다.
+
 </details>
 <details>
 
@@ -249,7 +268,7 @@ View의 지오메트리 변경정보를 디바운스시켜서 받습니다.
 </details>
 <details>
 
-<summary>``func popupModal(isPresented: Binding<Bool>, resize: PopupModal.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> any View, navigation: (() -> ModalNavigation)?) -> some View``</summary>
+<summary>``func popupModal<V>(isPresented: Binding<Bool>, resize: PopupModal.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> V, navigation: (() -> ModalNavigation)?) -> some View``</summary>
 
 팝업 모달을 표시합니다.
 
@@ -391,7 +410,7 @@ View의 지오메트리 변경정보를 디바운스시켜서 받습니다.
 </details>
 <details>
 
-<summary>``func skeleton(isPresented: Bool, skeletonView: () -> any View) -> some View``</summary>
+<summary>``func skeleton<V>(isPresented: Bool, skeletonView: () -> V) -> some View``</summary>
 
 현재 뷰에 커스텀 스켈레톤 로딩 UI를 적용합니다.
 

--- a/documentation/utilities/ios/view-implementations.md
+++ b/documentation/utilities/ios/view-implementations.md
@@ -706,7 +706,7 @@ View를 UIImage로 변환합니다.
 </details>
 <details>
 
-<summary>``func bottomSheetModal(isPresented: Binding<Bool>, needHandle: Bool, resize: BottomSheetModal.Resize, actionAreaModel: ActionArea.Model?, () -> any View, navigation: (() -> ModalNavigation)?) -> some View``</summary>
+<summary>``func bottomSheetModal<V>(isPresented: Binding<Bool>, needHandle: Bool, resize: BottomSheetModal.Resize, actionAreaModel: ActionArea.Model?, () -> V, navigation: (() -> ModalNavigation)?) -> some View``</summary>
 
 바텀 시트 모달을 표시합니다.
 
@@ -1345,7 +1345,7 @@ Montage 디자인 시스템의 그림자 효과를 적용합니다.
 </details>
 <details>
 
-<summary>``func fullModal(isPresented: Binding<Bool>, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> any View, navigation: (() -> ModalNavigation)?) -> some View``</summary>
+<summary>``func fullModal<V>(isPresented: Binding<Bool>, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> V, navigation: (() -> ModalNavigation)?) -> some View``</summary>
 
 전체 화면 모달을 표시합니다.
 
@@ -1513,6 +1513,25 @@ Montage 디자인 시스템의 그림자 효과를 적용합니다.
 - **Return Value**
 
   변환된 View
+</details>
+<details>
+
+<summary>``func ifEmptyView((Bool) -> Void) -> some View``</summary>
+
+View의 크기가 .zero로 변경되거나 .zero가 아닌 값으로 변경될 때 액션을 수행합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `action` | 크기가 .zero로 변경되거나 .zero가 아닌 값으로 변경될 때 실행할 액션 클로져. 파라메터로는 View 크기가 .zero인지 여부가 전달됩니다. |
+- **Return Value**
+
+  수정된 View
+- **Discussion**
+  >  **Note**
+  >
+  > opacity(0), hidden() 등 시각적으로 비어 보이지만 사이즈를 가지는 케이스는 감지되지 않습니다.
+
 </details>
 <details>
 
@@ -2170,7 +2189,7 @@ View의 지오메트리 변경정보를 디바운스시켜서 받습니다.
 </details>
 <details>
 
-<summary>``func popupModal(isPresented: Binding<Bool>, resize: PopupModal.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> any View, navigation: (() -> ModalNavigation)?) -> some View``</summary>
+<summary>``func popupModal<V>(isPresented: Binding<Bool>, resize: PopupModal.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, () -> V, navigation: (() -> ModalNavigation)?) -> some View``</summary>
 
 팝업 모달을 표시합니다.
 
@@ -2732,7 +2751,7 @@ View의 지오메트리 변경정보를 디바운스시켜서 받습니다.
 </details>
 <details>
 
-<summary>``func skeleton(isPresented: Bool, skeletonView: () -> any View) -> some View``</summary>
+<summary>``func skeleton<V>(isPresented: Bool, skeletonView: () -> V) -> some View``</summary>
 
 현재 뷰에 커스텀 스켈레톤 로딩 UI를 적용합니다.
 


### PR DESCRIPTION
문서 자동화 워크플로우가 고장나서 누락된 문서 PR입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - SwiftUI 유틸리티에 ifEmptyView((Bool) -> Void) 추가.
  - 여러 컴포넌트에서 “추가 콘텐츠 없는” 이니셜라이저 추가(예: ActionArea.Model, SnackBar.Model, Accordion).

- 문서
  - iOS 컴포넌트 전반에서 콘텐츠 클로저를 any View에서 제네릭 V로 통일: ActionArea, Accordion, Cell, GroupAvatar, ListCard, NormalCard, SectionHeader, TextField, SnackBar.
  - 모달/유틸리티 API 문서 업데이트: BottomSheetModal, FullModal, PopupModal, skeleton 등이 제네릭 V 클로저 사용.
  - 매개변수 설명 및 사용 예시를 제네릭 서명에 맞게 정비.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->