### PR TITLE
Montage SPM 설정 unsafe complie 옵션 제거

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,9 +33,6 @@ let package = Package(
             ],
             resources: [
                 .process("Asset")
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-enable-library-evolution"])
             ]
         ),
         .testTarget(


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-81647

# 수정사항
SPM설정에서 -enable-library-evolution 옵션 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Montage 타겟의 Swift 빌드 설정을 업데이트했습니다. 컴파일러 설정 옵션을 조정하여 빌드 구성을 간소화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->