### PR TITLE
feat: Popover 컴포넌트 추가

### DIFF
--- a/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
+++ b/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		4D8100502EA74BC6004CAD92 /* ComponentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D81004E2EA74BC6004CAD92 /* ComponentListView.swift */; };
 		4D8100522EA7594D004CAD92 /* BlueprintApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8100512EA7594D004CAD92 /* BlueprintApp.swift */; };
 		4D8100542EA76329004CAD92 /* ComponentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8100532EA76329004CAD92 /* ComponentSection.swift */; };
+		4D81005A2EA8760B004CAD92 /* PopoverPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8100592EA875FF004CAD92 /* PopoverPreview.swift */; };
 		4D8100562EA86106004CAD92 /* DividerPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8100552EA86106004CAD92 /* DividerPreview.swift */; };
 		4D853DF72D96491E004549CF /* IconButtonPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D853DF62D96491E004549CF /* IconButtonPreview.swift */; };
 		4D88E5FA2E8BC34D00EA0E67 /* PopupModalPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D88E5F92E8BC34D00EA0E67 /* PopupModalPreview.swift */; };
@@ -113,6 +114,7 @@
 		4D81004E2EA74BC6004CAD92 /* ComponentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentListView.swift; sourceTree = "<group>"; };
 		4D8100512EA7594D004CAD92 /* BlueprintApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueprintApp.swift; sourceTree = "<group>"; };
 		4D8100532EA76329004CAD92 /* ComponentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentSection.swift; sourceTree = "<group>"; };
+		4D8100592EA875FF004CAD92 /* PopoverPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverPreview.swift; sourceTree = "<group>"; };
 		4D8100552EA86106004CAD92 /* DividerPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerPreview.swift; sourceTree = "<group>"; };
 		4D853DF62D96491E004549CF /* IconButtonPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconButtonPreview.swift; sourceTree = "<group>"; };
 		4D88E5F82E8BC34D00EA0E67 /* FullModalPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullModalPreview.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 		4DF7C4FD2CE340F0002B241B /* Previews */ = {
 			isa = PBXGroup;
 			children = (
+				4D8100592EA875FF004CAD92 /* PopoverPreview.swift */,
 				4D5D8C9B2D27E8CE00108C92 /* AccordionPreview.swift */,
 				4DF7C4992CE340F0002B241B /* ActionAreaPreview.swift */,
 				4DFFE5652DBF82EF00DC6EB6 /* ActionChipPreview.swift */,
@@ -487,6 +490,7 @@
 				4DF7C51C2CE340F0002B241B /* TopNavigationPreview.swift in Sources */,
 				4D5597522D1E7EC000CFBCA5 /* DotPaginationPreview.swift in Sources */,
 				4D0D251E2DB763FE00608CE5 /* ThumbnailPreview.swift in Sources */,
+				4D81005A2EA8760B004CAD92 /* PopoverPreview.swift in Sources */,
 				4D96F7CE2EA07D7B00DFECE8 /* TransparentCheckerPatternModifier.swift in Sources */,
 				4DFFE5682DBF975000DC6EB6 /* FilterChipPreview.swift in Sources */,
 				4DA44F1B2D12CC91009FE3DB /* PullToRefreshPreview.swift in Sources */,

--- a/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListNavigationCoordinator.swift
+++ b/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListNavigationCoordinator.swift
@@ -61,6 +61,7 @@ final class ComponentListNavigationCoordinator: ObservableObject {
         case .card: CardPreview()
         case .listCard: ListCardPreview()
         case .framedStyle: FramedStylePreview()
+        case .popover: PopoverPreview()
         case .divider: DividerPreview()
         }
     }

--- a/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
+++ b/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
@@ -43,7 +43,6 @@ struct ComponentListView: View {
                     list
                 }
             }
-            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
             .navigationTitle("Blueprint")
             .toolbar(content: {
                 ToolbarItem(placement: .bottomBar) {
@@ -94,6 +93,7 @@ struct ComponentListView: View {
         .listStyle(.plain)
         .background(Color.semantic(.backgroundNormal))
         .scrollContentBackground(.hidden)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
     }
 }
 

--- a/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
+++ b/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
@@ -32,25 +32,39 @@ struct ComponentListView: View {
             }
     }
     
+    @FocusState private var searchFocused
+    
     var body: some View {
         NavigationStack(path: $coordinator.path) {
-            list
-                .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
-                .navigationTitle("Blueprint")
-                .toolbar(content: {
-                    ToolbarItem(placement: .bottomBar) {
-                        VStack {
-                            (Text("powered by the Wanted Design System, ") + Text("Montage™").bold())
-                                .typography(variant: .caption2, weight: .regular)
-                        }
-                    }
-                })
-                .navigationBarTitleDisplayMode(.large)
-                .navigationDestination(for: Component.self) { componentType in
-                    coordinator.destinationView(for: componentType)
-                        .navigationTitle(componentType.displayName)
-                        .navigationBarTitleDisplayMode(.inline)
+            Group {
+                if #available(iOS 18.0, *) {
+                    list.searchFocused($searchFocused)
+                } else {
+                    list
                 }
+            }
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
+            .navigationTitle("Blueprint")
+            .toolbar(content: {
+                ToolbarItem(placement: .bottomBar) {
+                    VStack {
+                        (Text("powered by the Wanted Design System, ") + Text("Montage™").bold())
+                            .typography(variant: .caption2, weight: .regular)
+                    }
+                }
+            })
+            .navigationBarTitleDisplayMode(.large)
+            .navigationDestination(for: Component.self) { componentType in
+                coordinator.destinationView(for: componentType)
+                    .navigationTitle(componentType.displayName)
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+            .onAppear {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    searchFocused = true
+                }
+            }
         }
     }
     

--- a/Sources/Blueprint/Sources/Scene/ComponentList/ComponentSection.swift
+++ b/Sources/Blueprint/Sources/Scene/ComponentList/ComponentSection.swift
@@ -32,7 +32,7 @@ enum Component: String, CaseIterable, Hashable, Identifiable {
          contentBadge
     case loading, skeleton, pullToRefresh
     case topNavigation, progressIndicator, tab, pagination, progressTracker, category
-    case pushBadge, fallbackView, snackbar, toast, tooltip
+    case pushBadge, fallbackView, snackbar, toast, tooltip, popover
     case modal
     case framedStyle
     
@@ -41,7 +41,7 @@ enum Component: String, CaseIterable, Hashable, Identifiable {
         case .typography, .color, .icon, .shadow, .control,
                 .flowLayout,
                 .button, .textButton, .iconButton, .thumbnail, .fallbackView, .pushBadge, .chip, .topNavigation,
-                .progressIndicator, .avatar, .toast, .snackbar, .tooltip, .actionArea,
+                .progressIndicator, .avatar, .toast, .snackbar, .tooltip, .popover, .actionArea,
                 .textArea, .textField, .select, .segmentedControl, .listCell, .tab, .slider,
                 .pullToRefresh, .skeleton, .loading, .progressTracker, .dateTimePicker,
                 .pagination, .accordion, .category, .playBadge, .sectionHeader, .modal,
@@ -70,7 +70,7 @@ enum Component: String, CaseIterable, Hashable, Identifiable {
             return .navigations
         case .pushBadge, .fallbackView, .snackbar, .toast:
             return .feedback
-        case .modal, .tooltip:
+        case .modal, .tooltip, .popover:
             return .presentation
         case .framedStyle:
             return .utility

--- a/Sources/Blueprint/Sources/Scene/Previews/PopoverPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/PopoverPreview.swift
@@ -13,10 +13,10 @@ struct PopoverPreview: View {
     @State private var isPresented: Bool = false
     @State private var variantIndex: Int = 0
     @State private var text: String = "메시지에 마침표를 찍어요."
-    @State private var heading: String = "제목"
+    @State private var heading: String = ""
     @State private var closeButton: Bool = true
     @State private var action: Bool = true
-    @State private var subAction: Bool = true
+    @State private var subAction: Bool = false
     @State private var page: Int = 1
     
     let variants = ["normal", "custom"]
@@ -82,7 +82,7 @@ struct PopoverPreview: View {
         VStack(spacing: 0) {
             ZStack(alignment: .topTrailing) {
                 Thumbnail(
-                    urlString: imageUrls[page - 1],
+                    urlString: imageUrls[safe: page - 1] ?? imageUrls[0],
                     ratio: .r3x2
                 )
                 IconButton(variant: .background(size: 20), icon: .closeThick) {
@@ -104,7 +104,7 @@ struct PopoverPreview: View {
                 }
                 
                 HStack(alignment: .bottom) {
-                    DotPagination(selectedPage: $page, totalPages: 3)
+                    DotPagination(selectedPage: $page, totalPages: imageUrls.count)
                         .size(.small)
                     Spacer()
                     Button(variant: .outlined, color: .assistive, size: .medium, text: "확인")
@@ -138,7 +138,7 @@ struct PopoverPreview: View {
                     
                     HStack {
                         Text("text")
-                        TextField(text: $text)
+                        TextArea(text: $text)
                     }
                     
                     HStack {

--- a/Sources/Blueprint/Sources/Scene/Previews/PopoverPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/PopoverPreview.swift
@@ -1,0 +1,162 @@
+//
+//  PopoverPreview.swift
+//  Blueprint
+//
+//  Created by 김삼열 on 10/22/25.
+//
+
+import SwiftUI
+import Montage
+
+struct PopoverPreview: View {
+    @State private var showTransparentChecker: Bool = false
+    @State private var isPresented: Bool = false
+    @State private var variantIndex: Int = 0
+    @State private var text: String = "메시지에 마침표를 찍어요."
+    @State private var heading: String = "제목"
+    @State private var closeButton: Bool = true
+    @State private var action: Bool = true
+    @State private var subAction: Bool = true
+    @State private var page: Int = 1
+    
+    let variants = ["normal", "custom"]
+    let imageUrls = [
+        "https://images.unsplash.com/photo-1529778873920-4da4926a72c2?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Y3V0ZSUyMGNhdHxlbnwwfHwwfHx8MA%3D%3D&fm=jpg&q=60&w=3000",
+        "https://media.4-paws.org/d/2/5/f/d25ff020556e4b5eae747c55576f3b50886c0b90/cut%20cat%20serhio%2002-1813x1811-720x719.jpg",
+        "https://i.pinimg.com/736x/c3/bc/9b/c3bc9be28c74848841256c867da9fb43.jpg"
+    ]
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                HStack {
+                    Text("Preview").bold()
+                    Spacer()
+                    Button(action: {
+                        showTransparentChecker.toggle()
+                    }) {
+                        Image(systemName: "checkerboard.rectangle")
+                            .foregroundColor(.semantic(.primaryNormal))
+                    }
+                }
+                .padding(.horizontal)
+                
+                VStack(spacing: 24) {
+                    Button(color: .primary, size: .medium, text: "Show") {
+                        isPresented = true
+                    }
+                    .modifying {
+                        if variantIndex == 0 {
+                            $0.popoverNormal(
+                                isPresented: $isPresented,
+                                heading: heading,
+                                text: text,
+                                closeButton: closeButton,
+                                action: action ? (title: "행동", action: {
+                                    print("Action tapped")
+                                    isPresented = false
+                                }) : nil,
+                                subAction: subAction ? (title: "보조행동", action: {
+                                    print("SubAction tapped")
+                                    isPresented = false
+                                }) : nil
+                            )
+                        } else {
+                            $0.popoverCustom(isPresented: $isPresented) {
+                                popoverContent
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                
+                optionSheet
+                    .padding(.horizontal)
+            }
+        }
+        .transparentChecking(isPresented: showTransparentChecker, checkerSize: 201, checkerColor: .red)
+    }
+    
+    @ViewBuilder
+    private var popoverContent: some View {
+        VStack(spacing: 0) {
+            ZStack(alignment: .topTrailing) {
+                Thumbnail(
+                    urlString: imageUrls[page - 1],
+                    ratio: .r3x2
+                )
+                IconButton(variant: .background(size: 20), icon: .closeThick) {
+                    isPresented = false
+                }
+                    .padding(.all, 14)
+            }
+            
+            VStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("인재의 추가 정보를 확인하세요.")
+                        .paragraph(variant: .headline2, weight: .bold, semantic: .labelNormal)
+                    Text("적극적으로 구직 중인, 다른 회사가 주목하는, 우리 회사에 관심있는 인재를 알 수 있어요.")
+                        .paragraph(variant: .body2Reading, weight: .medium, semantic: .labelNeutral)
+                        .lineLimit(nil)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                
+                HStack(alignment: .bottom) {
+                    DotPagination(selectedPage: $page, totalPages: 3)
+                        .size(.small)
+                    Spacer()
+                    Button(variant: .outlined, color: .assistive, size: .medium, text: "확인")
+                }
+            }
+            .padding(20)
+        }
+        .frame(width: 300)
+        .background(.ultraThinMaterial)
+        .background(SwiftUI.Color.semantic(.backgroundElevated).opacity(0.88))
+    }
+    
+    private var optionSheet: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Options").bold()
+            
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("variant")
+                    SegmentedControl(
+                        selectedIndex: $variantIndex,
+                        labels: variants
+                    )
+                    .size(.small)
+                }
+                if variantIndex == 0 {
+                    HStack {
+                        Text("heading")
+                        TextField(text: $heading)
+                    }
+                    
+                    HStack {
+                        Text("text")
+                        TextField(text: $text)
+                    }
+                    
+                    HStack {
+                        Text("closeButton")
+                        Control.switch(checked: closeButton) { closeButton = $0 }
+                        Text("action")
+                        Control.switch(checked: action) { action = $0 }
+                        Text("subAction")
+                        Control.switch(checked: subAction) { subAction = $0 }
+                    }
+                }
+            }
+            .font(.caption)
+        }
+    }
+}
+
+#Preview {
+    PopoverPreview()
+}
+

--- a/Sources/Blueprint/Sources/Utilities/TransparentCheckerPatternModifier.swift
+++ b/Sources/Blueprint/Sources/Utilities/TransparentCheckerPatternModifier.swift
@@ -100,7 +100,7 @@ class CheckerPatternCache {
             cgContext.fill(CGRect(origin: .zero, size: size))
             
             // 회색 체커 패턴
-            cgContext.setFillColor(checkerColor.opacity(0.3).uiColor.cgColor)
+            cgContext.setFillColor(checkerColor.opacity(0.5).uiColor.cgColor)
             
             let rows = Int(size.height / checkerSize) + 1
             let cols = Int(size.width / checkerSize) + 1

--- a/Sources/Montage/1 Components/8 Presentation/Popover.swift
+++ b/Sources/Montage/1 Components/8 Presentation/Popover.swift
@@ -109,11 +109,17 @@ struct NormalPopoverModifier: ViewModifier {
             if action != nil || subAction != nil {
                 HStack(spacing: 16) {
                     Spacer()
-                    if let subAction {
-                        TextButton(color: .assistive, size: .small, text: subAction.title, handler: subAction.action)
-                    }
                     if let action {
-                        TextButton(color: .primary, size: .small, text: action.title, handler: action.action)
+                        if let subAction {
+                            TextButton(color: .assistive, size: .small, text: subAction.title) {
+                                isPresented = false
+                                subAction.action()
+                            }
+                        }
+                        TextButton(color: .primary, size: .small, text: action.title) {
+                            isPresented = false
+                            action.action()
+                        }
                     }
                 }
                 .padding(.top, 4)
@@ -271,10 +277,10 @@ extension View {
     /// - Returns: 일반적인 팝오버 모디파이어
     public func popoverNormal(
         isPresented: Binding<Bool>,
-        heading: String,
+        heading: String = "",
         text: String,
         closeButton: Bool = true,
-        action: (title: String, action: () -> Void)? = nil,
+        action: (title: String, action: () -> Void)?,
         subAction: (title: String, action: () -> Void)? = nil
     ) -> some View {
         modifier(

--- a/Sources/Montage/1 Components/8 Presentation/Popover.swift
+++ b/Sources/Montage/1 Components/8 Presentation/Popover.swift
@@ -1,0 +1,301 @@
+//
+//  Popover.swift
+//  Views
+//
+//  Created by 김삼열 on 10/22/25.
+//  Copyright © 2025 WantedLab Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct NormalPopoverModifier: ViewModifier {
+    @Binding private var isPresented: Bool
+    private let heading: String
+    private let text: String
+    private let closeButton: Bool
+    private let action: (title: String, action: () -> Void)?
+    private let subAction: (title: String, action: () -> Void)?
+    
+    init(
+        isPresented: Binding<Bool>,
+        heading: String,
+        text: String,
+        closeButton: Bool,
+        action: (title: String, action: () -> Void)?,
+        subAction: (title: String, action: () -> Void)?
+    ) {
+        self._isPresented = isPresented
+        self.heading = heading
+        self.text = text
+        self.closeButton = closeButton
+        self.action = action
+        self.subAction = subAction
+    }
+    
+    @State private var contentSize: CGSize = .zero
+    @State private var headingHeight: CGFloat = .zero
+    @State private var textHeight: CGFloat = .zero
+    
+    func body(content: Content) -> some View {
+        content
+            .padding(8)
+            .background {
+                popoverContent
+                    .onGeometryChange(for: CGSize.self, of: { $0.size }, action: { contentSize = $0 })
+                    .hidden()
+            }
+            .background(
+                PopoverPresenter(
+                    isPresented: $isPresented,
+                    contentSize: contentSize
+                ) {
+                    popoverContent
+                }
+            )
+    }
+    
+    var popoverContent: some View {
+        VStack(spacing: 0) {
+            ZStack(alignment: .topTrailing) {
+                VStack(spacing: 6) {
+                    if heading.isNotEmpty {
+                        ZStack {
+                            SwiftUI.Color.clear
+                                .frame(height: headingHeight)
+                            HStack {
+                                Text(heading)
+                                    .paragraph(variant: .body2, weight: .bold, color: .semantic(.labelNormal))
+                                    .lineLimit(2)
+                                    .multilineTextAlignment(.leading)
+                                    .onGeometryChange(
+                                        for: CGFloat.self,
+                                        of: { $0.size.height },
+                                        action: { headingHeight = $0 }
+                                    )
+                                Spacer(minLength: closeButton ? 22 + 7 : 0)
+                            }
+                        }
+                    }
+                    if text.isNotEmpty {
+                        ZStack {
+                            SwiftUI.Color.clear
+                                .frame(height: textHeight)
+                            HStack {
+                                Text(text)
+                                    .paragraph(variant: .label2, weight: .medium, color: .semantic(.labelNeutral))
+                                    .lineLimit(nil)
+                                    .multilineTextAlignment(.leading)
+                                    .padding(.vertical, 2)
+                                    .onGeometryChange(
+                                        for: CGFloat.self,
+                                        of: { $0.size.height },
+                                        action: { textHeight = $0 }
+                                    )
+                                Spacer(minLength: closeButton ? 22 + 7 : 0)
+                            }
+                        }
+                    }
+                }
+                if closeButton {
+                    IconButton(variant: .normal(size: 16), icon: .close) {
+                        isPresented = false
+                    }
+                    .padding(.all, 3)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            
+            if action != nil || subAction != nil {
+                HStack(spacing: 16) {
+                    Spacer()
+                    if let subAction {
+                        TextButton(color: .assistive, size: .small, text: subAction.title, handler: subAction.action)
+                    }
+                    if let action {
+                        TextButton(color: .primary, size: .small, text: action.title, handler: action.action)
+                    }
+                }
+                .padding(.top, 4)
+                .padding(.horizontal, 14)
+                .padding(.bottom, 12)
+            }
+        }
+        .frame(minWidth: 140, maxWidth: 360)
+        .fixedSize(horizontal: true, vertical: true)
+        .background(.ultraThinMaterial)
+        .background(SwiftUI.Color.semantic(.backgroundElevated).opacity(0.88))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+struct CustomPopoverModifier<V: View>: ViewModifier {
+    @Binding private var isPresented: Bool
+    private let popoverContent: () -> V
+    
+    init(isPresented: Binding<Bool>, @ViewBuilder content: @escaping () -> V) {
+        self._isPresented = isPresented
+        self.popoverContent = content
+    }
+    
+    @State private var contentSize: CGSize = .zero
+    
+    func body(content: Content) -> some View {
+        content
+            .padding(8)
+            .background {
+                popoverContent()
+                    .onGeometryChange(for: CGSize.self, of: { $0.size }, action: { contentSize = $0 })
+                    .hidden()
+            }
+            .background(
+                PopoverPresenter(
+                    isPresented: $isPresented,
+                    contentSize: contentSize,
+                    popoverContent: popoverContent
+                )
+            )
+    }
+}
+
+struct PopoverPresenter<V: View>: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let contentSize: CGSize
+    let popoverContent: () -> V
+    
+    func makeUIViewController(context: Context) -> UIViewController {
+        let vc = UIViewController()
+        vc.view.backgroundColor = .clear
+        return vc
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        guard isPresented else {
+            if let contentVC = context.coordinator.contentVC {
+                contentVC.dismiss(animated: true) {
+                    context.coordinator.contentVC = nil
+                }
+            }
+            return
+        }
+        
+        // 이미 present된 경우 rootView만 업데이트
+        if let contentVC = context.coordinator.contentVC {
+            contentVC.rootView = popoverContent()
+            contentVC.preferredContentSize = contentSize
+            return
+        }
+        
+        // 처음 present하는 경우
+        let contentVC = UIHostingController(rootView: popoverContent())
+        contentVC.view.backgroundColor = .clear
+        contentVC.preferredContentSize = contentSize
+        contentVC.modalPresentationStyle = .popover
+        
+        if let popover = contentVC.popoverPresentationController {
+            popover.sourceView = uiViewController.view
+            popover.sourceRect = CGRect(x: uiViewController.view.bounds.minX,
+                                        y: uiViewController.view.bounds.minY,
+                                        width: uiViewController.view.bounds.width,
+                                        height: uiViewController.view.bounds.height)
+            popover.permittedArrowDirections = [.any]
+            popover.popoverLayoutMargins = .init(top: 8, left: 8, bottom: 8, right: 8)
+            popover.popoverBackgroundViewClass = NoArrowPopoverBackground.self
+            popover.delegate = context.coordinator
+        }
+        
+        context.coordinator.contentVC = contentVC
+        uiViewController.present(contentVC, animated: true)
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, UIPopoverPresentationControllerDelegate {
+        var parent: PopoverPresenter
+        var contentVC: UIHostingController<V>?
+        
+        init(_ parent: PopoverPresenter) {
+            self.parent = parent
+        }
+        
+        func adaptivePresentationStyle(
+            for controller: UIPresentationController
+        ) -> UIModalPresentationStyle {
+            .none
+        }
+        
+        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            parent.isPresented = false
+            contentVC = nil
+        }
+    }
+}
+
+
+class NoArrowPopoverBackground: UIPopoverBackgroundView {
+    override var arrowOffset: CGFloat {
+        get { 0 }
+        set { }
+    }
+    
+    override var arrowDirection: UIPopoverArrowDirection {
+        get { .any }
+        set { }
+    }
+    
+    override class func contentViewInsets() -> UIEdgeInsets {
+        .zero
+    }
+    
+    override class func arrowBase() -> CGFloat { 0 }
+    override class func arrowHeight() -> CGFloat { 0 }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.shadowOpacity = 0
+    }
+}
+
+extension View {
+    /// 일반적인 팝오버 모디파이어를 초기화합니다.
+    ///
+    /// - Parameters:
+    ///   - isPresented: 팝오버 표시 여부에 대한 바인딩
+    ///   - heading: 팝오버 제목
+    ///   - text: 팝오버 텍스트
+    ///   - closeButton: 팝오버 닫기 버튼 표시 여부
+    ///   - action: 팝오버 행동 버튼 표시 여부
+    ///   - subAction: 팝오버 보조 행동 버튼 표시 여부
+    /// - Returns: 일반적인 팝오버 모디파이어
+    public func popoverNormal(
+        isPresented: Binding<Bool>,
+        heading: String,
+        text: String,
+        closeButton: Bool = true,
+        action: (title: String, action: () -> Void)? = nil,
+        subAction: (title: String, action: () -> Void)? = nil
+    ) -> some View {
+        modifier(
+            NormalPopoverModifier(
+                isPresented: isPresented,
+                heading: heading,
+                text: text,
+                closeButton: closeButton,
+                action: action,
+                subAction: subAction
+            )
+        )
+    }
+    
+    /// 사용자 정의 팝오버 모디파이어를 초기화합니다.
+    ///
+    /// - Parameters:
+    ///   - isPresented: 팝오버 표시 여부에 대한 바인딩
+    ///   - content: 팝오버 콘텐츠를 반환하는 클로저
+    /// - Returns: 사용자 정의 팝오버 모디파이어
+    public func popoverCustom<V: View>(isPresented: Binding<Bool>, @ViewBuilder content: @escaping () -> V) -> some View {
+        modifier(CustomPopoverModifier(isPresented: isPresented, content: content))
+    }
+}


### PR DESCRIPTION
https://wantedlab.atlassian.net/browse/PI-79183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팝오버 컴포넌트 추가: 기본(제목·텍스트·작업 버튼 포함) 및 커스텀 콘텐츠 두 가지 프레젠테이션 스타일 제공
  * 팝오버 표시용 공개 API 추가로 SwiftUI에서 손쉽게 팝오버 호출 가능
  * 팝오버용 대화형 미리보기 UI 추가 — 변형·제목·텍스트·버튼 등 옵션 즉시 확인 가능
  * 컴포넌트 목록 및 네비게이션에 팝오버 항목 추가

* **사용성**
  * iOS 18 이상에서 검색 필드 자동 포커스 동작 추가

* **스타일**
  * 투명 체커 패턴 불투명도 증가로 시각적 대비 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->