### PR TITLE
chore: Blueprint 앱 메인 화면 하단 문구 잘리는 문제 수정(iOS 26)

### DIFF
--- a/Montage.xcworkspace/contents.xcworkspacedata
+++ b/Montage.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,1025 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <Group
+      location = "group:documentation"
+      name = "documentation">
+      <Group
+         location = "group:utilities"
+         name = "utilities">
+         <Group
+            location = "group:ios-extensions"
+            name = "ios-extensions">
+            <FileRef
+               location = "group:swift.md">
+            </FileRef>
+            <FileRef
+               location = "group:swiftuicore.md">
+            </FileRef>
+            <FileRef
+               location = "group:foundation.md">
+            </FileRef>
+            <FileRef
+               location = "group:corefoundation.md">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:ios-utility-components"
+            name = "ios-utility-components">
+            <FileRef
+               location = "group:opacity.md">
+            </FileRef>
+            <FileRef
+               location = "group:flowlayout.md">
+            </FileRef>
+            <FileRef
+               location = "group:scrollview.md">
+            </FileRef>
+            <FileRef
+               location = "group:shadow.md">
+            </FileRef>
+            <FileRef
+               location = "group:color.md">
+            </FileRef>
+            <FileRef
+               location = "group:interaction.md">
+            </FileRef>
+            <FileRef
+               location = "group:icon.md">
+            </FileRef>
+            <FileRef
+               location = "group:modalnavigation.md">
+            </FileRef>
+            <FileRef
+               location = "group:pulltorefresh.md">
+            </FileRef>
+            <FileRef
+               location = "group:spacing.md">
+            </FileRef>
+            <FileRef
+               location = "group:typography.md">
+            </FileRef>
+         </Group>
+      </Group>
+      <Group
+         location = "group:components"
+         name = "components">
+         <Group
+            location = "group:contents"
+            name = "contents">
+            <Group
+               location = "group:thumbnail"
+               name = "thumbnail">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:listcard"
+               name = "listcard">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:contentbadge"
+               name = "contentbadge">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:avatargroup"
+               name = "avatargroup">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:sectionheader"
+               name = "sectionheader">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:card"
+               name = "card">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:accordion"
+               name = "accordion">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:listcell"
+               name = "listcell">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:avatar"
+               name = "avatar">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:playbadge"
+               name = "playbadge">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:loading"
+            name = "loading">
+            <Group
+               location = "group:loading"
+               name = "loading">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:skeleton"
+               name = "skeleton">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:feedback"
+            name = "feedback">
+            <Group
+               location = "group:fallbackview"
+               name = "fallbackview">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:snackbar"
+               name = "snackbar">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:toast"
+               name = "toast">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:pushbadge"
+               name = "pushbadge">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:navigations"
+            name = "navigations">
+            <Group
+               location = "group:category"
+               name = "category">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:progressindicator"
+               name = "progressindicator">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:tab"
+               name = "tab">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:topnavigation"
+               name = "topnavigation">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:paginationdots"
+               name = "paginationdots">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:progresstracker"
+               name = "progresstracker">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:pagecounter"
+               name = "pagecounter">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:actions"
+            name = "actions">
+            <Group
+               location = "group:textbutton"
+               name = "textbutton">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:chip"
+               name = "chip">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:actionarea"
+               name = "actionarea">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:button"
+               name = "button">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:iconbutton"
+               name = "iconbutton">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:selection and input"
+            name = "selection and input">
+            <Group
+               location = "group:radio"
+               name = "radio">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:checkmark"
+               name = "checkmark">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:filterbutton"
+               name = "filterbutton">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:checkbox"
+               name = "checkbox">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:textfield"
+               name = "textfield">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:slider"
+               name = "slider">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:textarea"
+               name = "textarea">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:segmentedcontrol"
+               name = "segmentedcontrol">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:switch"
+               name = "switch">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:framedstyle"
+               name = "framedstyle">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:select"
+               name = "select">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:presentation"
+            name = "presentation">
+            <Group
+               location = "group:popup"
+               name = "popup">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:tooltip"
+               name = "tooltip">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:popover"
+               name = "popover">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:bottomsheet"
+               name = "bottomsheet">
+               <FileRef
+                  location = "group:ios.md">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+   </Group>
+   <Group
+      location = "group:scripts"
+      name = "scripts">
+      <FileRef
+         location = "group:generate_docc.sh">
+      </FileRef>
+      <FileRef
+         location = "group:icon_sync.js">
+      </FileRef>
+      <FileRef
+         location = "group:generate_third_party_licenses.mjs">
+      </FileRef>
+      <FileRef
+         location = "group:docc_to_md.js">
+      </FileRef>
+   </Group>
+   <Group
+      location = "group:Sources"
+      name = "Sources">
+      <Group
+         location = "group:Montage"
+         name = "Montage">
+         <Group
+            location = "group:1 Components"
+            name = "1 Components">
+            <Group
+               location = "group:2 Actions"
+               name = "2 Actions">
+               <FileRef
+                  location = "group:SolidUIButton.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:OutlinedUIButton.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Chip.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:IconButton.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:TextButton.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ActionArea.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Button.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:5 Loading"
+               name = "5 Loading">
+               <FileRef
+                  location = "group:Skeleton.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Loading.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:6 Navigations"
+               name = "6 Navigations">
+               <FileRef
+                  location = "group:TopNavigation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ProgressTracker.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PaginationDots.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ProgressIndicator.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Tab.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Category.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PageCounter.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:3 Selection And Input"
+               name = "3 Selection And Input">
+               <FileRef
+                  location = "group:TextArea.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Control.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:FramedStyle.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SegmentedControl.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Checkmark.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Select.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Switch.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:TextField.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:FilterButton.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Slider.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Checkbox.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Radio.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:7 Feedback"
+               name = "7 Feedback">
+               <FileRef
+                  location = "group:PushBadge.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SnackBar.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:FallbackView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Toast.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:9 Utilities"
+               name = "9 Utilities">
+               <FileRef
+                  location = "group:Typography.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PullToRefresh.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Icon.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Opacity.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ModalNavigation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Spacing.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ScrollView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Shadow.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:FlowLayout.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:InteractionUIView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Interaction.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Color.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:4 Contents"
+               name = "4 Contents">
+               <FileRef
+                  location = "group:ContentBadge.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ListCard.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Thumbnail.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Card.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ListCell.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Avatar.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AvatarGroup.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Accordion.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PlayBadge.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ContentBadgeUIView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SectionHeader.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:8 Presentation"
+               name = "8 Presentation">
+               <FileRef
+                  location = "group:Popover.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Tooltip.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:BottomSheet.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Popup.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Asset"
+            name = "Asset">
+            <FileRef
+               location = "group:Icon.xcassets">
+            </FileRef>
+            <FileRef
+               location = "group:Image.xcassets">
+            </FileRef>
+            <FileRef
+               location = "group:Color.xcassets">
+            </FileRef>
+            <Group
+               location = "group:Lottie"
+               name = "Lottie">
+               <FileRef
+                  location = "group:pullToRefresh-pulse-light.json">
+               </FileRef>
+               <FileRef
+                  location = "group:loading-circular-light.json">
+               </FileRef>
+               <FileRef
+                  location = "group:loading-wanted-dark.json">
+               </FileRef>
+               <FileRef
+                  location = "group:loading-circular-dark.json">
+               </FileRef>
+               <FileRef
+                  location = "group:loading-wanted-light.json">
+               </FileRef>
+               <FileRef
+                  location = "group:pullToRefresh-pulse-dark.json">
+               </FileRef>
+               <FileRef
+                  location = "group:pullToRefresh-pull-dark.json">
+               </FileRef>
+               <FileRef
+                  location = "group:pullToRefresh-pull-light.json">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:2 Utilities"
+            name = "2 Utilities">
+            <Group
+               location = "group:Modifiers"
+               name = "Modifiers">
+               <FileRef
+                  location = "group:FloatModifier.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GradientScrollEdgeModifier.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PressActionDetectingModifier.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AutoScrollModifier.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:UserInteractionDisablingModifier.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ListCellInteractionModifier.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DisableSwipeBackView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DebouncedGeometryChangeModifier.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Extension"
+               name = "Extension">
+               <Group
+                  location = "group:UIKit"
+                  name = "UIKit">
+                  <FileRef
+                     location = "group:NSAttributedString+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UIEdgeInsets+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UIView+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UIWindow+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CGImage+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UIImage+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UIApplication+.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:SwiftFoundation"
+                  name = "SwiftFoundation">
+                  <FileRef
+                     location = "group:Collection+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CGSize+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Bundle+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Optional+.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:SwiftUI"
+                  name = "SwiftUI">
+                  <FileRef
+                     location = "group:EnvironmentValues+.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SwiftUI+Debug.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Image+Montage.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:View+Montage.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:Protocols"
+               name = "Protocols">
+               <FileRef
+                  location = "group:KeyboardReadable.swift">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Blueprint"
+         name = "Blueprint">
+         <FileRef
+            location = "group:Blueprint.xcodeproj">
+         </FileRef>
+         <FileRef
+            location = "group:Blueprint-Info.plist">
+         </FileRef>
+         <Group
+            location = "group:Resources"
+            name = "Resources">
+            <FileRef
+               location = "group:LaunchScreen.storyboard">
+            </FileRef>
+            <FileRef
+               location = "group:Asset.xcassets">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <FileRef
+               location = "group:BlueprintApp.swift">
+            </FileRef>
+            <Group
+               location = "group:Utilities"
+               name = "Utilities">
+               <FileRef
+                  location = "group:CaseDescribable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Collection+.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:TransparentCheckerPatternModifier.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Scene"
+               name = "Scene">
+               <Group
+                  location = "group:ComponentList"
+                  name = "ComponentList">
+                  <FileRef
+                     location = "group:ComponentListNavigationCoordinator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ComponentListView.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ComponentSection.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Previews"
+                  name = "Previews">
+                  <FileRef
+                     location = "group:AccordionPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PopupPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SnackBarPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SkeletonPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PlayBadgePreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IconButtonPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FlowLayoutPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PaginationDotsPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModalNavigationPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ProgressTrackerPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PaginationPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TopNavigationPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ContentBadgePreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:HorizontalProgressTrackerPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TooltipPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AvatarPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PageCounterPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SliderPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SectionHeaderPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ColorPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ThumbnailPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ButtonPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TextFieldPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TabPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PopoverPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ChipPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PushBadgePreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FallbackViewPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DateTimePickerPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TextButtonPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CardPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CategoryPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ListCellPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TypographyPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FilterButtonPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ProgressIndicatorPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ToastPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PullToRefreshPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SegmentedControlPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:BottomSheetPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LoadingPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:VerticalProgressTrackerPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IconPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FramedStylePreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SelectPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ListCardPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TextAreaPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ShadowPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ControlPreview.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ActionAreaPreview.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
+   </Group>
+   <Group
+      location = "group:Tests"
+      name = "Tests">
+      <Group
+         location = "group:MontageTests"
+         name = "MontageTests">
+         <FileRef
+            location = "group:MontageTests.swift">
+         </FileRef>
+      </Group>
+   </Group>
+   <FileRef
+      location = "group:CODE_OF_CONDUCT.md">
+   </FileRef>
+   <FileRef
+      location = "group:DOCUMENTATION_GUIDELINES.md">
+   </FileRef>
+   <FileRef
+      location = "group:LICENSE">
+   </FileRef>
+   <FileRef
+      location = "group:Makefile">
+   </FileRef>
+   <FileRef
+      location = "group:package.json">
+   </FileRef>
+   <FileRef
+      location = "group:Package.swift">
+   </FileRef>
+   <FileRef
+      location = "group:README.md">
+   </FileRef>
+   <FileRef
+      location = "group:SECURITY.md">
+   </FileRef>
+   <FileRef
+      location = "group:THIRD_PARTY_LICENSES.md">
+   </FileRef>
+</Workspace>

--- a/Montage.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Montage.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "ce015d0ae6da392d3a2e82921ff7482591d1f786d188b2e9ffc091e98b11b880",
+  "pins" : [
+    {
+      "identity" : "lottie-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/lottie-ios",
+      "state" : {
+        "revision" : "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "pretendard-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/wanteddev/pretendard-ios",
+      "state" : {
+        "branch" : "main",
+        "revision" : "468a2bf832a3f245df031de14576d3625fb7b3e3"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "36e79ba485e9bb4d3cd4e3318908866dac5e7b51",
+        "version" : "5.21.5"
+      }
+    },
+    {
+      "identity" : "sdwebimageswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI.git",
+      "state" : {
+        "revision" : "0e331457ca9af2f0b08bcaa138a91ffb907b004f",
+        "version" : "3.1.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
+++ b/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
@@ -23,9 +23,7 @@
 		4D5597522D1E7EC000CFBCA5 /* PaginationDotsPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5597512D1E7EC000CFBCA5 /* PaginationDotsPreview.swift */; };
 		4D5597542D1E7F9400CFBCA5 /* PaginationPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5597532D1E7F9400CFBCA5 /* PaginationPreview.swift */; };
 		4D5597562D1E802E00CFBCA5 /* PageCounterPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5597552D1E802C00CFBCA5 /* PageCounterPreview.swift */; };
-		4D5B46D52CE3460B001DD48B /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4D5B46D42CE3460B001DD48B /* SnapKit */; };
 		4D5B46D82CE34625001DD48B /* Pretendard in Frameworks */ = {isa = PBXBuildFile; productRef = 4D5B46D72CE34625001DD48B /* Pretendard */; };
-		4D5B46DB2CE3463F001DD48B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 4D5B46DA2CE3463F001DD48B /* Lottie */; };
 		4D5D8C9C2D27E8E100108C92 /* AccordionPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5D8C9B2D27E8CE00108C92 /* AccordionPreview.swift */; };
 		4D5D8C9E2D2E5D9E00108C92 /* CategoryPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5D8C9D2D2E5D9E00108C92 /* CategoryPreview.swift */; };
 		4D6372C72DBA655200E66D22 /* CardPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6372C62DBA655200E66D22 /* CardPreview.swift */; };
@@ -72,23 +70,6 @@
 		4DFA5A532E572464003BED22 /* ShadowPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DFA5A522E572464003BED22 /* ShadowPreview.swift */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		4D9F46BD2CE32752000DBA7D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4D9F46A42CE32750000DBA7D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4D9F46AB2CE32750000DBA7D;
-			remoteInfo = Blueprint;
-		};
-		4D9F46C72CE32752000DBA7D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4D9F46A42CE32750000DBA7D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4D9F46AB2CE32750000DBA7D;
-			remoteInfo = Blueprint;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
 		4D0952662D7ABCCB00BB6044 /* ControlPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPreview.swift; sourceTree = "<group>"; };
 		4D0D251D2DB763F600608CE5 /* ThumbnailPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailPreview.swift; sourceTree = "<group>"; };
@@ -123,8 +104,6 @@
 		4D96F7C92E9FA8C300DFECE8 /* ColorPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPreview.swift; sourceTree = "<group>"; };
 		4D96F7CD2EA07D7B00DFECE8 /* TransparentCheckerPatternModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentCheckerPatternModifier.swift; sourceTree = "<group>"; };
 		4D9F46AC2CE32750000DBA7D /* Blueprint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Blueprint.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		4D9F46BC2CE32752000DBA7D /* BlueprintTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BlueprintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		4D9F46C62CE32752000DBA7D /* BlueprintUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BlueprintUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DA40B262D3E2F6A004C73E5 /* SectionHeaderPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderPreview.swift; sourceTree = "<group>"; };
 		4DA44F1A2D12CC91009FE3DB /* PullToRefreshPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullToRefreshPreview.swift; sourceTree = "<group>"; };
 		4DA44F1E2D195832009FE3DB /* ProgressTrackerPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressTrackerPreview.swift; sourceTree = "<group>"; };
@@ -160,24 +139,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4D5B46D52CE3460B001DD48B /* SnapKit in Frameworks */,
 				4D5B46D82CE34625001DD48B /* Pretendard in Frameworks */,
 				4D45DAF12D910C2D002B1686 /* Montage in Frameworks */,
-				4D5B46DB2CE3463F001DD48B /* Lottie in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4D9F46B92CE32752000DBA7D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4D9F46C32CE32752000DBA7D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -199,8 +162,6 @@
 			isa = PBXGroup;
 			children = (
 				4D9F46AC2CE32750000DBA7D /* Blueprint.app */,
-				4D9F46BC2CE32752000DBA7D /* BlueprintTests.xctest */,
-				4D9F46C62CE32752000DBA7D /* BlueprintUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -334,54 +295,12 @@
 			);
 			name = Blueprint;
 			packageProductDependencies = (
-				4D5B46D42CE3460B001DD48B /* SnapKit */,
 				4D5B46D72CE34625001DD48B /* Pretendard */,
-				4D5B46DA2CE3463F001DD48B /* Lottie */,
 				4D45DAF02D910C2D002B1686 /* Montage */,
 			);
 			productName = Blueprint;
 			productReference = 4D9F46AC2CE32750000DBA7D /* Blueprint.app */;
 			productType = "com.apple.product-type.application";
-		};
-		4D9F46BB2CE32752000DBA7D /* BlueprintTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4D9F46D32CE32752000DBA7D /* Build configuration list for PBXNativeTarget "BlueprintTests" */;
-			buildPhases = (
-				4D9F46B82CE32752000DBA7D /* Sources */,
-				4D9F46B92CE32752000DBA7D /* Frameworks */,
-				4D9F46BA2CE32752000DBA7D /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				4D9F46BE2CE32752000DBA7D /* PBXTargetDependency */,
-			);
-			name = BlueprintTests;
-			packageProductDependencies = (
-			);
-			productName = BlueprintTests;
-			productReference = 4D9F46BC2CE32752000DBA7D /* BlueprintTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		4D9F46C52CE32752000DBA7D /* BlueprintUITests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4D9F46D62CE32752000DBA7D /* Build configuration list for PBXNativeTarget "BlueprintUITests" */;
-			buildPhases = (
-				4D9F46C22CE32752000DBA7D /* Sources */,
-				4D9F46C32CE32752000DBA7D /* Frameworks */,
-				4D9F46C42CE32752000DBA7D /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				4D9F46C82CE32752000DBA7D /* PBXTargetDependency */,
-			);
-			name = BlueprintUITests;
-			packageProductDependencies = (
-			);
-			productName = BlueprintUITests;
-			productReference = 4D9F46C62CE32752000DBA7D /* BlueprintUITests.xctest */;
-			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 /* End PBXNativeTarget section */
 
@@ -396,14 +315,6 @@
 					4D9F46AB2CE32750000DBA7D = {
 						CreatedOnToolsVersion = 16.1;
 					};
-					4D9F46BB2CE32752000DBA7D = {
-						CreatedOnToolsVersion = 16.1;
-						TestTargetID = 4D9F46AB2CE32750000DBA7D;
-					};
-					4D9F46C52CE32752000DBA7D = {
-						CreatedOnToolsVersion = 16.1;
-						TestTargetID = 4D9F46AB2CE32750000DBA7D;
-					};
 				};
 			};
 			buildConfigurationList = 4D9F46A72CE32750000DBA7D /* Build configuration list for PBXProject "Blueprint" */;
@@ -416,10 +327,8 @@
 			mainGroup = 4D9F46A32CE32750000DBA7D;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				4D5B46D32CE3460B001DD48B /* XCRemoteSwiftPackageReference "SnapKit" */,
 				4D5B46D62CE34625001DD48B /* XCRemoteSwiftPackageReference "pretendard-ios" */,
-				4D5B46D92CE3463F001DD48B /* XCRemoteSwiftPackageReference "lottie-ios" */,
-				4D45DAEF2D910C2D002B1686 /* XCLocalSwiftPackageReference "../../../Montage" */,
+				4D45DAEF2D910C2D002B1686 /* XCLocalSwiftPackageReference "../../" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4D9F46AD2CE32750000DBA7D /* Products */;
@@ -427,8 +336,6 @@
 			projectRoot = "";
 			targets = (
 				4D9F46AB2CE32750000DBA7D /* Blueprint */,
-				4D9F46BB2CE32752000DBA7D /* BlueprintTests */,
-				4D9F46C52CE32752000DBA7D /* BlueprintUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -440,20 +347,6 @@
 			files = (
 				4DF7C5022CE340F0002B241B /* Asset.xcassets in Resources */,
 				4DF7C5032CE340F0002B241B /* LaunchScreen.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4D9F46BA2CE32752000DBA7D /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4D9F46C42CE32752000DBA7D /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -524,34 +417,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4D9F46B82CE32752000DBA7D /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4D9F46C22CE32752000DBA7D /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		4D9F46BE2CE32752000DBA7D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 4D9F46AB2CE32750000DBA7D /* Blueprint */;
-			targetProxy = 4D9F46BD2CE32752000DBA7D /* PBXContainerItemProxy */;
-		};
-		4D9F46C82CE32752000DBA7D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 4D9F46AB2CE32750000DBA7D /* Blueprint */;
-			targetProxy = 4D9F46C72CE32752000DBA7D /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		4D9F46CE2CE32752000DBA7D /* Debug */ = {
@@ -733,78 +599,6 @@
 			};
 			name = Release;
 		};
-		4D9F46D42CE32752000DBA7D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YEX9K6G97T;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wantedlab.BlueprintTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Blueprint.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Blueprint";
-			};
-			name = Debug;
-		};
-		4D9F46D52CE32752000DBA7D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YEX9K6G97T;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wantedlab.BlueprintTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Blueprint.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Blueprint";
-			};
-			name = Release;
-		};
-		4D9F46D72CE32752000DBA7D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YEX9K6G97T;
-				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wantedlab.BlueprintUITests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = Blueprint;
-			};
-			name = Debug;
-		};
-		4D9F46D82CE32752000DBA7D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YEX9K6G97T;
-				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wantedlab.BlueprintUITests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = Blueprint;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -826,56 +620,22 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4D9F46D32CE32752000DBA7D /* Build configuration list for PBXNativeTarget "BlueprintTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4D9F46D42CE32752000DBA7D /* Debug */,
-				4D9F46D52CE32752000DBA7D /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		4D9F46D62CE32752000DBA7D /* Build configuration list for PBXNativeTarget "BlueprintUITests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4D9F46D72CE32752000DBA7D /* Debug */,
-				4D9F46D82CE32752000DBA7D /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		4D45DAEF2D910C2D002B1686 /* XCLocalSwiftPackageReference "../../../Montage" */ = {
+		4D45DAEF2D910C2D002B1686 /* XCLocalSwiftPackageReference "../../" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../../Montage;
+			relativePath = ../../;
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		4D5B46D32CE3460B001DD48B /* XCRemoteSwiftPackageReference "SnapKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.7.1;
-			};
-		};
 		4D5B46D62CE34625001DD48B /* XCRemoteSwiftPackageReference "pretendard-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/wanteddev/pretendard-ios";
 			requirement = {
 				branch = main;
 				kind = branch;
-			};
-		};
-		4D5B46D92CE3463F001DD48B /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -885,20 +645,10 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = Montage;
 		};
-		4D5B46D42CE3460B001DD48B /* SnapKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4D5B46D32CE3460B001DD48B /* XCRemoteSwiftPackageReference "SnapKit" */;
-			productName = SnapKit;
-		};
 		4D5B46D72CE34625001DD48B /* Pretendard */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4D5B46D62CE34625001DD48B /* XCRemoteSwiftPackageReference "pretendard-ios" */;
 			productName = Pretendard;
-		};
-		4D5B46DA2CE3463F001DD48B /* Lottie */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4D5B46D92CE3463F001DD48B /* XCRemoteSwiftPackageReference "lottie-ios" */;
-			productName = Lottie;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
+++ b/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
@@ -48,7 +48,6 @@ struct ComponentListView: View {
                     .background {
                         Capsule()
                             .foregroundStyle(.ultraThinMaterial)
-                            .clipShape(Capsule())
                     }
                     .padding(8)
             }

--- a/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
+++ b/Sources/Blueprint/Sources/Scene/ComponentList/ComponentListView.swift
@@ -36,22 +36,23 @@ struct ComponentListView: View {
     
     var body: some View {
         NavigationStack(path: $coordinator.path) {
-            Group {
+            ZStack(alignment: .bottom) {
                 if #available(iOS 18.0, *) {
                     list.searchFocused($searchFocused)
                 } else {
                     list
                 }
+                (Text("powered by the Wanted Design System, ") + Text("Montage™").bold())
+                    .typography(variant: .caption2, weight: .regular)
+                    .padding(12)
+                    .background {
+                        Capsule()
+                            .foregroundStyle(.ultraThinMaterial)
+                            .clipShape(Capsule())
+                    }
+                    .padding(8)
             }
             .navigationTitle("Blueprint")
-            .toolbar(content: {
-                ToolbarItem(placement: .bottomBar) {
-                    VStack {
-                        (Text("powered by the Wanted Design System, ") + Text("Montage™").bold())
-                            .typography(variant: .caption2, weight: .regular)
-                    }
-                }
-            })
             .navigationBarTitleDisplayMode(.large)
             .navigationDestination(for: Component.self) { componentType in
                 coordinator.destinationView(for: componentType)

--- a/Sources/Blueprint/Sources/Scene/Previews/PaginationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/PaginationPreview.swift
@@ -6,7 +6,6 @@
 //
 
 import Montage
-import Pretendard
 import SwiftUI
 
 struct PaginationPreview: View {
@@ -47,6 +46,5 @@ struct PaginationPreview: View {
 }
 
 #Preview(body: {
-    _ = try? Pretendard.registerFonts()
     return PaginationPreview()
 })

--- a/Sources/Blueprint/Sources/Scene/Previews/PlayBadgePreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/PlayBadgePreview.swift
@@ -59,8 +59,6 @@ struct PlayBadgePreview: View {
 
 extension PlayBadge.Size: CaseDescribable {}
 
-import Pretendard
 #Preview {
-    _ = try? Pretendard.registerFonts()
     return PlayBadgePreview()
 }

--- a/Sources/Blueprint/Sources/Scene/Previews/ProgressTrackerPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ProgressTrackerPreview.swift
@@ -47,8 +47,6 @@ struct ProgressTrackerPreview: View {
     }
 }
 
-import Pretendard
 #Preview(body: {
-    _ = try? Pretendard.registerFonts()
     return ProgressTrackerPreview()
 })

--- a/Sources/Blueprint/Sources/Scene/Previews/SectionHeaderPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SectionHeaderPreview.swift
@@ -85,8 +85,6 @@ struct SectionHeaderPreview: View {
 
 extension SectionHeader.Size: CaseDescribable {}
 
-import Pretendard
 #Preview {
-    _ = try? Pretendard.registerFonts()
     return SectionHeaderPreview()
 }

--- a/Sources/Blueprint/Sources/Scene/Previews/TypographyPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TypographyPreview.swift
@@ -36,13 +36,13 @@ struct TypographyPreview: View {
             ForEach(Typography.Variant.allCases, id: \.self) { variant in
                 HStack(spacing: 4) {
                     VStack{
-                        Text("\(variant)")
+                        Text(String(describing: variant))
                             .typography(weight: .bold)
-                        Text("fontSize:\(variant.fontSize, specifier: "%.0f")")
-                        Text("fontHeight:\(variant.fontHeight, specifier: "%.1f")")
-                        Text("lineSpacing:\(variant.lineSpacing, specifier: "%.1f")")
-                        Text("lineHeight:\(variant.lineHeight, specifier: "%.1f")")
-                        Text("letterSpacing:\(variant.tracking, specifier: "%.1f")")
+                        Text("fontSize: " + String(format: "%.0f", variant.fontSize))
+                        Text("fontHeight: " + String(format: "%.1f", variant.fontHeight))
+                        Text("lineSpacing: " + String(format: "%.1f", variant.lineSpacing))
+                        Text("lineHeight: " + String(format: "%.1f", variant.lineHeight))
+                        Text("letterSpacing: " + String(format: "%.1f", variant.tracking))
                     }
                     .monospacedDigit()
                     .font(.system(size: 10, weight: .medium))
@@ -72,8 +72,6 @@ struct TypographyPreview: View {
     }
 }
 
-import Pretendard
 #Preview {
-    _ = try? Pretendard.registerFonts()
     return TypographyPreview()
 }


### PR DESCRIPTION
# 개요
# 수정사항
Blueprint 앱 메인 화면 하단 문구 잘리는 문제 수정(iOS 26)

# 미리보기
작업 전|작업 후
---|---
<img width="1206" height="2622" alt="simulator_screenshot_80464A22-3460-4054-A5E2-BC5BAE0E5029" src="https://github.com/user-attachments/assets/2e9fcf63-aefb-4703-a274-6b7115f3d072" />|<img width="1206" height="2622" alt="simulator_screenshot_22B43FE7-D111-4178-AAAB-63062A879B41" src="https://github.com/user-attachments/assets/6c5cd9f0-52ad-4225-b22d-2215474082c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 컴포넌트 목록 화면의 하단 문구를 툴바 기반에서 캡슐형 오버레이 텍스트로 변경해 시각적 일관성과 가독성을 개선했습니다.
  * 타이포그래피 프리뷰의 레이블/값 표기를 더 명확한 문자열 형식으로 정리했습니다.

* **작업(Chores)**
  * 테스트 대상 및 관련 패키지 참조를 제거하고 프로젝트/워크스페이스 구성을 정리했습니다.
  * 워크스페이스 구조와 패키지 잠금파일을 업데이트했습니다.

* **참고사항**
  * 프리뷰 환경에서의 폰트 등록이 제거되어 일부 프리뷰 렌더링에 영향이 있을 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->