### PR TITLE
[PI-79111] TopNavigation Title, Leading, Trailing 영역 Slot으로 변경

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
@@ -141,8 +141,14 @@ struct BottomSheetModalPreview: View {
             },
             navigation: navigation
             ? {
-                ModalNavigation(title: "제목")
+                ModalNavigation()
                     .variant(navigationVariants[navVariantIndex])
+                    .title({
+                        ModalNavigation.TitleView(
+                            variant: navigationVariants[navVariantIndex],
+                            title: "제목"
+                        )
+                    })
                     .leading {
                         TopNavigation.LeadingButton(.back(action: {}))
                     }

--- a/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
@@ -143,7 +143,9 @@ struct BottomSheetModalPreview: View {
             ? {
                 ModalNavigation(title: "제목")
                     .variant(navigationVariants[navVariantIndex])
-                    .leadingButton(.back(action: {}))
+                    .leading {
+                        TopNavigation.LeadingButton(.back(action: {}))
+                    }
                     .trailingButtons([
                         .icon(.plus, action: {}),
                         .icon(.minus, action: {}),

--- a/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
@@ -153,28 +153,26 @@ struct BottomSheetModalPreview: View {
                         TopNavigation.LeadingButton(.back(action: {}))
                     }
                     .trailingContents(
-                        [
-                            {
-                                TopNavigation.TrailingIconButton(
-                                    icon: .plus,
-                                    action: {}
-                                )
-                            },
-                            {
-                                TopNavigation.TrailingIconButton(
-                                    icon: .minus,
-                                    action: {}
-                                )
-                            },
-                            {
-                                TopNavigation.TrailingIconButton(
-                                    icon: .close,
-                                    action: {
-                                        show = false
-                                    }
-                                )
-                            }
-                        ]
+                        {
+                            TopNavigation.TrailingIconButton(
+                                icon: .plus,
+                                action: {}
+                            )
+                        },
+                        {
+                            TopNavigation.TrailingIconButton(
+                                icon: .minus,
+                                action: {}
+                            )
+                        },
+                        {
+                            TopNavigation.TrailingIconButton(
+                                icon: .close,
+                                action: {
+                                    show = false
+                                }
+                            )
+                        }
                     )
             }
             : nil

--- a/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
@@ -149,10 +149,10 @@ struct BottomSheetModalPreview: View {
                             title: "제목"
                         )
                     })
-                    .leading {
+                    .leadingContent {
                         TopNavigation.LeadingButton(.back(action: {}))
                     }
-                    .trailings(
+                    .trailingContents(
                         [
                             {
                                 TopNavigation.TrailingIconButton(

--- a/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/BottomSheetModalPreview.swift
@@ -146,11 +146,30 @@ struct BottomSheetModalPreview: View {
                     .leading {
                         TopNavigation.LeadingButton(.back(action: {}))
                     }
-                    .trailingButtons([
-                        .icon(.plus, action: {}),
-                        .icon(.minus, action: {}),
-                        .icon(.close, action: { show = false })
-                    ])
+                    .trailings(
+                        [
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .plus,
+                                    action: {}
+                                )
+                            },
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .minus,
+                                    action: {}
+                                )
+                            },
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .close,
+                                    action: {
+                                        show = false
+                                    }
+                                )
+                            }
+                        ]
+                    )
             }
             : nil
         )

--- a/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
@@ -115,11 +115,30 @@ struct FullModalPreview: View {
                             .back(action: {})
                         )
                     }
-                    .trailingButtons([
-                        .icon(.plus, action: {}),
-                        .icon(.minus, action: {}),
-                        .icon(.close, action: { show = false })
-                    ])
+                    .trailings(
+                        [
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .plus,
+                                    action: {}
+                                )
+                            },
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .minus,
+                                    action: {}
+                                )
+                            },
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .close,
+                                    action: {
+                                        show = false
+                                    }
+                                )
+                            }
+                        ]
+                    )
             }
             : nil
         )

--- a/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
@@ -110,7 +110,11 @@ struct FullModalPreview: View {
             ? {
                 ModalNavigation(title: "제목")
                     .variant(navigationVariants[navVariantIndex])
-                    .leadingButton(.back(action: {}))
+                    .leading {
+                        TopNavigation.LeadingButton(
+                            .back(action: {})
+                        )
+                    }
                     .trailingButtons([
                         .icon(.plus, action: {}),
                         .icon(.minus, action: {}),

--- a/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
@@ -116,12 +116,12 @@ struct FullModalPreview: View {
                             title: "제목"
                         )
                     })
-                    .leading {
+                    .leadingContent {
                         TopNavigation.LeadingButton(
                             .back(action: {})
                         )
                     }
-                    .trailings(
+                    .trailingContents(
                         [
                             {
                                 TopNavigation.TrailingIconButton(

--- a/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/FullModalPreview.swift
@@ -108,8 +108,14 @@ struct FullModalPreview: View {
             },
             navigation: navigation
             ? {
-                ModalNavigation(title: "제목")
+                ModalNavigation()
                     .variant(navigationVariants[navVariantIndex])
+                    .title({
+                        ModalNavigation.TitleView(
+                            variant: navigationVariants[navVariantIndex],
+                            title: "제목"
+                        )
+                    })
                     .leading {
                         TopNavigation.LeadingButton(
                             .back(action: {})

--- a/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
@@ -40,43 +40,46 @@ struct ModalNavigationPreview: View {
             )
             
             VStack(spacing: 0) {
-                ModalNavigation(
-                    title: "제목",
-                    scrollOffset: $contentOffset
-                )
-                .variant(variants[variantIndex])
-                .leading {
-                    Group {
-                        if leadingButton {
-                            TopNavigation.LeadingButton.init(
-                                leadingButtons[leadingButtonTypeIndex]
-                            )
-                        }
-                    }
-                }
-                .trailings(
-                    actions.map { kind -> (() -> AnyView) in
-                        switch kind {
-                        case let .icon(i, d, s, a):
-                            {
-                                AnyView(TopNavigation.TrailingIconButton(
-                                    icon: i,
-                                    disable: d,
-                                    showPushBadge: s,
-                                    action: a
-                                ))
-                            }
-                        case let .text(t, d, a):
-                            {
-                                AnyView(TopNavigation.TrailingTextButton(
-                                    text: t,
-                                    disable: d,
-                                    action: a
-                                ))
+                ModalNavigation(scrollOffset: $contentOffset)
+                    .variant(variants[variantIndex])
+                    .title({
+                        ModalNavigation.TitleView(
+                            variant: variants[variantIndex],
+                            title: "제목"
+                        )
+                    })
+                    .leading {
+                        Group {
+                            if leadingButton {
+                                TopNavigation.LeadingButton.init(
+                                    leadingButtons[leadingButtonTypeIndex]
+                                )
                             }
                         }
                     }
-                )
+                    .trailings(
+                        actions.map { kind -> (() -> AnyView) in
+                            switch kind {
+                            case let .icon(i, d, s, a):
+                                {
+                                    AnyView(TopNavigation.TrailingIconButton(
+                                        icon: i,
+                                        disable: d,
+                                        showPushBadge: s,
+                                        action: a
+                                    ))
+                                }
+                            case let .text(t, d, a):
+                                {
+                                    AnyView(TopNavigation.TrailingTextButton(
+                                        text: t,
+                                        disable: d,
+                                        action: a
+                                    ))
+                                }
+                            }
+                        }
+                    )
                 
                 VStack(alignment: .leading) {
                     HStack {

--- a/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
@@ -46,7 +46,15 @@ struct ModalNavigationPreview: View {
                 )
                 .variant(variants[variantIndex])
                 .trailingButtons(Array(actions.prefix(trailingButtonCount).reversed()))
-                .leadingButton(leadingButton ? leadingButtons[leadingButtonTypeIndex] : nil)
+                .leading {
+                    Group {
+                        if leadingButton {
+                            TopNavigation.LeadingButton.init(
+                                leadingButtons[leadingButtonTypeIndex]
+                            )
+                        }
+                    }
+                }
                 
                 VStack(alignment: .leading) {
                     HStack {

--- a/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
@@ -48,7 +48,7 @@ struct ModalNavigationPreview: View {
                             title: "제목"
                         )
                     })
-                    .leading {
+                    .leadingContent {
                         Group {
                             if leadingButton {
                                 TopNavigation.LeadingButton.init(
@@ -57,7 +57,7 @@ struct ModalNavigationPreview: View {
                             }
                         }
                     }
-                    .trailings(
+                    .trailingContents(
                         actions.map { kind -> (() -> AnyView) in
                             switch kind {
                             case let .icon(i, d, s, a):

--- a/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
@@ -58,7 +58,7 @@ struct ModalNavigationPreview: View {
                         }
                     }
                     .trailingContents(
-                        actions.map { kind -> (() -> AnyView) in
+                        Array(actions.prefix(trailingButtonCount)).map { kind -> (() -> AnyView) in
                             switch kind {
                             case let .icon(i, d, s, a):
                                 {

--- a/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/ModalNavigationPreview.swift
@@ -45,7 +45,6 @@ struct ModalNavigationPreview: View {
                     scrollOffset: $contentOffset
                 )
                 .variant(variants[variantIndex])
-                .trailingButtons(Array(actions.prefix(trailingButtonCount).reversed()))
                 .leading {
                     Group {
                         if leadingButton {
@@ -55,6 +54,29 @@ struct ModalNavigationPreview: View {
                         }
                     }
                 }
+                .trailings(
+                    actions.map { kind -> (() -> AnyView) in
+                        switch kind {
+                        case let .icon(i, d, s, a):
+                            {
+                                AnyView(TopNavigation.TrailingIconButton(
+                                    icon: i,
+                                    disable: d,
+                                    showPushBadge: s,
+                                    action: a
+                                ))
+                            }
+                        case let .text(t, d, a):
+                            {
+                                AnyView(TopNavigation.TrailingTextButton(
+                                    text: t,
+                                    disable: d,
+                                    action: a
+                                ))
+                            }
+                        }
+                    }
+                )
                 
                 VStack(alignment: .leading) {
                     HStack {

--- a/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
@@ -130,12 +130,12 @@ struct PopupModalPreview: View {
                             title: "제목"
                         )
                     })
-                    .leading {
+                    .leadingContent {
                         TopNavigation.LeadingButton(
                             .back(action: {})
                         )
                     }
-                    .trailings(
+                    .trailingContents(
                         [
                             {
                                 TopNavigation.TrailingIconButton(

--- a/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
@@ -124,7 +124,11 @@ struct PopupModalPreview: View {
             ? {
                 ModalNavigation(title: "제목")
                     .variant(navigationVariants[navVariantIndex])
-                    .leadingButton(.back(action: {}))
+                    .leading {
+                        TopNavigation.LeadingButton(
+                            .back(action: {})
+                        )
+                    }
                     .trailingButtons([
                         .icon(.plus, action: {}),
                         .icon(.minus, action: {}),

--- a/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
@@ -129,11 +129,30 @@ struct PopupModalPreview: View {
                             .back(action: {})
                         )
                     }
-                    .trailingButtons([
-                        .icon(.plus, action: {}),
-                        .icon(.minus, action: {}),
-                        .icon(.close, action: { show = false })
-                    ])
+                    .trailings(
+                        [
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .plus,
+                                    action: {}
+                                )
+                            },
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .minus,
+                                    action: {}
+                                )
+                            },
+                            {
+                                TopNavigation.TrailingIconButton(
+                                    icon: .close,
+                                    action: {
+                                        show = false
+                                    }
+                                )
+                            }
+                        ]
+                    )
             }
             : nil
         )

--- a/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/PopupModalPreview.swift
@@ -122,8 +122,14 @@ struct PopupModalPreview: View {
             },
             navigation: navigation
             ? {
-                ModalNavigation(title: "제목")
+                ModalNavigation()
                     .variant(navigationVariants[navVariantIndex])
+                    .title({
+                        ModalNavigation.TitleView(
+                            variant: navigationVariants[navVariantIndex],
+                            title: "제목"
+                        )
+                    })
                     .leading {
                         TopNavigation.LeadingButton(
                             .back(action: {})

--- a/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
@@ -47,7 +47,7 @@ struct TopNavigationPreview: View {
     @State var background: Bool = false
     @State var leading: LeadingContentsKind = .back
     @State var trailing: [TrailingButton] = []
-    @State var trailingContentDisable: Bool = false
+    @State var trailingContentsDisable: Bool = false
     @State var toast: Toast.Model? = nil
     @State var backgroundColor: SwiftUI.Color? = nil
     @State var selectedBackgroundColorName: Montage.Color.Semantic = .backgroundNormal
@@ -151,13 +151,14 @@ struct TopNavigationPreview: View {
             case .icon: {
                 TopNavigation.TrailingIconButton(
                     icon: .bell,
+                    disable: trailingContentsDisable,
                     action: { closure() }
                 )
             }
             case .text: {
                 TopNavigation.TrailingTextButton(
                     text: "알림",
-                    disable: trailingContentDisable,
+                    disable: trailingContentsDisable,
                     action: {
                         closure()
                     }
@@ -199,7 +200,7 @@ struct TopNavigationPreview: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Text("Varint :")
+                Text("Variant :")
                     .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Menu(variant.selectableTitle) {
@@ -235,7 +236,7 @@ struct TopNavigationPreview: View {
                 }
             }
             HStack {
-                Text("LeadingButton :")
+                Text("LeadingContent :")
                     .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Menu(leading.selectableTitle) {
@@ -249,7 +250,7 @@ struct TopNavigationPreview: View {
                 }
             }
             HStack {
-                Text("Add TrailingButton: ")
+                Text("Add TrailingContents : ")
                     .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Menu("추가") {
@@ -263,13 +264,13 @@ struct TopNavigationPreview: View {
                 }
             }
             HStack {
-                Text("TrailingButton Disable: ")
+                Text("TrailingContents Disable: ")
                     .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Button {
-                    trailingContentDisable.toggle()
+                    trailingContentsDisable.toggle()
                 } label: {
-                    Text(trailingContentDisable ? "true" : "false")
+                    Text(trailingContentsDisable ? "true" : "false")
                 }
             }
             HStack {

--- a/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
@@ -66,11 +66,82 @@ struct TopNavigationPreview: View {
         }
     }
     
-    private var leadingButton: TopNavigation.Resource.LeadingButtonInfo {
+    private var leadingButton: () -> any View {
         switch leading {
-        case .back: return .back(action: { presentationMode.wrappedValue.dismiss() })
-        case .icon: return .icon(.arrowLeft, action: { presentationMode.wrappedValue.dismiss()})
-        case .text: return .text("뒤로", action: { presentationMode.wrappedValue.dismiss()})
+        case .back:
+            return {
+                IconButton(
+                    variant: background
+                    ? .background(size: 24, isAlternative: alternative)
+                    : .default,
+                    icon: background ? .chevronLeftThick : .chevronLeft
+                ) {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .frame(width: 24, height: 24)
+            }
+        case .icon:
+            return {
+                IconButton(
+                    variant: background
+                    ? .background(size: 24, isAlternative: alternative)
+                    : .default,
+                    icon: .bell
+                ) {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .frame(width: 24, height: 24)
+            }
+        case .text:
+            return {
+                if background {
+                    SwiftUI.Button {
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Text("텍스트")
+                            .paragraphNew(
+                                variant: .body2,
+                                weight: .medium,
+                                semantic: (alternative ? .staticWhite : .labelAlternative)
+                            )
+                            .if(alternative) {
+                                $0.opacity(0.88)
+                            } else: {
+                                $0.blendMode(.plusDarker)
+                            }
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 10)
+                            .modifying { original in
+                                Group {
+                                    if alternative {
+                                        original.background(
+                                            SwiftUI.Color.atomic(.coolNeutral30)
+                                                .opacity(0.61)
+                                        )
+                                    } else {
+                                        original.background(
+                                            ZStack {
+                                                SwiftUI.Color.semantic(.staticBlack)
+                                                    .opacity(0.05)
+                                                SwiftUI.Color.semantic(.staticWhite)
+                                                    .opacity(0.35)
+                                            }
+                                        )
+                                        .background(.thinMaterial)
+                                    }
+                                }
+                                .clipShape(RoundedRectangle(cornerRadius: 1000))
+                            }
+                    }
+                } else {
+                    Button.text(text: "텍스트") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                    .contentColor(.semantic(.labelNormal))
+                    .fontVariant(.headline2)
+                    .fontWeight(.regular)
+                }
+            }
         }
     }
     
@@ -240,7 +311,7 @@ struct TopNavigationPreview: View {
             variant: v,
             title: "제목",
             backgroundColor: backgroundColor,
-            leadingButton: leadingButton,
+            leading: leadingButton,
             trailingButtons: trailingButton,
             withBottom: actionAreaModel
         )

--- a/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
@@ -21,7 +21,7 @@ struct TopNavigationPreview: View {
         }
     }
     
-    enum LeadingButton: String, CaseIterable {
+    enum LeadingContentsKind: String, CaseIterable {
         case back
         case icon
         case text
@@ -45,9 +45,9 @@ struct TopNavigationPreview: View {
     @State var variant: Variant = .normal
     @State var alternative: Bool = false
     @State var background: Bool = false
-    @State var leading: LeadingButton = .back
+    @State var leading: LeadingContentsKind = .back
     @State var trailing: [TrailingButton] = []
-    @State var trailingButtonDisable: Bool = false
+    @State var trailingContentDisable: Bool = false
     @State var toast: Toast.Model? = nil
     @State var backgroundColor: SwiftUI.Color? = nil
     @State var selectedBackgroundColorName: Montage.Color.Semantic = .backgroundNormal
@@ -66,7 +66,7 @@ struct TopNavigationPreview: View {
         }
     }
     
-    private var leadingButton: () -> any View {
+    private var leadingContent: () -> any View {
         switch leading {
         case .back:
             return {
@@ -145,11 +145,24 @@ struct TopNavigationPreview: View {
         }
     }
     
-    private var trailingButton: [TopNavigation.Resource.TrailingButtonInfo] {
+    private var trailingContents: [() -> any View] {
         return trailing.map {
             switch $0 {
-            case .icon: return .icon(.bell, disable: trailingButtonDisable, action: { closure() })
-            case .text: return .text("알림", disable: trailingButtonDisable, action: { closure() })
+            case .icon: {
+                TopNavigation.TrailingIconButton(
+                    icon: .bell,
+                    action: { closure() }
+                )
+            }
+            case .text: {
+                TopNavigation.TrailingTextButton(
+                    text: "알림",
+                    disable: trailingContentDisable,
+                    action: {
+                        closure()
+                    }
+                )
+            }
             }
         }
     }
@@ -226,7 +239,7 @@ struct TopNavigationPreview: View {
                     .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Menu(leading.selectableTitle) {
-                    ForEach(LeadingButton.allCases, id: \.self) { action in
+                    ForEach(LeadingContentsKind.allCases, id: \.self) { action in
                         Button {
                             leading = action
                         } label: {
@@ -254,9 +267,9 @@ struct TopNavigationPreview: View {
                     .typographyNew(variant: .headline2, weight: .medium)
                 Spacer()
                 Button {
-                    trailingButtonDisable.toggle()
+                    trailingContentDisable.toggle()
                 } label: {
-                    Text(trailingButtonDisable ? "true" : "false")
+                    Text(trailingContentDisable ? "true" : "false")
                 }
             }
             HStack {
@@ -311,8 +324,8 @@ struct TopNavigationPreview: View {
             variant: v,
             title: "제목",
             backgroundColor: backgroundColor,
-            leading: leadingButton,
-            trailingButtons: trailingButton,
+            leading: leadingContent,
+            trailings: trailingContents,
             withBottom: actionAreaModel
         )
         .toast($toast)

--- a/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
@@ -329,8 +329,8 @@ struct TopNavigationPreview: View {
                 )
             },
             backgroundColor: backgroundColor,
-            leading: leadingContent,
-            trailings: trailingContents,
+            leadingContent: leadingContent,
+            trailingContents: trailingContents,
             withBottom: actionAreaModel
         )
         .toast($toast)

--- a/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Preview/TopNavigationPreview.swift
@@ -322,7 +322,12 @@ struct TopNavigationPreview: View {
         .padding(.all, 20)
         .topNavigation(
             variant: v,
-            title: "제목",
+            title: {
+                TopNavigation.TitleView(
+                    variant: v,
+                    title: "제목"
+                )
+            },
             backgroundColor: backgroundColor,
             leading: leadingContent,
             trailings: trailingContents,

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -102,12 +102,13 @@ public struct TopNavigation: View {
     
     /// 내비게이션 영역의 오른쪽(trailing) 영역에 표시할 뷰들을 설정합니다.
     ///
-    /// 최대 3개까지의 뷰를 배열로 전달할 수 있으며, 각 요소는 클로저 형태로 제공되어야 합니다.
-    /// 내부적으로 `AnyView`로 타입이 지워져 렌더링됩니다.
+    /// 최대 3개까지의 뷰를 클로저 배열로 전달할 수 있으며,
+    /// 각 클로저는 다양한 타입의 View를 반환할 수 있습니다 (`any View`).
+    /// 내부적으로는 모든 View를 `AnyView`로 타입을 지운 후 렌더링합니다.
     ///
     /// - Parameter contents: trailing 영역에 표시할 뷰들을 반환하는 클로저 배열
     /// - Returns: 수정된 인스턴스를 반환합니다.
-    public func trailing<V: View>(_ contents: [() -> V]) -> Self {
+    public func trailings(_ contents: [() -> any View]) -> Self {
         var zelf = self
         zelf.trailings = contents.prefix(3).map{ view in { AnyView(view()) } }
         return zelf
@@ -243,15 +244,14 @@ public struct TopNavigation: View {
 
         var body: some View {
             HStack(alignment: .center, spacing: 16) {
-                ForEach(contents.indices, id: \.self) { i in
-                    Group { contents[i]() }
+                ForEach(Array(contents.enumerated()), id: \.offset) { _, makeView in
+                    makeView()
                 }
             }
             .contentShape(Rectangle().scale(2), eoFill: true) // 터치영역 확장
         }
     }
 }
-
 
 extension TopNavigation {
     /// 내비게이션 바의 제목 컴포넌트입니다.
@@ -720,7 +720,7 @@ extension TopNavigation {
                         )
                         .title { title() }
                         .leading { leading() }
-                        .trailing(trailings)
+                        .trailings(trailings)
                         .onGeometryChange(
                             for: CGSize.self,
                             of: { $0.size },

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -19,7 +19,7 @@ import SwiftUI
 ///     backgroundColor: (*optional)
 /// )
 /// .title { 제목 컴포넌트 }
-/// .leading { 왼쪽 영역 컴포넌트 }
+/// .leadingContent { 왼쪽 영역 컴포넌트 }
 /// .trailing([
 ///     { 컴포넌트1 },
 ///     { 컴포넌트2 } ...
@@ -55,11 +55,8 @@ public struct TopNavigation: View {
     ///
     /// - Parameters:
     ///   - variant: 내비게이션 바의 외관 스타일
-    ///   - title: 표시할 제목
     ///   - scrollOffset: 스크롤 오프셋 값
     ///   - backgroundColor: 배경색
-    ///   - leading: 좌측에 표시할 컨텐츠
-    ///   - trailings: 우측에 표시할 버튼 배열 (최대 3개까지 표시)
     public init(
         variant: Variant = .normal,
         scrollOffset: CGFloat = .zero,
@@ -73,8 +70,8 @@ public struct TopNavigation: View {
     // MARK: - Modifiers
     
     private var title: () -> AnyView  = { AnyView(EmptyView()) }
-    private var leading: () -> AnyView  = { AnyView(EmptyView()) }
-    private var trailings: [() -> AnyView] = []
+    private var leadingContent: () -> AnyView  = { AnyView(EmptyView()) }
+    private var trailingContents: [() -> AnyView] = []
     
     /// 내비게이션 영역의 타이틀 뷰를 설정합니다.
     ///
@@ -88,15 +85,15 @@ public struct TopNavigation: View {
         return zelf
     }
     
-    /// 내비게이션 영역의 왼쪽(leading) 영역에 표시할 뷰를 설정합니다.
+    /// 내비게이션 영역의 왼쪽(leadingContent) 영역에 표시할 뷰를 설정합니다.
     ///
     /// 주로 아이콘이나 취소 버튼 등을 배치할 수 있으며, ViewBuilder를 통해 정의됩니다.
     ///
-    /// - Parameter content: leading 영역에 표시할 뷰를 반환하는 클로저
+    /// - Parameter content: leadingContent 영역에 표시할 뷰를 반환하는 클로저
     /// - Returns: 수정된 인스턴스를 반환합니다.
-    public func leading<V: View>(@ViewBuilder content: @escaping () -> V) -> Self {
+    public func leadingContent<V: View>(@ViewBuilder content: @escaping () -> V) -> Self {
         var zelf = self
-        zelf.leading = { AnyView(content()) }
+        zelf.leadingContent = { AnyView(content()) }
         return zelf
     }
     
@@ -108,9 +105,9 @@ public struct TopNavigation: View {
     ///
     /// - Parameter contents: trailing 영역에 표시할 뷰들을 반환하는 클로저 배열
     /// - Returns: 수정된 인스턴스를 반환합니다.
-    public func trailings(_ contents: [() -> any View]) -> Self {
+    public func trailingContents(_ contents: [() -> any View]) -> Self {
         var zelf = self
-        zelf.trailings = contents.prefix(3).map{ view in { AnyView(view()) } }
+        zelf.trailingContents = contents.prefix(3).map{ view in { AnyView(view()) } }
         return zelf
     }
 
@@ -119,8 +116,8 @@ public struct TopNavigation: View {
             Contents(
                 variant: variant,
                 title: title,
-                leading: leading,
-                trailings: trailings
+                leadingContent: leadingContent,
+                trailingContents: trailingContents
             )
             .padding(.all, 16)
             .background {
@@ -156,8 +153,8 @@ public struct TopNavigation: View {
         
         var variant: Variant
         var title: () -> AnyView
-        var leading: () -> AnyView
-        var trailings: [() -> AnyView]
+        var leadingContent: () -> AnyView
+        var trailingContents: [() -> AnyView]
 
         private var titleSize: CGFloat {
             let componentSize: CGFloat = max(leadingSize.width, totalSizeOfTrailings.width)
@@ -179,14 +176,14 @@ public struct TopNavigation: View {
                 switch variant {
                 case .normal:
                     HStack(spacing: .zero) {
-                        leading()
+                        leadingContent()
                             .onGeometryChange(
                                 for: CGSize.self,
                                 of: { $0.size },
                                 action: { leadingSize = $0 }
                             )
                         Spacer()
-                        TrailingContents(trailings)
+                        TrailingContents(trailingContents)
                         .onGeometryChange(
                             for: CGSize.self,
                             of: { $0.size },
@@ -198,9 +195,9 @@ public struct TopNavigation: View {
                 case .extended:
                     VStack(spacing: 20) {
                         HStack {
-                            leading()
+                            leadingContent()
                             Spacer()
-                            TrailingContents(trailings)
+                            TrailingContents(trailingContents)
                         }
                         HStack {
                             title()
@@ -212,14 +209,14 @@ public struct TopNavigation: View {
                 case let .floating(alternative, background):
                     ZStack {
                         HStack(spacing: .zero) {
-                            leading()
+                            leadingContent()
                                 .onGeometryChange(
                                     for: CGSize.self,
                                     of: { $0.size },
                                     action: { leadingSize = $0 }
                                 )
                             Spacer()
-                            TrailingContents(trailings)
+                            TrailingContents(trailingContents)
                                 .onGeometryChange(
                                     for: CGSize.self,
                                     of: { $0.size },
@@ -660,8 +657,8 @@ extension TopNavigation {
         private let title: (() -> AnyView)
         private let showIndicator: Bool
         private let backgroundColor: SwiftUI.Color?
-        private let leading: (() -> AnyView)
-        private let trailings: [() -> AnyView]
+        private let leadingContent: (() -> AnyView)
+        private let trailingContents: [() -> AnyView]
         private let actionAreaModel: ActionArea.Model?
         
         /// TopNavigationModifier를 초기화합니다.
@@ -671,24 +668,24 @@ extension TopNavigation {
         ///   - title: 제목 영역
         ///   - showIndicator: 인디케이터 표시 여부
         ///   - backgroundColor: 배경색
-        ///   - leading: 좌측에 표시할 컴포넌트
-        ///   - trailings: 우측에 표시할 컴포넌트 배열
+        ///   - leadingContent: 좌측에 표시할 컴포넌트
+        ///   - trailingContents: 우측에 표시할 컴포넌트 배열
         ///   - actionAreaModel: 액션 영역 모델
         init(
             variant: Variant,
             title: (() -> any View)? = nil,
             showIndicator: Bool = true,
             backgroundColor: SwiftUI.Color? = nil,
-            leading: (() -> any View)? = nil,
-            trailings: [() -> any View] = [],
+            leadingContent: (() -> any View)? = nil,
+            trailingContents: [() -> any View] = [],
             actionAreaModel: ActionArea.Model? = nil
         ) {
             self.variant = variant
             self.title = title.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
             self.showIndicator = showIndicator
             self.backgroundColor = backgroundColor
-            self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
-            self.trailings = trailings.prefix(3).map { view in { AnyView(view()) } }
+            self.leadingContent = leadingContent.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
+            self.trailingContents = trailingContents.prefix(3).map { view in { AnyView(view()) } }
             self.actionAreaModel = actionAreaModel
         }
         
@@ -719,8 +716,8 @@ extension TopNavigation {
                             backgroundColor: backgroundColor
                         )
                         .title { title() }
-                        .leading { leading() }
-                        .trailings(trailings)
+                        .leadingContent { leadingContent() }
+                        .trailingContents(trailingContents)
                         .onGeometryChange(
                             for: CGSize.self,
                             of: { $0.size },
@@ -754,16 +751,16 @@ extension View {
     ///   - variant: 내비게이션 바의 외관 스타일 (기본값: .normal)
     ///   - title: 표시할 제목
     ///   - backgroundColor: 배경색 (기본값: nil)
-    ///   - leading: 좌측에 표시할 컴포넌트 (기본값: nil)
-    ///   - trailings: 우측에 표시할 컴포넌트 (기본값: [])
+    ///   - leadingContent: 좌측에 표시할 컴포넌트 (기본값: nil)
+    ///   - trailingContents: 우측에 표시할 컴포넌트 (기본값: [])
     ///   - model: 하단 액션 영역에 대한 모델 (기본값: nil)
     /// - Returns: TopNavigation이 적용된 뷰
     public func topNavigation(
         variant: TopNavigation.Variant = .normal,
         title: (() -> any View)? = nil,
         backgroundColor: SwiftUI.Color? = nil,
-        leading: (() -> any View)? = nil,
-        trailings: [() -> any View] = [],
+        leadingContent: (() -> any View)? = nil,
+        trailingContents: [() -> any View] = [],
         withBottom model: ActionArea.Model? = nil
     ) -> some View {
         modifier(
@@ -771,8 +768,8 @@ extension View {
                 variant: variant,
                 title: title,
                 backgroundColor: backgroundColor,
-                leading: leading,
-                trailings: trailings,
+                leadingContent: leadingContent,
+                trailingContents: trailingContents,
                 actionAreaModel: model
             )
         )

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -9,15 +9,15 @@ import SwiftUI
 
 /// 상단에 표시되는 내비게이션 바 컴포넌트입니다.
 ///
-/// 제목, 뒤로가기 버튼, 추가 액션 버튼 등을 포함할 수 있으며, 다양한 외관 스타일을 지원합니다.
+/// 제목, 뒤로가기, 추가 액션 버튼 등을 포함할 수 있으며, 다양한 외관 스타일을 지원합니다.
 /// 스크롤 시 배경색과 구분선의 불투명도가 자동으로 조절됩니다.
 ///
 /// ```swift
 /// TopNavigation(
 ///     variant: .normal,
 ///     title: "제목",
-///     leadingButton: .back {
-///         // 뒤로가기 동작
+///     leading: {
+///         // 뒤로가기 동작 컴포넌트
 ///     },
 ///     trailingButtons: [
 ///         .icon(.search) {
@@ -33,7 +33,6 @@ public struct TopNavigation: View {
     private let title: String
     private let scrollOffset: CGFloat
     private let backgroundColor: SwiftUI.Color?
-    private let leadingButton: Resource.LeadingButtonInfo?
     private let trailingButtons: [Resource.TrailingButtonInfo]
     
     // MARK: - Computed properties
@@ -62,30 +61,40 @@ public struct TopNavigation: View {
     ///   - title: 표시할 제목
     ///   - scrollOffset: 스크롤 오프셋 값
     ///   - backgroundColor: 배경색
-    ///   - leadingButton: 좌측에 표시할 버튼
+    ///   - leading: 좌측에 표시할 컨텐츠
     ///   - trailingButtons: 우측에 표시할 버튼 배열 (최대 3개까지 표시)
     public init(
         variant: Variant = .normal,
         title: String = "",
         scrollOffset: CGFloat = .zero,
         backgroundColor: SwiftUI.Color? = nil,
-        leadingButton: Resource.LeadingButtonInfo? = nil,
+        leading: (() -> any View)? = nil,
         trailingButtons: [Resource.TrailingButtonInfo] = []
     ) {
         self.variant = variant
         self.title = title
         self.scrollOffset = scrollOffset
         self.backgroundColor = backgroundColor
-        self.leadingButton = leadingButton
+        self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
         self.trailingButtons = Array(trailingButtons.prefix(3))
     }
     
+    // MARK: - Modifiers
+    
+    private var leading: () -> AnyView
+    
+    public func leading<V: View>(@ViewBuilder content: @escaping () -> V) -> Self {
+        var zelf = self
+        zelf.leading = { AnyView(content()) }
+        return zelf
+    }
+
     public var body: some View {
         ZStack(alignment: .bottom) {
             Contents(
                 variant: variant,
                 title: title,
-                leadingButton: leadingButton,
+                leading: leading,
                 trailingButtons: trailingButtons
             )
             .padding(.all, 16)
@@ -122,7 +131,7 @@ public struct TopNavigation: View {
         
         var variant: Variant
         var title: String
-        var leadingButton: Resource.LeadingButtonInfo? = nil
+        var leading: () -> AnyView
         var trailingButtons: [Resource.TrailingButtonInfo]
 
         private var titleSize: CGFloat {
@@ -145,7 +154,7 @@ public struct TopNavigation: View {
                 switch variant {
                 case .normal:
                     HStack(spacing: .zero) {
-                        LeadingButton(leadingButton)
+                        leading()
                             .onGeometryChange(
                                 for: CGSize.self,
                                 of: { $0.size },
@@ -164,7 +173,7 @@ public struct TopNavigation: View {
                 case .extended:
                     VStack(spacing: 20) {
                         HStack {
-                            LeadingButton(leadingButton)
+                            leading()
                             Spacer()
                             TrailingButtons(trailingButtons)
                         }
@@ -178,7 +187,7 @@ public struct TopNavigation: View {
                 case let .floating(alternative, background):
                     ZStack {
                         HStack(spacing: .zero) {
-                            LeadingButton(leadingButton, alternative, background)
+                            leading()
                                 .onGeometryChange(
                                     for: CGSize.self,
                                     of: { $0.size },
@@ -211,12 +220,12 @@ public struct TopNavigation: View {
         }
     }
     
-    struct LeadingButton: View {
+    public struct LeadingButton: View {
         let action: Resource.LeadingButtonInfo?
         let alternative: Bool
         let background: Bool
         
-        init(
+        public init(
             _ action: Resource.LeadingButtonInfo?,
             _ alternative: Bool = false,
             _ background: Bool = false
@@ -226,7 +235,7 @@ public struct TopNavigation: View {
             self.background = background
         }
         
-        var body: some View {
+        public var body: some View {
             if let action {
                 Group {
                     switch action {
@@ -555,7 +564,7 @@ extension TopNavigation {
         private let title: String
         private let showIndicator: Bool
         private let backgroundColor: SwiftUI.Color?
-        private let leadingButton: Resource.LeadingButtonInfo?
+        private let leading: (() -> any View)?
         private let trailingButtons: [Resource.TrailingButtonInfo]
         private let actionAreaModel: ActionArea.Model?
         
@@ -574,7 +583,7 @@ extension TopNavigation {
             title: String,
             showIndicator: Bool = true,
             backgroundColor: SwiftUI.Color? = nil,
-            leadingButton: Resource.LeadingButtonInfo?,
+            leading: (() -> any View)? = nil,
             trailingButtons: [Resource.TrailingButtonInfo],
             actionAreaModel: ActionArea.Model? = nil
         ) {
@@ -582,7 +591,7 @@ extension TopNavigation {
             self.title = title
             self.showIndicator = showIndicator
             self.backgroundColor = backgroundColor
-            self.leadingButton = leadingButton
+            self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
             self.trailingButtons = trailingButtons
             self.actionAreaModel = actionAreaModel
         }
@@ -613,7 +622,7 @@ extension TopNavigation {
                             title: title,
                             scrollOffset: scrollStatus.contentOffset.y,
                             backgroundColor: backgroundColor,
-                            leadingButton: leadingButton,
+                            leading: leading,
                             trailingButtons: trailingButtons
                         )
                         .onGeometryChange(
@@ -657,7 +666,7 @@ extension View {
         variant: TopNavigation.Variant = .normal,
         title: String,
         backgroundColor: SwiftUI.Color? = nil,
-        leadingButton: TopNavigation.Resource.LeadingButtonInfo? = nil,
+        leading: (() -> any View)? = nil,
         trailingButtons: [TopNavigation.Resource.TrailingButtonInfo] = [],
         withBottom model: ActionArea.Model? = nil
     ) -> some View {
@@ -666,7 +675,7 @@ extension View {
                 variant: variant,
                 title: title,
                 backgroundColor: backgroundColor,
-                leadingButton: leadingButton,
+                leading: leading,
                 trailingButtons: trailingButtons,
                 actionAreaModel: model
             )

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -15,26 +15,20 @@ import SwiftUI
 /// ```swift
 /// TopNavigation(
 ///     variant: .normal,
-///     title: "제목",
-///     leading: {
-///         // 뒤로가기 동작 컴포넌트
-///     },
-///     trailing: [
-///         {
-///           // 컴포넌트1
-///         },
-///         {
-///           // 컴포넌트2
-///         },
-///         ...
-///     ]
+///     scrollOffset: (*optional),
+///     backgroundColor: (*optional)
 /// )
+/// .title { 제목 컴포넌트 }
+/// .leading { 왼쪽 영역 컴포넌트 }
+/// .trailing([
+///     { 컴포넌트1 },
+///     { 컴포넌트2 } ...
+/// ])
 /// ```
 public struct TopNavigation: View {
     // MARK: - Uninitialised properties
     
     private let variant: Variant
-    private let title: String
     private let scrollOffset: CGFloat
     private let backgroundColor: SwiftUI.Color?
     
@@ -68,32 +62,52 @@ public struct TopNavigation: View {
     ///   - trailings: 우측에 표시할 버튼 배열 (최대 3개까지 표시)
     public init(
         variant: Variant = .normal,
-        title: String = "",
         scrollOffset: CGFloat = .zero,
-        backgroundColor: SwiftUI.Color? = nil,
-        leading: (() -> any View)? = nil,
-        trailings: [(() -> any View)] = []
+        backgroundColor: SwiftUI.Color? = nil
     ) {
         self.variant = variant
-        self.title = title
         self.scrollOffset = scrollOffset
         self.backgroundColor = backgroundColor
-        self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
-        self.trailings = trailings.prefix(3).map { view in { AnyView(view()) } }
     }
     
     // MARK: - Modifiers
     
-    private var leading: () -> AnyView
-    private var trailings: [() -> AnyView]
+    private var title: () -> AnyView  = { AnyView(EmptyView()) }
+    private var leading: () -> AnyView  = { AnyView(EmptyView()) }
+    private var trailings: [() -> AnyView] = []
     
+    /// 내비게이션 영역의 타이틀 뷰를 설정합니다.
+    ///
+    /// 타이틀에는 텍스트 또는 커스텀 뷰를 사용할 수 있으며, ViewBuilder를 통해 정의됩니다.
+    ///
+    /// - Parameter content: 표시할 타이틀 뷰를 반환하는 클로저
+    /// - Returns: 수정된 인스턴스를 반환합니다.
+    public func title<V: View>(@ViewBuilder content: @escaping () -> V) -> Self {
+        var zelf = self
+        zelf.title = { AnyView(content()) }
+        return zelf
+    }
+    
+    /// 내비게이션 영역의 왼쪽(leading) 영역에 표시할 뷰를 설정합니다.
+    ///
+    /// 주로 아이콘이나 취소 버튼 등을 배치할 수 있으며, ViewBuilder를 통해 정의됩니다.
+    ///
+    /// - Parameter content: leading 영역에 표시할 뷰를 반환하는 클로저
+    /// - Returns: 수정된 인스턴스를 반환합니다.
     public func leading<V: View>(@ViewBuilder content: @escaping () -> V) -> Self {
         var zelf = self
         zelf.leading = { AnyView(content()) }
         return zelf
     }
     
-    public func trailing<V: View>(contents: [() -> V]) -> Self {
+    /// 내비게이션 영역의 오른쪽(trailing) 영역에 표시할 뷰들을 설정합니다.
+    ///
+    /// 최대 3개까지의 뷰를 배열로 전달할 수 있으며, 각 요소는 클로저 형태로 제공되어야 합니다.
+    /// 내부적으로 `AnyView`로 타입이 지워져 렌더링됩니다.
+    ///
+    /// - Parameter contents: trailing 영역에 표시할 뷰들을 반환하는 클로저 배열
+    /// - Returns: 수정된 인스턴스를 반환합니다.
+    public func trailing<V: View>(_ contents: [() -> V]) -> Self {
         var zelf = self
         zelf.trailings = contents.prefix(3).map{ view in { AnyView(view()) } }
         return zelf
@@ -140,7 +154,7 @@ public struct TopNavigation: View {
         @State private var screenWidth: CGFloat = 0
         
         var variant: Variant
-        var title: String
+        var title: () -> AnyView
         var leading: () -> AnyView
         var trailings: [() -> AnyView]
 
@@ -178,7 +192,7 @@ public struct TopNavigation: View {
                             action: { totalSizeOfTrailings = $0 }
                         )
                     }
-                    titleView
+                    title()
                         .frame(width: titleSize, height: 24)
                 case .extended:
                     VStack(spacing: 20) {
@@ -188,7 +202,7 @@ public struct TopNavigation: View {
                             TrailingContents(trailings)
                         }
                         HStack {
-                            titleView
+                            title()
                                 .frame(height: 24, alignment: variant.textAlignment)
                             Spacer()
                         }
@@ -212,14 +226,55 @@ public struct TopNavigation: View {
                                 )
                         }
                         .frame(height: 24)
-                        titleView
+                        title()
                             .frame(width: titleSize, height: 24)
                     }
                 }
             }
         }
+    }
+    
+    struct TrailingContents: View {
+        let contents: [() -> AnyView]
         
-        private var titleView: some View {
+        init(_ contents:  [() -> AnyView]) {
+            self.contents = contents
+        }
+
+        var body: some View {
+            HStack(alignment: .center, spacing: 16) {
+                ForEach(contents.indices, id: \.self) { i in
+                    Group { contents[i]() }
+                }
+            }
+            .contentShape(Rectangle().scale(2), eoFill: true) // 터치영역 확장
+        }
+    }
+}
+
+
+extension TopNavigation {
+    /// 내비게이션 바의 제목 컴포넌트입니다.
+    ///
+    /// 전달받은 스타일(variant)에 따라 타이포그래피가 동적으로 적용되며,
+    /// 최대 한 줄로 제한된 제목 텍스트를 보여줍니다.
+    ///
+    /// ```swift
+    /// TitleView(variant: .normal, title: "제목")
+    /// ```
+    public struct TitleView: View {
+        let variant: Variant
+        let title: String
+        
+        public init(
+            variant: Variant,
+            title: String
+        ) {
+            self.variant = variant
+            self.title = title
+        }
+        
+        public var body: some View {
             Text(title)
                 .paragraphNew(
                     variant: variant.typoVariant,
@@ -230,6 +285,20 @@ public struct TopNavigation: View {
         }
     }
     
+    /// 내비게이션 바의 왼쪽(leading) 영역에 위치하는 기본 버튼입니다.
+    ///
+    /// 뒤로가기, 아이콘 버튼, 텍스트 버튼 등의 다양한 형태를 지원하며,
+    /// 배경 및 대체 스타일도 옵션으로 제공합니다.
+    ///
+    /// ```swift
+    /// LeadingButton(
+    ///     .back { dismiss() },
+    ///     true,   // alternative 스타일
+    ///     false   // background 없음
+    /// )
+    /// ```
+    ///
+    /// 버튼이 없을 경우에는 투명한 공간을 차지하여 레이아웃이 유지됩니다.
     public struct LeadingButton: View {
         let action: Resource.LeadingButtonInfo?
         let alternative: Bool
@@ -287,23 +356,21 @@ public struct TopNavigation: View {
         }
     }
     
-    struct TrailingContents: View {
-        let contents: [() -> AnyView]
-        
-        init(_ contents:  [() -> AnyView]) {
-            self.contents = contents
-        }
-
-        var body: some View {
-            HStack(alignment: .center, spacing: 16) {
-                ForEach(contents.indices, id: \.self) { i in
-                    Group { contents[i]() }
-                }
-            }
-            .contentShape(Rectangle().scale(2), eoFill: true)
-        }
-    }
-    
+    /// 내비게이션 바의 오른쪽(trailing)에 위치하는 텍스트 버튼입니다.
+    ///
+    /// 배경이 있는 스타일과 없는 스타일을 모두 지원하며,
+    /// alternative 색상 스타일 및 disable 처리도 가능합니다.
+    ///
+    /// ```swift
+    /// TrailingTextButton(
+    ///     text: "확인",
+    ///     background: true,
+    ///     alternative: false,
+    ///     disable: false
+    /// ) {
+    ///     // 버튼 액션
+    /// }
+    /// ```
     public struct TrailingTextButton: View {
         private let text: String
         private let background: Bool
@@ -380,6 +447,20 @@ public struct TopNavigation: View {
         }
     }
     
+    /// 내비게이션 바의 오른쪽(trailing)에 위치하는 아이콘 버튼입니다.
+    ///
+    /// 배경 스타일, alternative 색상, 비활성화(disable), 푸시 뱃지 등을 옵션으로 설정할 수 있습니다.
+    ///
+    /// ```swift
+    /// TrailingIconButton(
+    ///     icon: .bell,
+    ///     background: true,
+    ///     alternative: false,
+    ///     showPushBadge: true
+    /// ) {
+    ///     // 버튼 액션
+    /// }
+    /// ```
     public struct TrailingIconButton: View {
         private let icon: Icon
         private let disable: Bool
@@ -576,26 +657,26 @@ extension TopNavigation {
     /// ```
     struct TopNavigationModifier: ViewModifier {
         private let variant: Variant
-        private let title: String
+        private let title: (() -> AnyView)
         private let showIndicator: Bool
         private let backgroundColor: SwiftUI.Color?
-        private let leading: (() -> any View)?
-        private let trailings: [() -> any View]
+        private let leading: (() -> AnyView)
+        private let trailings: [() -> AnyView]
         private let actionAreaModel: ActionArea.Model?
         
         /// TopNavigationModifier를 초기화합니다.
         ///
         /// - Parameters:
         ///   - variant: 내비게이션 바의 외관 스타일
-        ///   - title: 표시할 제목
+        ///   - title: 제목 영역
         ///   - showIndicator: 인디케이터 표시 여부
         ///   - backgroundColor: 배경색
-        ///   - leading: 좌측에 표시할 버튼
-        ///   - trailings: 우측에 표시할 버튼 배열
+        ///   - leading: 좌측에 표시할 컴포넌트
+        ///   - trailings: 우측에 표시할 컴포넌트 배열
         ///   - actionAreaModel: 액션 영역 모델
         init(
             variant: Variant,
-            title: String,
+            title: (() -> any View)? = nil,
             showIndicator: Bool = true,
             backgroundColor: SwiftUI.Color? = nil,
             leading: (() -> any View)? = nil,
@@ -603,7 +684,7 @@ extension TopNavigation {
             actionAreaModel: ActionArea.Model? = nil
         ) {
             self.variant = variant
-            self.title = title
+            self.title = title.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
             self.showIndicator = showIndicator
             self.backgroundColor = backgroundColor
             self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
@@ -634,12 +715,12 @@ extension TopNavigation {
                     VStack(alignment: .leading, spacing: .zero) {
                         TopNavigation(
                             variant: variant,
-                            title: title,
                             scrollOffset: scrollStatus.contentOffset.y,
-                            backgroundColor: backgroundColor,
-                            leading: leading,
-                            trailings: trailings
+                            backgroundColor: backgroundColor
                         )
+                        .title { title() }
+                        .leading { leading() }
+                        .trailing(trailings)
                         .onGeometryChange(
                             for: CGSize.self,
                             of: { $0.size },
@@ -679,7 +760,7 @@ extension View {
     /// - Returns: TopNavigation이 적용된 뷰
     public func topNavigation(
         variant: TopNavigation.Variant = .normal,
-        title: String,
+        title: (() -> any View)? = nil,
         backgroundColor: SwiftUI.Color? = nil,
         leading: (() -> any View)? = nil,
         trailings: [() -> any View] = [],

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -14,10 +14,10 @@ import SwiftUI
 ///
 /// ```swift
 /// TopNavigation(
-///     variant: .normal,
 ///     scrollOffset: $scrollOffset,
 ///     backgroundColor: .white
 /// )
+/// .variant(.normal)
 /// .title ( /* 제목 텍스트 */ )
 /// .leadingContent { /* 왼쪽 영역 컴포넌트 */ }
 /// .trailingContents(
@@ -27,10 +27,10 @@ import SwiftUI
 /// ```
 /// ```swift
 ///TopNavigation(
-///    variant: .normal,
 ///    scrollOffset: $scrollOffset,
 ///    backgroundColor: .white
 ///)
+///.variant(.floating())
 ///.title { /* 제목 컴포넌트 */ }
 ///.leadingContent { /* 왼쪽 영역 컴포넌트 */ }
 ///.trailingContents(
@@ -100,17 +100,15 @@ public struct TopNavigation: View {
     
     /// 텍스트 기반 타이틀을 설정합니다.
     ///
-    /// 전달된 텍스트는 `TopNavigation.TitleView`로 감싸져 렌더링되며,
-    /// Variant를 함께 지정하여 텍스트의 타이포 스타일이나 정렬 등을 조절할 수 있습니다.
+    /// 전달된 텍스트는 `TopNavigation.TitleView`로 감싸져 렌더링됩니다.
     ///
     /// - Parameters:
-    ///   - variant: 타이틀에 적용할 스타일 (기본값: `.normal`)
     ///   - text: 타이틀에 표시할 문자열
     /// - Returns: 수정된 내비게이션 바 인스턴스
-    public func title(variant: Variant = .normal, text: String) -> Self {
+    public func title(text: String) -> Self {
         var zelf = self
         zelf.title = {
-            AnyView(TitleView(variant: variant, title: text))
+            AnyView(TitleView(variant: self.variant, title: text))
         }
         return zelf
     }
@@ -562,7 +560,8 @@ extension TopNavigation {
     /// 내비게이션 바의 다양한 레이아웃과 시각적 스타일을 정의합니다.
     ///
     /// ```swift
-    /// TopNavigation(variant: .floating)
+    /// TopNavigation
+    ///     .variant(.floating())
     ///     .title { ... }
     /// ```
     public enum Variant: Equatable {
@@ -588,9 +587,9 @@ extension TopNavigation {
         /// 뒤로가기 버튼, 아이콘 버튼, 텍스트 버튼을 지원합니다.
         ///
         /// ```swift
-        /// TopNavigation(
-        ///     leadingContent: { .. }
-        /// )
+        /// TopNavigation()
+        ///     .leadingContent: { /* ... */ }
+        ///
         /// ```
         public enum LeadingButtonInfo {
             /// 뒤로가기 버튼
@@ -613,14 +612,10 @@ extension TopNavigation {
         ///
         /// ```swift
         /// TopNavigation(
-        ///     trailingButtons: [
-        ///         .icon(.search) {
-        ///             // 검색 동작
-        ///         },
-        ///         .text("완료") {
-        ///             // 완료 동작
-        ///         }
-        ///     ]
+        ///     .trailingContents(
+        ///         { TopNavigation.TrailingIconButton(icon: .search) { /* ... */ } },
+        ///         { TopNavigation.TrailingTextButton(text: "완료") { /* ... */ } }
+        ///     )
         /// )
         /// ```
         public enum TrailingButtonInfo: Hashable {
@@ -704,7 +699,7 @@ extension TopNavigation {
     ///         TopNavigation.TopNavigationModifier(
     ///             variant: .normal,
     ///             title: {
-    ///                 TopNavigation.TitleView(variant: .normal, title: "제목")
+    ///                 TopNavigation.TitleView(title: "제목")
     ///             },
     ///             leadingContent: {
     ///                 TopNavigation.LeadingButton(.back(action: {}))

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -430,6 +430,7 @@ extension TopNavigation {
                                 .clipShape(RoundedRectangle(cornerRadius: 1000))
                             }
                     }
+                    .disabled(disable)
                 } else {
                     Button.text(text: text) {
                         action()

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -15,12 +15,12 @@ import SwiftUI
 /// ```swift
 /// TopNavigation(
 ///     variant: .normal,
-///     scrollOffset: (*optional),
-///     backgroundColor: (*optional)
+///     scrollOffset: // 기본값 .zero,
+///     backgroundColor: // 기본값 nil
 /// )
 /// .title { 제목 컴포넌트 }
 /// .leadingContent { 왼쪽 영역 컴포넌트 }
-/// .trailing([
+/// .trailingContents([
 ///     { 컴포넌트1 },
 ///     { 컴포넌트2 } ...
 /// ])
@@ -106,8 +106,22 @@ public struct TopNavigation: View {
     /// - Parameter contents: trailing 영역에 표시할 뷰들을 반환하는 클로저 배열
     /// - Returns: 수정된 인스턴스를 반환합니다.
     public func trailingContents(_ contents: [() -> any View]) -> Self {
+        trailingContents(contents.prefix(3).map{ view in { AnyView(view()) } })
+    }
+
+    /// 내비게이션 영역의 오른쪽(trailing) 영역에 표시할 뷰들을 설정합니다.
+    ///
+    /// 이 메서드는 배열 버전(`trailingContents(_:)`)에 대한 편의 오버로딩입니다.
+    ///
+    /// - Parameter contents: 오른쪽에 노출될 컨텐츠 클로저들 (최대 3개까지 표시)
+    /// - Returns: 수정된 내비게이션 바 뷰
+    public func trailingContents(_ contents: (() -> any View)...) -> Self {
+        trailingContents(contents)
+    }
+
+    func trailingContents(_ contents: [() -> AnyView]) -> Self {
         var zelf = self
-        zelf.trailingContents = contents.prefix(3).map{ view in { AnyView(view()) } }
+        zelf.trailingContents = Array(contents.prefix(3))
         return zelf
     }
 
@@ -158,10 +172,10 @@ public struct TopNavigation: View {
 
         private var titleSize: CGFloat {
             let componentSize: CGFloat = max(leadingSize.width, totalSizeOfTrailings.width)
-            let componentWitdh: CGFloat = componentSize * 2
+            let componentWidth: CGFloat = componentSize * 2
             let horizontalPadding: CGFloat = 16 * 2
             let titleHorizontalPadding: CGFloat = 4 * 2
-            return max(screenWidth - (componentWitdh + horizontalPadding + titleHorizontalPadding), 0)
+            return max(screenWidth - (componentWidth + horizontalPadding + titleHorizontalPadding), 0)
         }
         
         var body: some View {
@@ -206,7 +220,7 @@ public struct TopNavigation: View {
                         }
                         .padding(.horizontal, 4)
                     }
-                case let .floating(alternative, background):
+                case .floating:
                     ZStack {
                         HStack(spacing: .zero) {
                             leadingContent()
@@ -262,9 +276,9 @@ extension TopNavigation {
     public struct TitleView: View {
         let variant: Variant
         let title: String
-        
+
         public init(
-            variant: Variant,
+            variant: Variant = .normal,
             title: String
         ) {
             self.variant = variant
@@ -504,10 +518,8 @@ extension TopNavigation {
     /// 내비게이션 바의 다양한 레이아웃과 시각적 스타일을 정의합니다.
     ///
     /// ```swift
-    /// TopNavigation(
-    ///     variant: .floating(alternative: true, background: true),
-    ///     title: "제목"
-    /// )
+    /// TopNavigation(variant: .floating)
+    ///     .title { ... }
     /// ```
     public enum Variant: Equatable {
         /// 기본 내비게이션 바 스타일
@@ -515,9 +527,6 @@ extension TopNavigation {
         /// 확장된 내비게이션 바 스타일 (제목이 별도의 줄에 표시됨)
         case extended
         /// 플로팅 스타일의 내비게이션 바
-        /// - Parameters:
-        ///   - alternative: 대체 색상 사용 여부
-        ///   - background: 배경색 적용 여부
         case floating(alternative: Bool = false, background: Bool = false)
         
         fileprivate var isFloating: Bool {
@@ -536,9 +545,7 @@ extension TopNavigation {
         ///
         /// ```swift
         /// TopNavigation(
-        ///     leadingButton: .back {
-        ///         // 뒤로가기 동작
-        ///     }
+        ///     leadingContent: { .. }
         /// )
         /// ```
         public enum LeadingButtonInfo {
@@ -603,7 +610,14 @@ extension TopNavigation {
                 lhs: TopNavigation.Resource.TrailingButtonInfo,
                 rhs: TopNavigation.Resource.TrailingButtonInfo
             ) -> Bool {
-                lhs.hashValue == rhs.hashValue
+                switch (lhs, rhs) {
+                case let (.icon(li, ld, ls, _), .icon(ri, rd, rs, _)):
+                    return li == ri && ld == rd && ls == rs
+                case let (.text(lt, ld, _), .text(rt, rd, _)):
+                    return lt == rt && ld == rd
+                default:
+                    return false
+                }
             }
         }
     }
@@ -645,18 +659,24 @@ extension TopNavigation {
     ///     .modifier(
     ///         TopNavigation.TopNavigationModifier(
     ///             variant: .normal,
-    ///             title: "제목",
-    ///             leadingButton: .back { 
-    ///                 // 뒤로가기 동작
+    ///             title: {
+    ///                 TopNavigation.TitleView(variant: .normal, title: "제목")
     ///             },
-    ///             trailingButtons: []
+    ///             leadingContent: {
+    ///                 TopNavigation.LeadingButton(.back(action: {}))
+    ///             },
+    ///             trailingContents: [
+    ///                 {
+    ///                     TopNavigation.TrailingIconButton(icon: .bell, action: {})
+    ///                 }
+    ///                 ...
+    ///             ]
     ///         )
     ///     )
     /// ```
     struct TopNavigationModifier: ViewModifier {
         private let variant: Variant
         private let title: (() -> AnyView)
-        private let showIndicator: Bool
         private let backgroundColor: SwiftUI.Color?
         private let leadingContent: (() -> AnyView)
         private let trailingContents: [() -> AnyView]
@@ -667,26 +687,23 @@ extension TopNavigation {
         /// - Parameters:
         ///   - variant: 내비게이션 바의 외관 스타일
         ///   - title: 제목 영역
-        ///   - showIndicator: 인디케이터 표시 여부
         ///   - backgroundColor: 배경색
         ///   - leadingContent: 좌측에 표시할 컴포넌트
         ///   - trailingContents: 우측에 표시할 컴포넌트 배열
         ///   - actionAreaModel: 액션 영역 모델
         init(
             variant: Variant,
-            title: (() -> any View)? = nil,
-            showIndicator: Bool = true,
+            title: (() -> AnyView)? = nil,
             backgroundColor: SwiftUI.Color? = nil,
-            leadingContent: (() -> any View)? = nil,
-            trailingContents: [() -> any View] = [],
+            leadingContent: (() -> AnyView)? = nil,
+            trailingContents: [() -> AnyView] = [],
             actionAreaModel: ActionArea.Model? = nil
         ) {
             self.variant = variant
-            self.title = title.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
-            self.showIndicator = showIndicator
+            self.title = title ?? { AnyView(EmptyView()) }
             self.backgroundColor = backgroundColor
-            self.leadingContent = leadingContent.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
-            self.trailingContents = trailingContents.prefix(3).map { view in { AnyView(view()) } }
+            self.leadingContent = leadingContent ?? { AnyView(EmptyView()) }
+            self.trailingContents = Array(trailingContents.prefix(3))
             self.actionAreaModel = actionAreaModel
         }
         
@@ -750,10 +767,10 @@ extension View {
     ///
     /// - Parameters:
     ///   - variant: 내비게이션 바의 외관 스타일 (기본값: .normal)
-    ///   - title: 표시할 제목
+    ///   - title: 표시할 제목 컴포넌트 클로저 (기본값: nil)
     ///   - backgroundColor: 배경색 (기본값: nil)
-    ///   - leadingContent: 좌측에 표시할 컴포넌트 (기본값: nil)
-    ///   - trailingContents: 우측에 표시할 컴포넌트 (기본값: [])
+    ///   - leadingContent: 좌측에 표시할 컴포넌트 클로저 (기본값: nil)
+    ///   - trailingContents: 우측에 표시할 컴포넌트 클로저 (기본값: [])
     ///   - model: 하단 액션 영역에 대한 모델 (기본값: nil)
     /// - Returns: TopNavigation이 적용된 뷰
     public func topNavigation(
@@ -767,10 +784,10 @@ extension View {
         modifier(
             TopNavigation.TopNavigationModifier(
                 variant: variant,
-                title: title,
+                title: title.map { v in { AnyView(v()) } },
                 backgroundColor: backgroundColor,
-                leadingContent: leadingContent,
-                trailingContents: trailingContents,
+                leadingContent: leadingContent.map { v in { AnyView(v()) } },
+                trailingContents: trailingContents.prefix(3).map { v in { AnyView(v()) } },
                 actionAreaModel: model
             )
         )

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -15,20 +15,33 @@ import SwiftUI
 /// ```swift
 /// TopNavigation(
 ///     variant: .normal,
-///     scrollOffset: // 기본값 .zero,
-///     backgroundColor: // 기본값 nil
+///     scrollOffset: $scrollOffset,
+///     backgroundColor: .white
 /// )
-/// .title { 제목 컴포넌트 }
-/// .leadingContent { 왼쪽 영역 컴포넌트 }
-/// .trailingContents([
-///     { 컴포넌트1 },
-///     { 컴포넌트2 } ...
-/// ])
+/// .title ( /* 제목 텍스트 */ )
+/// .leadingContent { /* 왼쪽 영역 컴포넌트 */ }
+/// .trailingContents(
+///     { /* 컴포넌트1 },
+///     { /* 컴포넌트2 } ...
+/// )
+/// ```
+/// ```swift
+///TopNavigation(
+///    variant: .normal,
+///    scrollOffset: $scrollOffset,
+///    backgroundColor: .white
+///)
+///.title { /* 제목 컴포넌트 */ }
+///.leadingContent { /* 왼쪽 영역 컴포넌트 */ }
+///.trailingContents(
+///    { /* 컴포넌트1 },
+///    { /* 컴포넌트2 } ...
+///)
 /// ```
 public struct TopNavigation: View {
     // MARK: - Uninitialised properties
     
-    private let variant: Variant
+    
     private let scrollOffset: CGFloat
     private let backgroundColor: SwiftUI.Color?
     
@@ -58,20 +71,49 @@ public struct TopNavigation: View {
     ///   - scrollOffset: 스크롤 오프셋 값
     ///   - backgroundColor: 배경색
     public init(
-        variant: Variant = .normal,
         scrollOffset: CGFloat = .zero,
         backgroundColor: SwiftUI.Color? = nil
     ) {
-        self.variant = variant
         self.scrollOffset = scrollOffset
         self.backgroundColor = backgroundColor
     }
     
     // MARK: - Modifiers
     
+    private var variant: Variant = .normal
     private var title: () -> AnyView  = { AnyView(EmptyView()) }
     private var leadingContent: () -> AnyView  = { AnyView(EmptyView()) }
     private var trailingContents: [() -> AnyView] = []
+
+    /// 내비게이션 바의 스타일(Variant)을 설정합니다.
+    ///
+    /// `.normal`, `.extended`, `.floating`, `.emphasized` 중 하나의 스타일을 지정할 수 있으며,
+    /// 스타일에 따라 내비게이션의 외형과 정렬 방식 등이 달라집니다.
+    ///
+    /// - Parameter variant: 적용할 내비게이션 스타일
+    /// - Returns: 수정된 내비게이션 바 인스턴스
+    public func variant(_ variant: Variant) -> Self {
+        var zelf = self
+        zelf.variant = variant
+        return zelf
+    }
+    
+    /// 텍스트 기반 타이틀을 설정합니다.
+    ///
+    /// 전달된 텍스트는 `TopNavigation.TitleView`로 감싸져 렌더링되며,
+    /// Variant를 함께 지정하여 텍스트의 타이포 스타일이나 정렬 등을 조절할 수 있습니다.
+    ///
+    /// - Parameters:
+    ///   - variant: 타이틀에 적용할 스타일 (기본값: `.normal`)
+    ///   - text: 타이틀에 표시할 문자열
+    /// - Returns: 수정된 내비게이션 바 인스턴스
+    public func title(variant: Variant = .normal, text: String) -> Self {
+        var zelf = self
+        zelf.title = {
+            AnyView(TitleView(variant: variant, title: text))
+        }
+        return zelf
+    }
     
     /// 내비게이션 영역의 타이틀 뷰를 설정합니다.
     ///
@@ -111,12 +153,14 @@ public struct TopNavigation: View {
 
     /// 내비게이션 영역의 오른쪽(trailing) 영역에 표시할 뷰들을 설정합니다.
     ///
-    /// 이 메서드는 배열 버전(`trailingContents(_:)`)에 대한 편의 오버로딩입니다.
+    /// 최대 3개까지의 뷰를 클로저를 , 로 구분하여 전달할 수 있으며,
+    /// 각 클로저는 다양한 타입의 View를 반환할 수 있습니다 (`any View`).
+    /// 내부적으로는 모든 View를 `AnyView`로 타입을 지운 후 렌더링합니다.
     ///
-    /// - Parameter contents: 오른쪽에 노출될 컨텐츠 클로저들 (최대 3개까지 표시)
-    /// - Returns: 수정된 내비게이션 바 뷰
+    /// - Parameter contents: trailing 영역에 표시할 뷰들을 반환하는 클로저들
+    /// - Returns: 수정된 인스턴스를 반환합니다.
     public func trailingContents(_ contents: (() -> any View)...) -> Self {
-        trailingContents(contents)
+        trailingContents(contents.prefix(3).map{ view in { AnyView(view()) } })
     }
 
     func trailingContents(_ contents: [() -> AnyView]) -> Self {
@@ -198,11 +242,11 @@ public struct TopNavigation: View {
                             )
                         Spacer()
                         TrailingContents(trailingContents)
-                        .onGeometryChange(
-                            for: CGSize.self,
-                            of: { $0.size },
-                            action: { totalSizeOfTrailings = $0 }
-                        )
+                            .onGeometryChange(
+                                for: CGSize.self,
+                                of: { $0.size },
+                                action: { totalSizeOfTrailings = $0 }
+                            )
                     }
                     title()
                         .frame(width: titleSize, height: 24)
@@ -729,10 +773,10 @@ extension TopNavigation {
                     
                     VStack(alignment: .leading, spacing: .zero) {
                         TopNavigation(
-                            variant: variant,
                             scrollOffset: scrollStatus.contentOffset.y,
                             backgroundColor: backgroundColor
                         )
+                        .variant(variant)
                         .title { title() }
                         .leadingContent { leadingContent() }
                         .trailingContents(trailingContents)
@@ -785,6 +829,36 @@ extension View {
             TopNavigation.TopNavigationModifier(
                 variant: variant,
                 title: title.map { v in { AnyView(v()) } },
+                backgroundColor: backgroundColor,
+                leadingContent: leadingContent.map { v in { AnyView(v()) } },
+                trailingContents: trailingContents.prefix(3).map { v in { AnyView(v()) } },
+                actionAreaModel: model
+            )
+        )
+    }
+
+    /// 현재 뷰에 TopNavigation 바를 적용합니다.
+    ///
+    /// - Parameters:
+    ///   - variant: 내비게이션 바의 외관 스타일 (기본값: .normal)
+    ///   - title: 표시할 텍스트 타이틀 (기본값: nil)
+    ///   - backgroundColor: 배경색 (기본값: nil)
+    ///   - leadingContent: 좌측에 표시할 컴포넌트 클로저 (기본값: nil)
+    ///   - trailingContents: 우측에 표시할 컴포넌트 클로저 (기본값: [])
+    ///   - model: 하단 액션 영역에 대한 모델 (기본값: nil)
+    /// - Returns: TopNavigation이 적용된 뷰
+    public func topNavigation(
+        variant: TopNavigation.Variant = .normal,
+        title: String,
+        backgroundColor: SwiftUI.Color? = nil,
+        leadingContent: (() -> any View)? = nil,
+        trailingContents: [() -> any View] = [],
+        withBottom model: ActionArea.Model? = nil
+    ) -> some View {
+        modifier(
+            TopNavigation.TopNavigationModifier(
+                variant: variant,
+                title:  { AnyView(TopNavigation.TitleView(variant: variant, title: title)) },
                 backgroundColor: backgroundColor,
                 leadingContent: leadingContent.map { v in { AnyView(v()) } },
                 trailingContents: trailingContents.prefix(3).map { v in { AnyView(v()) } },

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -19,10 +19,14 @@ import SwiftUI
 ///     leading: {
 ///         // 뒤로가기 동작 컴포넌트
 ///     },
-///     trailingButtons: [
-///         .icon(.search) {
-///             // 검색 동작
-///         }
+///     trailing: [
+///         {
+///           // 컴포넌트1
+///         },
+///         {
+///           // 컴포넌트2
+///         },
+///         ...
 ///     ]
 /// )
 /// ```
@@ -33,7 +37,6 @@ public struct TopNavigation: View {
     private let title: String
     private let scrollOffset: CGFloat
     private let backgroundColor: SwiftUI.Color?
-    private let trailingButtons: [Resource.TrailingButtonInfo]
     
     // MARK: - Computed properties
 
@@ -62,30 +65,37 @@ public struct TopNavigation: View {
     ///   - scrollOffset: 스크롤 오프셋 값
     ///   - backgroundColor: 배경색
     ///   - leading: 좌측에 표시할 컨텐츠
-    ///   - trailingButtons: 우측에 표시할 버튼 배열 (최대 3개까지 표시)
+    ///   - trailings: 우측에 표시할 버튼 배열 (최대 3개까지 표시)
     public init(
         variant: Variant = .normal,
         title: String = "",
         scrollOffset: CGFloat = .zero,
         backgroundColor: SwiftUI.Color? = nil,
         leading: (() -> any View)? = nil,
-        trailingButtons: [Resource.TrailingButtonInfo] = []
+        trailings: [(() -> any View)] = []
     ) {
         self.variant = variant
         self.title = title
         self.scrollOffset = scrollOffset
         self.backgroundColor = backgroundColor
         self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
-        self.trailingButtons = Array(trailingButtons.prefix(3))
+        self.trailings = trailings.prefix(3).map { view in { AnyView(view()) } }
     }
     
     // MARK: - Modifiers
     
     private var leading: () -> AnyView
+    private var trailings: [() -> AnyView]
     
     public func leading<V: View>(@ViewBuilder content: @escaping () -> V) -> Self {
         var zelf = self
         zelf.leading = { AnyView(content()) }
+        return zelf
+    }
+    
+    public func trailing<V: View>(contents: [() -> V]) -> Self {
+        var zelf = self
+        zelf.trailings = contents.prefix(3).map{ view in { AnyView(view()) } }
         return zelf
     }
 
@@ -95,7 +105,7 @@ public struct TopNavigation: View {
                 variant: variant,
                 title: title,
                 leading: leading,
-                trailingButtons: trailingButtons
+                trailings: trailings
             )
             .padding(.all, 16)
             .background {
@@ -125,17 +135,17 @@ public struct TopNavigation: View {
     }
     
     struct Contents: View {
-        @State private var leadingButtonSize: CGSize = .zero
-        @State private var totalSizeOfTrailingButtons: CGSize = .zero
+        @State private var leadingSize: CGSize = .zero
+        @State private var totalSizeOfTrailings: CGSize = .zero
         @State private var screenWidth: CGFloat = 0
         
         var variant: Variant
         var title: String
         var leading: () -> AnyView
-        var trailingButtons: [Resource.TrailingButtonInfo]
+        var trailings: [() -> AnyView]
 
         private var titleSize: CGFloat {
-            let componentSize: CGFloat = max(leadingButtonSize.width, totalSizeOfTrailingButtons.width)
+            let componentSize: CGFloat = max(leadingSize.width, totalSizeOfTrailings.width)
             let componentWitdh: CGFloat = componentSize * 2
             let horizontalPadding: CGFloat = 16 * 2
             let titleHorizontalPadding: CGFloat = 4 * 2
@@ -158,15 +168,15 @@ public struct TopNavigation: View {
                             .onGeometryChange(
                                 for: CGSize.self,
                                 of: { $0.size },
-                                action: { leadingButtonSize = $0 }
+                                action: { leadingSize = $0 }
                             )
                         Spacer()
-                        TrailingButtons(trailingButtons)
-                            .onGeometryChange(
-                                for: CGSize.self,
-                                of: { $0.size },
-                                action: { totalSizeOfTrailingButtons = $0 }
-                            )
+                        TrailingContents(trailings)
+                        .onGeometryChange(
+                            for: CGSize.self,
+                            of: { $0.size },
+                            action: { totalSizeOfTrailings = $0 }
+                        )
                     }
                     titleView
                         .frame(width: titleSize, height: 24)
@@ -175,7 +185,7 @@ public struct TopNavigation: View {
                         HStack {
                             leading()
                             Spacer()
-                            TrailingButtons(trailingButtons)
+                            TrailingContents(trailings)
                         }
                         HStack {
                             titleView
@@ -191,14 +201,14 @@ public struct TopNavigation: View {
                                 .onGeometryChange(
                                     for: CGSize.self,
                                     of: { $0.size },
-                                    action: { leadingButtonSize = $0 }
+                                    action: { leadingSize = $0 }
                                 )
                             Spacer()
-                            TrailingButtons(trailingButtons, alternative, background)
+                            TrailingContents(trailings)
                                 .onGeometryChange(
                                     for: CGSize.self,
                                     of: { $0.size },
-                                    action: { totalSizeOfTrailingButtons = $0 }
+                                    action: { totalSizeOfTrailings = $0 }
                                 )
                         }
                         .frame(height: 24)
@@ -262,9 +272,9 @@ public struct TopNavigation: View {
                     case let .text(t, action):
                         TrailingTextButton(
                             text: t,
-                            action: action,
                             background: background,
-                            alternative: alternative
+                            alternative: alternative,
+                            action: action
                         )
                         .frame(height: 24)
                     }
@@ -277,129 +287,134 @@ public struct TopNavigation: View {
         }
     }
     
-    struct TrailingButtons: View {
-        let buttons: [Resource.TrailingButtonInfo]
-        let alternative: Bool
-        let background: Bool
+    struct TrailingContents: View {
+        let contents: [() -> AnyView]
         
-        init(
-            _ buttons: [Resource.TrailingButtonInfo],
-            _ alternative: Bool = false,
-            _ background: Bool = false
-        ) {
-            self.buttons = buttons
-            self.alternative = alternative
-            self.background = background
+        init(_ contents:  [() -> AnyView]) {
+            self.contents = contents
         }
 
         var body: some View {
-            if buttons.isEmpty == false {
-                HStack(alignment: .center, spacing: 16) {
-                    ForEach(buttons, id: \.self) { button in
-                        Group {
-                            switch button {
-                            case let .icon(i, d, s, action):
-                                IconButton(
-                                    variant: background ?
-                                        .background(size: 24, isAlternative: alternative) : .default,
-                                    icon: i
-                                ) {
-                                    action()
-                                }
-                                .disable(d)
-                                .showPushBadge(s)
-                                .frame(width: 24, height: 24)
-                            case let .text(t, d, action):
-                                TrailingTextButton(
-                                    text: t,
-                                    action: action,
-                                    background: background,
-                                    alternative: alternative,
-                                    disable: d
-                                )
-                                .frame(height: 24)
-                            }
-                        }
-                    }
+            HStack(alignment: .center, spacing: 16) {
+                ForEach(contents.indices, id: \.self) { i in
+                    Group { contents[i]() }
                 }
-                .contentShape(Rectangle().scale(2), eoFill: true)
-            } else {
-                SwiftUI.Color.clear
-                    .frame(width: 24, height: 24)
             }
+            .contentShape(Rectangle().scale(2), eoFill: true)
         }
     }
     
-    private struct TrailingTextButton: View {
+    public struct TrailingTextButton: View {
         private let text: String
-        private let action: () -> Void
         private let background: Bool
         private let alternative: Bool
         private let disable: Bool
+        private let action: () -> Void
         
-        init(
+        public init(
             text: String,
-            action: @escaping () -> Void,
-            background: Bool,
-            alternative: Bool,
-            disable: Bool = false
+            background: Bool = false,
+            alternative: Bool = false,
+            disable: Bool = false,
+            action: @escaping () -> Void
         ) {
             self.text = text
-            self.action = action
             self.background = background
             self.alternative = alternative
             self.disable = disable
+            self.action = action
         }
 
-        var body: some View {
-            if background {
-                SwiftUI.Button {
-                    action()
-                } label: {
-                    Text(text)
-                        .paragraphNew(
-                            variant: .body2,
-                            weight: .medium,
-                            semantic: disable ? .labelDisable : (alternative ? .staticWhite : .labelAlternative)
-                        )
-                        .if(alternative) {
-                            $0.opacity(0.88)
-                        } else: {
-                            $0.blendMode(.plusDarker)
-                        }
-                        .padding(.vertical, 5)
-                        .padding(.horizontal, 10)
-                        .modifying { original in
-                            Group {
-                                if alternative {
-                                    original.background(
-                                        SwiftUI.Color.atomic(.coolNeutral30)
-                                            .opacity(0.61)
-                                    )
-                                } else {
-                                    original.background(
-                                        ZStack {
-                                            SwiftUI.Color.semantic(.staticBlack)
-                                                .opacity(0.05)
-                                            SwiftUI.Color.semantic(.staticWhite)
-                                                .opacity(0.35)
-                                        }
-                                    )
-                                    .background(.thinMaterial)
-                                }
+        public var body: some View {
+            Group {
+                if background {
+                    SwiftUI.Button {
+                        action()
+                    } label: {
+                        Text(text)
+                            .paragraphNew(
+                                variant: .body2,
+                                weight: .medium,
+                                semantic: disable ? .labelDisable : (alternative ? .staticWhite : .labelAlternative)
+                            )
+                            .if(alternative) {
+                                $0.opacity(0.88)
+                            } else: {
+                                $0.blendMode(.plusDarker)
                             }
-                            .clipShape(RoundedRectangle(cornerRadius: 1000))
-                        }
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 10)
+                            .modifying { original in
+                                Group {
+                                    if alternative {
+                                        original.background(
+                                            SwiftUI.Color.atomic(.coolNeutral30)
+                                                .opacity(0.61)
+                                        )
+                                    } else {
+                                        original.background(
+                                            ZStack {
+                                                SwiftUI.Color.semantic(.staticBlack)
+                                                    .opacity(0.05)
+                                                SwiftUI.Color.semantic(.staticWhite)
+                                                    .opacity(0.35)
+                                            }
+                                        )
+                                        .background(.thinMaterial)
+                                    }
+                                }
+                                .clipShape(RoundedRectangle(cornerRadius: 1000))
+                            }
+                    }
+                } else {
+                    Button.text(text: text) {
+                        action()
+                    }
+                    .disable(disable)
+                    .contentColor(.semantic(.labelNormal))
+                    .fontVariant(.headline2)
+                    .fontWeight(.regular)
                 }
-            } else {
-                Button.text(text: text) {
-                    action()
-                }
-                .disable(disable)
-                .contentColor(.semantic(.labelNormal))
-                .fontVariant(.headline2)
-                .fontWeight(.regular)
             }
+            .frame(height: 24)
+        }
+    }
+    
+    public struct TrailingIconButton: View {
+        private let icon: Icon
+        private let disable: Bool
+        private let background: Bool
+        private let alternative: Bool
+        private let showPushBadge: Bool
+        private let action: () -> Void
+        
+        public init(
+            icon: Icon,
+            disable: Bool = false,
+            background: Bool = false,
+            alternative: Bool = false,
+            showPushBadge: Bool = false,
+            action: @escaping () -> Void
+        ) {
+            self.icon = icon
+            self.disable = disable
+            self.background = background
+            self.alternative = alternative
+            self.showPushBadge = showPushBadge
+            self.action = action
+        }
+        
+        public var body: some View {
+            IconButton(
+                variant: background ?
+                    .background(size: 24, isAlternative: alternative) : .default,
+                icon: icon
+            ) {
+                action()
+            }
+            .disable(disable)
+            .showPushBadge(showPushBadge)
+            .frame(width: 24, height: 24)
         }
     }
 }
@@ -565,7 +580,7 @@ extension TopNavigation {
         private let showIndicator: Bool
         private let backgroundColor: SwiftUI.Color?
         private let leading: (() -> any View)?
-        private let trailingButtons: [Resource.TrailingButtonInfo]
+        private let trailings: [() -> any View]
         private let actionAreaModel: ActionArea.Model?
         
         /// TopNavigationModifier를 초기화합니다.
@@ -575,8 +590,8 @@ extension TopNavigation {
         ///   - title: 표시할 제목
         ///   - showIndicator: 인디케이터 표시 여부
         ///   - backgroundColor: 배경색
-        ///   - leadingButton: 좌측에 표시할 버튼
-        ///   - trailingButtons: 우측에 표시할 버튼 배열
+        ///   - leading: 좌측에 표시할 버튼
+        ///   - trailings: 우측에 표시할 버튼 배열
         ///   - actionAreaModel: 액션 영역 모델
         init(
             variant: Variant,
@@ -584,7 +599,7 @@ extension TopNavigation {
             showIndicator: Bool = true,
             backgroundColor: SwiftUI.Color? = nil,
             leading: (() -> any View)? = nil,
-            trailingButtons: [Resource.TrailingButtonInfo],
+            trailings: [() -> any View] = [],
             actionAreaModel: ActionArea.Model? = nil
         ) {
             self.variant = variant
@@ -592,7 +607,7 @@ extension TopNavigation {
             self.showIndicator = showIndicator
             self.backgroundColor = backgroundColor
             self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
-            self.trailingButtons = trailingButtons
+            self.trailings = trailings.prefix(3).map { view in { AnyView(view()) } }
             self.actionAreaModel = actionAreaModel
         }
         
@@ -623,7 +638,7 @@ extension TopNavigation {
                             scrollOffset: scrollStatus.contentOffset.y,
                             backgroundColor: backgroundColor,
                             leading: leading,
-                            trailingButtons: trailingButtons
+                            trailings: trailings
                         )
                         .onGeometryChange(
                             for: CGSize.self,
@@ -658,8 +673,8 @@ extension View {
     ///   - variant: 내비게이션 바의 외관 스타일 (기본값: .normal)
     ///   - title: 표시할 제목
     ///   - backgroundColor: 배경색 (기본값: nil)
-    ///   - leadingButton: 좌측에 표시할 버튼 (기본값: nil)
-    ///   - trailingButtons: 우측에 표시할 버튼 배열 (기본값: [])
+    ///   - leading: 좌측에 표시할 컴포넌트 (기본값: nil)
+    ///   - trailings: 우측에 표시할 컴포넌트 (기본값: [])
     ///   - model: 하단 액션 영역에 대한 모델 (기본값: nil)
     /// - Returns: TopNavigation이 적용된 뷰
     public func topNavigation(
@@ -667,7 +682,7 @@ extension View {
         title: String,
         backgroundColor: SwiftUI.Color? = nil,
         leading: (() -> any View)? = nil,
-        trailingButtons: [TopNavigation.Resource.TrailingButtonInfo] = [],
+        trailings: [() -> any View] = [],
         withBottom model: ActionArea.Model? = nil
     ) -> some View {
         modifier(
@@ -676,7 +691,7 @@ extension View {
                 title: title,
                 backgroundColor: backgroundColor,
                 leading: leading,
-                trailingButtons: trailingButtons,
+                trailings: trailings,
                 actionAreaModel: model
             )
         )

--- a/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
@@ -14,20 +14,18 @@ import SwiftUI
 /// 다양한 스타일을 지원합니다.
 ///
 /// ```swift
-/// ModalNavigation(title: "제목")
+/// ModalNavigation()
 ///     .variant(.normal)
-///     leading: {
+///     .title {
+///         ModalNavigation.TitleView(variant: .normal, title: "제목")
+///     }
+///     .leading {
 ///         // 뒤로가기 동작 컴포넌트
-///     },
-///     trailing: [
-///         {
-///           // 컴포넌트1
-///         },
-///         {
-///           // 컴포넌트2
-///         },
-///         ...
-///     ]
+///     }
+///     .trailings([
+///         { /* 컴포넌트1 */ },
+///         { /* 컴포넌트2 */ }
+///     ])
 /// ```
 public struct ModalNavigation: View {
     // MARK: - Types
@@ -61,8 +59,9 @@ public struct ModalNavigation: View {
     /// 내비게이션 바를 초기화합니다.
     ///
     /// - Parameters:
-    ///   - title: 내비게이션 바에 표시할 제목
-    ///   - scrollOffset: 스크롤 오프셋에 대한 바인딩 (기본값: .constant(0))
+    ///   - title: 타이틀 영역을 구성하는 뷰 빌더 (없으면 빈 뷰)
+    ///   - scrollOffset: 스크롤 오프셋 바인딩 (기본값: .constant(0))
+    ///   - leading: 왼쪽 영역을 구성하는 뷰 빌더 (없으면 빈 뷰)
     public init(
         title: (() -> any View)? = nil,
         scrollOffset: Binding<CGFloat> = .constant(0),
@@ -161,7 +160,7 @@ public struct ModalNavigation: View {
     /// - Returns: 수정된 내비게이션 바 뷰
     public func title<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Self {
         var zelf = self
-        zelf.title = title
+        zelf.title = { AnyView(content()) }
         return zelf
     }
     
@@ -171,17 +170,21 @@ public struct ModalNavigation: View {
     /// - Returns: 수정된 내비게이션 바 뷰
     public func leading<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Self {
         var zelf = self
-        zelf.leading = leading
+        zelf.leading = { AnyView(content()) }
         return zelf
     }
     
     /// 내비게이션 바의 오른쪽 버튼 영역을 설정합니다.
     ///
+    /// 최대 3개까지의 뷰를 클로저 배열로 전달할 수 있으며,
+    /// 각 클로저는 다양한 타입의 View를 반환할 수 있습니다 (`any View`).
+    /// 내부적으로는 모든 View를 `AnyView`로 타입을 지운 후 렌더링합니다.
+    ///
     /// - Parameter contents: 오른쪽에 노출될 컨텐츠 배열 (최대 3개까지 표시)
     /// - Returns: 수정된 내비게이션 바 뷰
-    public func trailings<V: View>(_ contents: [() -> V]) -> Self {
+    public func trailings(_ contents: [() -> any View]) -> Self {
         var zelf = self
-        zelf.trailings = contents.prefix(3).map { view in { AnyView(view()) } }
+        zelf.trailings = contents.prefix(3).map { content in { AnyView(content()) } }
         return zelf
     }
     
@@ -207,8 +210,8 @@ public struct ModalNavigation: View {
                         title()
                         Spacer(minLength: 0)
                         Group {
-                            ForEach(trailings.indices, id: \.self) { i in
-                                trailings[i]()
+                            ForEach(Array(trailings.enumerated()), id: \.offset) { _, makeView in
+                                makeView()
                             }
                         }
                     }
@@ -284,15 +287,6 @@ private extension ModalNavigation.Variant {
         case .extended: .bold
         case .floating: .bold
         case .emphasized: .bold
-        }
-    }
-    
-    var textAlignment: Alignment {
-        switch self {
-        case .normal: .center
-        case .extended: .leading
-        case .floating: .center
-        case .emphasized: .leading
         }
     }
 }

--- a/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
@@ -16,14 +16,18 @@ import SwiftUI
 /// ```swift
 /// ModalNavigation(title: "제목")
 ///     .variant(.normal)
-///     .leadingButton(.back {
-///         // 뒤로가기 동작
-///     })
-///     .trailingButtons([
-///         .icon(.close, action: {
-///             // 닫기 동작
-///         })
-///     ])
+///     leading: {
+///         // 뒤로가기 동작 컴포넌트
+///     },
+///     trailing: [
+///         {
+///           // 컴포넌트1
+///         },
+///         {
+///           // 컴포넌트2
+///         },
+///         ...
+///     ]
 /// ```
 public struct ModalNavigation: View {
     // MARK: - Types
@@ -78,7 +82,7 @@ public struct ModalNavigation: View {
                 variant: variant,
                 title: title,
                 leading: leading,
-                trailingButtons: trailingButtons
+                trailings: trailings
             )
             .if(needHandleArea) {
                 $0.padding(.top, 10)
@@ -109,7 +113,7 @@ public struct ModalNavigation: View {
     private var backgroundColor: SwiftUI.Color? = nil
     private var needHandleArea = false
     private var leading: () -> AnyView
-    private var trailingButtons: [TopNavigation.Resource.TrailingButtonInfo] = []
+    private var trailings: [() -> AnyView] = []
     
     /// 내비게이션 바의 스타일을 설정합니다.
     ///
@@ -161,13 +165,13 @@ public struct ModalNavigation: View {
         return zelf
     }
     
-    /// 내비게이션 바의 오른쪽 버튼들을 설정합니다.
+    /// 내비게이션 바의 오른쪽 버튼 영역을 설정합니다.
     ///
-    /// - Parameter actions: 오른쪽 버튼 배열 (최대 3개까지 표시)
+    /// - Parameter contents: 오른쪽에 노출될 컨텐츠 배열 (최대 3개까지 표시)
     /// - Returns: 수정된 내비게이션 바 뷰
-    public func trailingButtons(_ actions: [TopNavigation.Resource.TrailingButtonInfo]) -> Self {
+    public func trailings<V: View>(_ contents: [() -> V]) -> Self {
         var zelf = self
-        zelf.trailingButtons = Array(actions.prefix(3))
+        zelf.trailings = contents.prefix(3).map { view in { AnyView(view()) } }
         return zelf
     }
     
@@ -175,7 +179,7 @@ public struct ModalNavigation: View {
         var variant: Variant
         var title: String
         var leading: () -> AnyView
-        var trailingButtons: [TopNavigation.Resource.TrailingButtonInfo]
+        var trailings: [() -> AnyView]
         
         var body: some View {
             switch variant {
@@ -184,7 +188,7 @@ public struct ModalNavigation: View {
                     variant: variant.topNavigationVariant,
                     title: title,
                     leading: leading,
-                    trailingButtons: trailingButtons
+                    trailings: trailings
                 )
             case .emphasized:
                 ZStack {
@@ -199,7 +203,11 @@ public struct ModalNavigation: View {
                             .lineLimit(1)
                             .frame(height: 24, alignment: variant.textAlignment)
                         Spacer(minLength: 0)
-                        TopNavigation.TrailingButtons(trailingButtons)
+                        Group {
+                            ForEach(trailings.indices, id: \.self) { i in
+                                trailings[i]()
+                            }
+                        }
                     }
                 }
             }

--- a/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
@@ -55,8 +55,7 @@ public struct ModalNavigation: View {
     }
     
     // MARK: - Initialisers
-    
-    private let title: String
+
     @Binding private var scrollOffset: CGFloat
     
     /// 내비게이션 바를 초기화합니다.
@@ -65,11 +64,11 @@ public struct ModalNavigation: View {
     ///   - title: 내비게이션 바에 표시할 제목
     ///   - scrollOffset: 스크롤 오프셋에 대한 바인딩 (기본값: .constant(0))
     public init(
-        title: String,
+        title: (() -> any View)? = nil,
         scrollOffset: Binding<CGFloat> = .constant(0),
         leading: (() -> any View)? = nil
     ) {
-        self.title = title
+        self.title = title.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
         _scrollOffset = scrollOffset
         self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
     }
@@ -112,6 +111,7 @@ public struct ModalNavigation: View {
     private var variant: Variant = .normal
     private var backgroundColor: SwiftUI.Color? = nil
     private var needHandleArea = false
+    private var title: () -> AnyView
     private var leading: () -> AnyView
     private var trailings: [() -> AnyView] = []
     
@@ -155,6 +155,16 @@ public struct ModalNavigation: View {
         return zelf
     }
     
+    /// 내비게이션 바의 타이틀  영역을 설정합니다.
+    ///
+    /// - Parameter content: 타이틀 영역에 컨텐츠
+    /// - Returns: 수정된 내비게이션 바 뷰
+    public func title<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Self {
+        var zelf = self
+        zelf.title = title
+        return zelf
+    }
+    
     /// 내비게이션 바의 왼쪽 버튼 영역을 설정합니다.
     ///
     /// - Parameter content: 왼쪽에 노출될 컨텐츠
@@ -177,7 +187,7 @@ public struct ModalNavigation: View {
     
     private struct Contents: View {
         var variant: Variant
-        var title: String
+        var title: () -> AnyView
         var leading: () -> AnyView
         var trailings: [() -> AnyView]
         
@@ -194,14 +204,7 @@ public struct ModalNavigation: View {
                 ZStack {
                     HStack(spacing: 20) {
                         leading()
-                        Text(title)
-                            .paragraphNew(
-                                variant: variant.typoVariant,
-                                weight: variant.typoWeight,
-                                semantic: .labelStrong
-                            )
-                            .lineLimit(1)
-                            .frame(height: 24, alignment: variant.textAlignment)
+                        title()
                         Spacer(minLength: 0)
                         Group {
                             ForEach(trailings.indices, id: \.self) { i in
@@ -211,6 +214,31 @@ public struct ModalNavigation: View {
                     }
                 }
             }
+        }
+    }
+}
+
+extension ModalNavigation {
+    public struct TitleView: View {
+        let variant: Variant
+        let title: String
+        
+        public init(
+            variant: Variant,
+            title: String
+        ) {
+            self.variant = variant
+            self.title = title
+        }
+        
+        public var body: some View {
+            Text(title)
+                .paragraphNew(
+                    variant: variant.typoVariant,
+                    weight: variant.typoWeight,
+                    semantic: .labelStrong
+                )
+                .lineLimit(1)
         }
     }
 }

--- a/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
@@ -229,7 +229,7 @@ extension ModalNavigation {
         let title: String
         
         public init(
-            variant: Variant,
+            variant: Variant = .normal,
             title: String
         ) {
             self.variant = variant

--- a/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
@@ -60,9 +60,14 @@ public struct ModalNavigation: View {
     /// - Parameters:
     ///   - title: 내비게이션 바에 표시할 제목
     ///   - scrollOffset: 스크롤 오프셋에 대한 바인딩 (기본값: .constant(0))
-    public init(title: String, scrollOffset: Binding<CGFloat> = .constant(0)) {
+    public init(
+        title: String,
+        scrollOffset: Binding<CGFloat> = .constant(0),
+        leading: (() -> any View)? = nil
+    ) {
         self.title = title
         _scrollOffset = scrollOffset
+        self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
     }
     
     // MARK: - Body
@@ -72,7 +77,7 @@ public struct ModalNavigation: View {
             Contents(
                 variant: variant,
                 title: title,
-                leadingButton: leadingButton,
+                leading: leading,
                 trailingButtons: trailingButtons
             )
             .if(needHandleArea) {
@@ -103,7 +108,7 @@ public struct ModalNavigation: View {
     private var variant: Variant = .normal
     private var backgroundColor: SwiftUI.Color? = nil
     private var needHandleArea = false
-    private var leadingButton: TopNavigation.Resource.LeadingButtonInfo? = nil
+    private var leading: () -> AnyView
     private var trailingButtons: [TopNavigation.Resource.TrailingButtonInfo] = []
     
     /// 내비게이션 바의 스타일을 설정합니다.
@@ -146,13 +151,13 @@ public struct ModalNavigation: View {
         return zelf
     }
     
-    /// 내비게이션 바의 왼쪽 버튼을 설정합니다.
+    /// 내비게이션 바의 왼쪽 버튼 영역을 설정합니다.
     ///
-    /// - Parameter leadingButton: 왼쪽 버튼 설정
+    /// - Parameter content: 왼쪽에 노출될 컨텐츠
     /// - Returns: 수정된 내비게이션 바 뷰
-    public func leadingButton(_ leadingButton: TopNavigation.Resource.LeadingButtonInfo?) -> Self {
+    public func leading<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Self {
         var zelf = self
-        zelf.leadingButton = leadingButton
+        zelf.leading = leading
         return zelf
     }
     
@@ -169,7 +174,7 @@ public struct ModalNavigation: View {
     private struct Contents: View {
         var variant: Variant
         var title: String
-        var leadingButton: TopNavigation.Resource.LeadingButtonInfo?
+        var leading: () -> AnyView
         var trailingButtons: [TopNavigation.Resource.TrailingButtonInfo]
         
         var body: some View {
@@ -178,13 +183,13 @@ public struct ModalNavigation: View {
                 TopNavigation.Contents(
                     variant: variant.topNavigationVariant,
                     title: title,
-                    leadingButton: leadingButton,
+                    leading: leading,
                     trailingButtons: trailingButtons
                 )
             case .emphasized:
                 ZStack {
                     HStack(spacing: 20) {
-                        TopNavigation.LeadingButton(leadingButton)
+                        leading()
                         Text(title)
                             .paragraphNew(
                                 variant: variant.typoVariant,

--- a/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/8 Presentation/ModalNavigation.swift
@@ -19,10 +19,10 @@ import SwiftUI
 ///     .title {
 ///         ModalNavigation.TitleView(variant: .normal, title: "제목")
 ///     }
-///     .leading {
+///     .leadingContent {
 ///         // 뒤로가기 동작 컴포넌트
 ///     }
-///     .trailings([
+///     .trailingContents([
 ///         { /* 컴포넌트1 */ },
 ///         { /* 컴포넌트2 */ }
 ///     ])
@@ -59,17 +59,9 @@ public struct ModalNavigation: View {
     /// 내비게이션 바를 초기화합니다.
     ///
     /// - Parameters:
-    ///   - title: 타이틀 영역을 구성하는 뷰 빌더 (없으면 빈 뷰)
     ///   - scrollOffset: 스크롤 오프셋 바인딩 (기본값: .constant(0))
-    ///   - leading: 왼쪽 영역을 구성하는 뷰 빌더 (없으면 빈 뷰)
-    public init(
-        title: (() -> any View)? = nil,
-        scrollOffset: Binding<CGFloat> = .constant(0),
-        leading: (() -> any View)? = nil
-    ) {
-        self.title = title.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
+    public init(scrollOffset: Binding<CGFloat> = .constant(0)) {
         _scrollOffset = scrollOffset
-        self.leading = leading.map { view in { AnyView(view()) } } ?? { AnyView(EmptyView()) }
     }
     
     // MARK: - Body
@@ -79,8 +71,8 @@ public struct ModalNavigation: View {
             Contents(
                 variant: variant,
                 title: title,
-                leading: leading,
-                trailings: trailings
+                leadingContent: leadingContent,
+                trailingContents: trailingContents
             )
             .if(needHandleArea) {
                 $0.padding(.top, 10)
@@ -110,9 +102,9 @@ public struct ModalNavigation: View {
     private var variant: Variant = .normal
     private var backgroundColor: SwiftUI.Color? = nil
     private var needHandleArea = false
-    private var title: () -> AnyView
-    private var leading: () -> AnyView
-    private var trailings: [() -> AnyView] = []
+    private var title: () -> AnyView = { AnyView(EmptyView()) }
+    private var leadingContent: () -> AnyView = { AnyView(EmptyView()) }
+    private var trailingContents: [() -> AnyView] = []
     
     /// 내비게이션 바의 스타일을 설정합니다.
     ///
@@ -154,9 +146,9 @@ public struct ModalNavigation: View {
         return zelf
     }
     
-    /// 내비게이션 바의 타이틀  영역을 설정합니다.
+    /// 내비게이션 바의 타이틀 영역을 설정합니다.
     ///
-    /// - Parameter content: 타이틀 영역에 컨텐츠
+    /// - Parameter content: 타이틀 영역에 표시될 콘텐츠
     /// - Returns: 수정된 내비게이션 바 뷰
     public func title<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Self {
         var zelf = self
@@ -168,9 +160,9 @@ public struct ModalNavigation: View {
     ///
     /// - Parameter content: 왼쪽에 노출될 컨텐츠
     /// - Returns: 수정된 내비게이션 바 뷰
-    public func leading<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Self {
+    public func leadingContent<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Self {
         var zelf = self
-        zelf.leading = { AnyView(content()) }
+        zelf.leadingContent = { AnyView(content()) }
         return zelf
     }
     
@@ -182,17 +174,27 @@ public struct ModalNavigation: View {
     ///
     /// - Parameter contents: 오른쪽에 노출될 컨텐츠 배열 (최대 3개까지 표시)
     /// - Returns: 수정된 내비게이션 바 뷰
-    public func trailings(_ contents: [() -> any View]) -> Self {
+    public func trailingContents(_ contents: [() -> any View]) -> Self {
         var zelf = self
-        zelf.trailings = contents.prefix(3).map { content in { AnyView(content()) } }
+        zelf.trailingContents = contents.prefix(3).map { content in { AnyView(content()) } }
         return zelf
+    }
+    
+    /// 내비게이션 바의 오른쪽 버튼 영역을 설정합니다.
+    ///
+    /// 이 메서드는 배열 버전(`trailingContents(_:)`)에 대한 편의 오버로딩입니다.
+    ///
+    /// - Parameter contents: 오른쪽에 노출될 컨텐츠 클로저들 (최대 3개까지 표시)
+    /// - Returns: 수정된 내비게이션 바 뷰
+    public func trailingContents(_ contents: (() -> any View)...) -> Self {
+        trailingContents(contents)
     }
     
     private struct Contents: View {
         var variant: Variant
         var title: () -> AnyView
-        var leading: () -> AnyView
-        var trailings: [() -> AnyView]
+        var leadingContent: () -> AnyView
+        var trailingContents: [() -> AnyView]
         
         var body: some View {
             switch variant {
@@ -200,17 +202,17 @@ public struct ModalNavigation: View {
                 TopNavigation.Contents(
                     variant: variant.topNavigationVariant,
                     title: title,
-                    leading: leading,
-                    trailings: trailings
+                    leadingContent: leadingContent,
+                    trailingContents: trailingContents
                 )
             case .emphasized:
                 ZStack {
                     HStack(spacing: 20) {
-                        leading()
+                        leadingContent()
                         title()
                         Spacer(minLength: 0)
                         Group {
-                            ForEach(Array(trailings.enumerated()), id: \.offset) { _, makeView in
+                            ForEach(Array(trailingContents.enumerated()), id: \.offset) { _, makeView in
                                 makeView()
                             }
                         }


### PR DESCRIPTION
# 개요
- Jira 링크 : https://wantedlab.atlassian.net/browse/PI-79111

# 수정사항

* 기존 String과 Enum으로만 한정되어있던 TopNavigation의 Title, Leading,  Trailing 영역을 커스텀이 가능한 View를 사용할 수 있도록 수정합니다.
* 한정된 View를 사용하는것이 통일된 UX를 해치지 않는 길이지만, 수정 과정 중 디자이너와 개발자간의 커뮤니케이션 비용이 많아 위 기조로 변경합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ModalNavigation/TopNavigation에 TitleView, LeadingButton, TrailingIconButton, TrailingTextButton 등 공개 빌더 구성 요소 추가.

- **Refactor**
  - 여러 프리뷰와 컴포넌트를 파라미터 없는 초기자와 체인형 빌더(.variant, .title, .leadingContent, .trailingContents)로 전면 전환해 클로저 기반 동적 렌더링 도입.

- **Breaking Changes**
  - 기존 title 초기자 및 leadingButton/trailingButtons 기반 API 제거 — 빌더형 사용으로 마이그레이션 필요.

- **Documentation**
  - 빌더 기반 사용 예시 및 API 문서 갱신.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->