### PR TITLE
ScrollView contentSize 측정 방법 변경

### DIFF
--- a/Sources/Montage/1 Components/9 Utilities/ScrollView.swift
+++ b/Sources/Montage/1 Components/9 Utilities/ScrollView.swift
@@ -76,14 +76,9 @@ public struct ScrollView: View {
                 .frame(width: 0, height: 0)
                 VStack {
                     AnyView(content())
-                        .background(
-                            GeometryReader { proxy in
-                                SwiftUI.Color.clear.preference(
-                                    key: ContentSizePreferenceKey.self,
-                                    value: proxy.size
-                                )
-                            }
-                        )
+                        .onGeometryChange(for: CGSize.self, of: { $0.size }, for: .milliseconds(200), action: {
+                            scrollStatus.wrappedValue.contentSize = $0
+                        })
                 }
             }
         }
@@ -102,9 +97,6 @@ public struct ScrollView: View {
         .onPreferenceChange(OffsetPreferenceKey.self) {
             scrollStatus.wrappedValue.contentOffset = $0
             onOffsetChanged($0)
-        }
-        .onPreferenceChange(ContentSizePreferenceKey.self) {
-            scrollStatus.wrappedValue.contentSize = $0
         }
         .onPreferenceChange(ScrollViewSizePreferenceKey.self) {
             scrollStatus.wrappedValue.scrollViewSize = $0
@@ -219,11 +211,6 @@ private extension ScrollView {
 struct OffsetPreferenceKey: PreferenceKey {
     public static var defaultValue: CGPoint = .zero
     public static func reduce(value _: inout CGPoint, nextValue _: () -> CGPoint) {}
-}
-
-struct ContentSizePreferenceKey: PreferenceKey {
-    public static var defaultValue: CGSize = .zero
-    public static func reduce(value _: inout CGSize, nextValue _: () -> CGSize) {}
 }
 
 struct ScrollViewSizePreferenceKey: PreferenceKey {

--- a/Sources/Montage/2 Utilities/Extension/SwiftUI/View+Montage.swift
+++ b/Sources/Montage/2 Utilities/Extension/SwiftUI/View+Montage.swift
@@ -88,7 +88,7 @@ extension View {
     public func onGeometryChange<T>(
         for type: T.Type,
         of transform: @escaping (GeometryProxy) -> T,
-        for dueTime: RunLoop.SchedulerTimeType.Stride,
+        for dueTime: ContinuousClock.Instant.Duration,
         action: @escaping (_ newValue: T) -> Void
     ) -> some View where T: Equatable {
         modifier(DebouncedGeometryChangeModifier(for: type, of: transform, for: dueTime, action: action))

--- a/Sources/Montage/2 Utilities/Modifiers/DebouncedGeometryChangeModifier.swift
+++ b/Sources/Montage/2 Utilities/Modifiers/DebouncedGeometryChangeModifier.swift
@@ -6,34 +6,39 @@
 //  Copyright © 2025 WantedLab Inc. All rights reserved.
 //
 
-import Combine
 import SwiftUI
 
 struct DebouncedGeometryChangeModifier<T: Equatable>: ViewModifier {
-    private let size: PassthroughSubject<T, Never> = .init()
-    private var cancellables = Set<AnyCancellable>()
-
+    @State private var resizingTask: Task<(), Never>?
+    
     private let type: T.Type
     private let transform: (GeometryProxy) -> T
+    private let dueTime: ContinuousClock.Instant.Duration
+    private let action: (_ newValue: T) -> Void
 
     init(
         for type: T.Type,
         of transform: @escaping (GeometryProxy) -> T,
-        for dueTime: RunLoop.SchedulerTimeType.Stride,
+        for dueTime: ContinuousClock.Instant.Duration,
         action: @escaping (_ newValue: T) -> Void
     ) {
         self.type = type
         self.transform = transform
-        size.debounce(for: dueTime, scheduler: RunLoop.main)
-            .sink {
-                action($0)
-            }
-            .store(in: &cancellables)
+        self.dueTime = dueTime
+        self.action = action
     }
 
     func body(content: Content) -> some View {
         content.onGeometryChange(for: type, of: transform) { newValue in
-            size.send(newValue)
+            resizingTask?.cancel()
+            resizingTask = Task {
+                do {
+                    try await Task.sleep(for: dueTime)
+                    try Task.checkCancellation()
+                    action(newValue)
+                } catch {
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# 수정사항
- onPreferenceChange 에서는 contentSize를 잘 측정하지 못하여 다시 DebouncedGeometryChangeModifier를 사용
- DebouncedGeometryChangeModifier 구현 변경
  - 뷰가 다시 그려질 때마다 PassthroughSubject가 구독 취소되어 사이즈 업데이트가 누락되는 문제 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 기하학적 변화 추적 메커니즘을 비동기 기반 디바운싱 시스템으로 개선했습니다.
  * 타이밍 파라미터 타입이 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->