### PR TITLE
BottomSheet 컴포넌트에 onDismiss 클로저 추가

### DIFF
--- a/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
+++ b/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
@@ -289,6 +289,7 @@ struct BottomSheetModifier: ViewModifier {
     private let ignoresEdgeInsets: Bool
     private let actionAreaModel: ActionArea.Model?
     private let navigation: (() -> ModalNavigation)?
+    private let onDismiss: (() -> Void)?
     private let bottomSheetContent: () -> AnyView
     
     init<V: View>(
@@ -299,6 +300,7 @@ struct BottomSheetModifier: ViewModifier {
         ignoresEdgeInsets: Bool = false,
         actionAreaModel: ActionArea.Model? = nil,
         navigation: (() -> ModalNavigation)? = nil,
+        onDismiss: (() -> Void)? = nil,
         @ViewBuilder _ content: @escaping () -> V
     ) {
         _isPresented = isPresented
@@ -308,6 +310,7 @@ struct BottomSheetModifier: ViewModifier {
         self.ignoresEdgeInsets = ignoresEdgeInsets
         self.actionAreaModel = actionAreaModel
         self.navigation = navigation
+        self.onDismiss = onDismiss
         bottomSheetContent = { AnyView(content()) }
     }
     
@@ -315,7 +318,10 @@ struct BottomSheetModifier: ViewModifier {
         content
             .modifying {
                 if isFullScreenCover {
-                    $0.fullScreenCover(isPresented: $isPresented) {
+                    $0.fullScreenCover(
+                        isPresented: $isPresented,
+                        onDismiss: onDismiss
+                    ) {
                         BottomSheet {
                             bottomSheetContent()
                         }
@@ -326,7 +332,10 @@ struct BottomSheetModifier: ViewModifier {
                         .modalActionArea(actionAreaModel)
                     }
                 } else {
-                    $0.sheet(isPresented: $isPresented) {
+                    $0.sheet(
+                        isPresented: $isPresented,
+                        onDismiss: onDismiss
+                    ) {
                         BottomSheet {
                             bottomSheetContent()
                         }
@@ -356,6 +365,7 @@ extension View {
     ///   - ignoresEdgeInsets: 모달 내용이 Edge 인셋을 무시할지 여부
     ///   - actionAreaModel: 모달 하단에 표시할 액션 영역 모델, 생략하면 기본값으로 `nil` 적용
     ///   - navigation: 모달 상단에 표시할 네비게이션 클로저, 생략하면 기본값으로 `nil` 적용
+    ///   - onDismiss: 모달이 닫힐때 호출될 클로저
     ///   - content: 모달에 표시할 콘텐츠 클로저
     /// - Returns: 바텀 시트 모달이 적용된 뷰
     public func bottomSheet<V: View>(
@@ -366,6 +376,7 @@ extension View {
         ignoresEdgeInsets: Bool = false,
         actionAreaModel: ActionArea.Model? = nil,
         navigation: (() -> ModalNavigation)? = nil,
+        onDismiss: (() -> Void)? = nil,
         @ViewBuilder _ content: @escaping () -> V
     ) -> some View {
         modifier(
@@ -377,6 +388,7 @@ extension View {
                 ignoresEdgeInsets: ignoresEdgeInsets,
                 actionAreaModel: actionAreaModel,
                 navigation: navigation,
+                onDismiss: onDismiss,
                 content
             )
         )

--- a/documentation/components/presentation/bottomsheet/ios.md
+++ b/documentation/components/presentation/bottomsheet/ios.md
@@ -217,7 +217,7 @@ YourView()
 
 <details>
 
-<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, () -> V) -> some View``</summary>
+<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, onDismiss: (() -> Void)?, () -> V) -> some View``</summary>
 
 
 바텀 시트 모달을 표시합니다.
@@ -232,6 +232,7 @@ YourView()
   | `ignoresEdgeInsets` | 모달 내용이 Edge 인셋을 무시할지 여부 |
   | `actionAreaModel` | 모달 하단에 표시할 액션 영역 모델, 생략하면 기본값으로 `nil` 적용 |
   | `navigation` | 모달 상단에 표시할 네비게이션 클로저, 생략하면 기본값으로 `nil` 적용 |
+  | `onDismiss` | 모달이 닫힐때 호출될 클로저 |
   | `content` | 모달에 표시할 콘텐츠 클로저 |
 - **Return Value**
 

--- a/documentation/utilities/ios-extensions/swiftuicore.md
+++ b/documentation/utilities/ios-extensions/swiftuicore.md
@@ -106,7 +106,7 @@ View를 UIImage로 변환합니다.
 </details>
 <details>
 
-<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, () -> V) -> some View``</summary>
+<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, onDismiss: (() -> Void)?, () -> V) -> some View``</summary>
 
 
 바텀 시트 모달을 표시합니다.
@@ -121,6 +121,7 @@ View를 UIImage로 변환합니다.
   | `ignoresEdgeInsets` | 모달 내용이 Edge 인셋을 무시할지 여부 |
   | `actionAreaModel` | 모달 하단에 표시할 액션 영역 모델, 생략하면 기본값으로 `nil` 적용 |
   | `navigation` | 모달 상단에 표시할 네비게이션 클로저, 생략하면 기본값으로 `nil` 적용 |
+  | `onDismiss` | 모달이 닫힐때 호출될 클로저 |
   | `content` | 모달에 표시할 콘텐츠 클로저 |
 - **Return Value**
 

--- a/documentation/utilities/ios-utility-components/icon.md
+++ b/documentation/utilities/ios-utility-components/icon.md
@@ -1567,6 +1567,11 @@ Button(action: {}) {
 </details>
 <details>
 
+<summary>``case telescope``</summary>
+
+</details>
+<details>
+
 <summary>``case template``</summary>
 
 </details>


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

# 수정사항
바텀시트 컴포넌트에 onDismiss 클로저를 추가하여 바텀시트가 닫히고 나서 동작해야 할 클로저를 할당할 수 있게 하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 하단 시트 닫힐 때 실행할 콜백 옵션 추가

* **설명서**
  * 하단 시트 API 설명서 업데이트
  * 망원경 아이콘 옵션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->