### PR TITLE
figma-icon-sync 워크플로우 오류 수정

### DIFF
--- a/.github/workflows/figma-icon-sync.yml
+++ b/.github/workflows/figma-icon-sync.yml
@@ -48,9 +48,7 @@ jobs:
         run: |
           # 브랜치명 생성 (Jira 이슈 번호가 있으면 사용, 없으면 run_id 사용)
           if [ -n "${{ github.event.inputs.jira_issue }}" ]; then
-            # Jira 이슈 번호에서 공백과 특수문자를 하이픈으로 변환하여 안전한 브랜치명 생성
-            SANITIZED_JIRA_ISSUE=$(echo "${{ github.event.inputs.jira_issue }}" | tr -c 'A-Za-z0-9._-/' '-' | tr '[:space:]' '-')
-            BRANCH_NAME="feature/$SANITIZED_JIRA_ISSUE"
+            BRANCH_NAME="feature/${{ github.event.inputs.jira_issue }}"
           else
             BRANCH_NAME="feature/code-connect/${{ github.run_id }}"
           fi
@@ -86,7 +84,9 @@ jobs:
           
           if [ -z "$PR_URL" ]; then
             # 기존 PR이 없으면 새로운 PR 생성
-            PR_URL=$(gh pr create -B "${{ steps.extract_branch.outputs.branch }}" -H "${{ steps.commit.outputs.branch_name }}" --title "feat: add icons synced from figma" --body "$PR_BODY" --json url --jq '.url')
+            gh pr create -B "${{ steps.extract_branch.outputs.branch }}" -H "${{ steps.commit.outputs.branch_name }}" --title "feat: add icons synced from figma" --body "$PR_BODY"
+            # PR 생성 후 URL 다시 가져오기
+            PR_URL=$(gh pr view -H "${{ steps.commit.outputs.branch_name }}" --json url --jq '.url' 2>/dev/null || echo "")
           fi
           
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 분기명 생성 로직 단순화: Jira 이슈 값을 그대로 사용하고, 기본 분기명은 기존과 동일하게 유지.
  - PR 생성 후 URL을 별도로 조회하도록 변경하여 링크 획득의 안정성 향상.
  - 슬랙 알림은 기존 형식을 유지하며, 새 조회 방식으로 확보한 PR 링크를 사용.

- **Refactor**
  - 불필요한 중간 처리와 정규화 단계를 제거해 워크플로우를 단순화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->