### PR TITLE
PushBadge number variant에 100이상 입력 시 99+로 표시하도록 변경

### DIFF
--- a/Sources/Montage/1 Components/7 Feedback/PushBadge.swift
+++ b/Sources/Montage/1 Components/7 Feedback/PushBadge.swift
@@ -35,7 +35,7 @@ public struct PushBadge: View {
         /// 'N' 문자를 표시하는 뱃지
         case new
         /// 특정 숫자를 표시하는 뱃지
-        /// - Parameter number: 표시할 숫자
+        /// - Parameter number: 표시할 숫자, 99 초과 시 "99+"로 표시
         case number(_ number: Int)
     }
     
@@ -117,7 +117,7 @@ public struct PushBadge: View {
                             .foregroundColor(backgroundColor)
                     }
             case .number(let number):
-                Text("\(number)")
+                Text(number > 99 ? "99+" : "\(number)")
                     .font(font)
                     .frame(minWidth: textMinSize.width)
                     .frame(height: textMinSize.height)

--- a/documentation/components/feedback/pushbadge/ios.md
+++ b/documentation/components/feedback/pushbadge/ios.md
@@ -244,7 +244,7 @@ PushBadge를 초기화합니다.
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `number` | 표시할 숫자 |
+  | `number` | 표시할 숫자, 99 초과 시 “99+“로 표시 |
 </details>
 
 </details>


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-80666

# 수정사항
* PushBadge에서 number variant에 100이상 입력 시 99+로 표시하도록 변경합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 배지 컴포넌트의 숫자 표기가 99를 초과할 경우 원숫자 대신 "99+"로 표시되도록 수정되었습니다.
* **문서화**
  * PushBadge의 숫자 표기에 대한 설명이 "99+"로 표시됨을 반영하도록 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->