### PR TITLE
feat: ModalNavigation.Variant extended를 display로 변경

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/BottomSheetPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/BottomSheetPreview.swift
@@ -249,7 +249,7 @@ struct BottomSheetPreview: View {
 
     private let navigationVariants: [ModalNavigation.Variant] = [
         .normal,
-        .extended,
+        .display,
         .emphasized,
         .floating(alternative: false, background: false),
     ]

--- a/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
@@ -142,7 +142,7 @@ struct ModalNavigationPreview: View {
     }
     
     private var variants: [ModalNavigation.Variant] {
-        [.normal, .extended, .emphasized, .floating(alternative: alternative, background: background)]
+        [.normal, .display, .emphasized, .floating(alternative: alternative, background: background)]
     }
     
     private var leadingButtons: [TopNavigation.Resource.LeadingButtonInfo] {

--- a/Sources/Blueprint/Sources/Scene/Previews/PopupPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/PopupPreview.swift
@@ -221,7 +221,7 @@ struct PopupPreview: View {
 
     private let navigationVariants: [ModalNavigation.Variant] = [
         .normal,
-        .extended,
+        .display,
         .emphasized,
         .floating(alternative: true, background: true),
     ]

--- a/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
@@ -35,6 +35,9 @@ public struct ModalNavigation: View {
         /// 기본 스타일의 내비게이션 바
         case normal
         /// 제목이 별도 줄에 표시되는 확장된 스타일
+        case display
+        /// 제목이 별도 줄에 표시되는 확장된 스타일
+        @available(*, deprecated, renamed: "display", message: "will be removed on next major version update")
         case extended
         /// 배경이 투명한 플로팅 스타일
         /// - Parameters:
@@ -47,7 +50,7 @@ public struct ModalNavigation: View {
         fileprivate var isFloating: Bool {
             switch self {
             case .floating: true
-            case .normal, .extended, .emphasized: false
+            case .normal, .display, .extended, .emphasized: false
             }
         }
     }
@@ -225,7 +228,7 @@ public struct ModalNavigation: View {
         
         var body: some View {
             switch variant {
-            case .normal, .extended, .floating:
+            case .normal, .display, .extended, .floating:
                 TopNavigation.Contents(
                     variant: variant.topNavigationVariant,
                     titleText: titleText,
@@ -302,7 +305,7 @@ private extension ModalNavigation.Variant {
     var topNavigationVariant: TopNavigation.Variant {
         switch self {
         case .normal: .normal
-        case .extended: .display
+        case .display, .extended: .display
         case .floating: .floating
         case .emphasized: .normal
         }
@@ -311,7 +314,7 @@ private extension ModalNavigation.Variant {
     var typoVariant: Typography.Variant {
         switch self {
         case .normal: .headline2
-        case .extended: .title3
+        case .display, .extended: .title3
         case .floating: .headline2
         case .emphasized: .heading2
         }
@@ -320,7 +323,7 @@ private extension ModalNavigation.Variant {
     var typoWeight: Typography.Weight {
         switch self {
         case .normal: .bold
-        case .extended: .bold
+        case .display, .extended: .bold
         case .floating: .bold
         case .emphasized: .bold
         }

--- a/documentation/utilities/ios-utility-components/modalnavigation.md
+++ b/documentation/utilities/ios-utility-components/modalnavigation.md
@@ -219,6 +219,13 @@ ModalNavigation()
 
 <details>
 
+<summary>``case display``</summary>
+
+
+제목이 별도 줄에 표시되는 확장된 스타일
+</details>
+<details>
+
 <summary>``case emphasized``</summary>
 
 
@@ -226,7 +233,7 @@ ModalNavigation()
 </details>
 <details>
 
-<summary>``case extended``</summary>
+<summary>~~``case extended``~~</summary>
 
 
 제목이 별도 줄에 표시되는 확장된 스타일


### PR DESCRIPTION
## Summary
- `ModalNavigation.Variant`에 `display` 케이스 추가
- 기존 `extended` 케이스를 deprecated 처리
- Blueprint 프리뷰 파일들 `display`로 마이그레이션

https://wantedlab.atlassian.net/browse/PI-81675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모달 네비게이션에 새로운 `display` 변형 추가

* **더 이상 사용되지 않음**
  * `extended` 변형이 더 이상 사용되지 않으며, 다음 메이저 버전에서 제거될 예정입니다.

* **문서**
  * 모달 네비게이션 API 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->