### PR TITLE
다크모드 TextArea 배경색 오류 수정

### DIFF
--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -231,6 +231,7 @@ public struct Select: View {
     
     // MARK: - Body
     
+    @Environment(\.colorScheme) private var colorScheme
     @State private var contentSize: CGSize = .zero
     @State private var flowLayoutSize: CGSize = .zero
     @State private var defaultMenuPresented = false
@@ -384,8 +385,13 @@ public struct Select: View {
                     if disable {
                         SwiftUI.Color.semantic(.fillAlternative)
                     } else {
-                        SwiftUI.Color.white.opacity(0.6)
-                            .background(.ultraThinMaterial)
+                        if colorScheme == .light {
+                            SwiftUI.Color.atomic(.common100).opacity(0.6)
+                                .background(.ultraThinMaterial)
+                        } else {
+                            SwiftUI.Color.atomic(.coolNeutral17).opacity(0.61)
+                                .background(.ultraThinMaterial)
+                        }
                     }
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -314,6 +314,7 @@ public struct TextArea: View {
     
     // MARK: - Body
     
+    @Environment(\.colorScheme) private var colorScheme
     @State private var typedCharacters = 0
     @FocusState private var internalFocusState
     
@@ -414,8 +415,13 @@ public struct TextArea: View {
             if disable {
                 SwiftUI.Color.semantic(.fillAlternative)
             } else {
-                SwiftUI.Color.white.opacity(0.6)
-                    .background(.ultraThinMaterial)
+                if colorScheme == .light {
+                    SwiftUI.Color.atomic(.common100).opacity(0.6)
+                        .background(.ultraThinMaterial)
+                } else {
+                    SwiftUI.Color.atomic(.coolNeutral17).opacity(0.61)
+                        .background(.ultraThinMaterial)
+                }
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -257,6 +257,7 @@ public struct TextField: View {
     // MARK: - Body
     
     @Environment(\.safeAreaInsets) private var safeAreaInsets
+    @Environment(\.colorScheme) private var colorScheme
     @State private var textFieldFrame: CGRect = .zero
     @FocusState private var textFieldFocusState: Bool
     @State private var autoCompletionContentHeight: CGFloat = .zero
@@ -396,8 +397,13 @@ private extension TextField {
             if disable {
                 SwiftUI.Color.semantic(.fillAlternative)
             } else {
-                SwiftUI.Color.white.opacity(0.6)
-                    .background(.ultraThinMaterial)
+                if colorScheme == .light {
+                    SwiftUI.Color.atomic(.common100).opacity(0.6)
+                        .background(.ultraThinMaterial)
+                } else {
+                    SwiftUI.Color.atomic(.coolNeutral17).opacity(0.61)
+                        .background(.ultraThinMaterial)
+                }
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))


### PR DESCRIPTION
https://wantedlab.atlassian.net/browse/PI-80283

# 미리보기
작업 전|작업 후
---|---
<img width="1170" height="2532" alt="simulator_screenshot_F55C9CE1-FB37-4C70-B5AB-045A76195704" src="https://github.com/user-attachments/assets/2690a3f3-39f1-4c5e-a89d-ee9a8e3c5123" />|<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-17 at 10 22 17" src="https://github.com/user-attachments/assets/76725682-b439-40ca-b455-5a63e80b947f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * Select, TextArea, TextField 컴포넌트의 테마 인식 배경 스타일링을 개선했습니다.
  * 라이트 모드와 다크 모드에서 각각 다른 색상으로 렌더링되는 배경을 추가했습니다.
  * 입력 필드의 시각적 표현이 시스템 색상 설정에 따라 동적으로 조정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->