### PR TITLE
fix: PullToRefresh DragGesture를 onScrollPhaseChange로 교체 (PI-81596)

### DIFF
--- a/Sources/Montage/1 Components/9 Utilities/PullToRefresh.swift
+++ b/Sources/Montage/1 Components/9 Utilities/PullToRefresh.swift
@@ -8,8 +8,8 @@
 import Lottie
 import SwiftUI
 
+@available(iOS 18, *)
 public enum PullToRefresh {
-    @available(iOS 18, *)
     struct Modifier: ViewModifier {
         @Binding private var scrollYOffset: CGFloat
         private let refresh: () async -> Void
@@ -70,51 +70,46 @@ public enum PullToRefresh {
 
                     content
                 }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 1)
-                        .onChanged { _ in
-                            isScrolling = true
+                .onScrollPhaseChange { oldPhase, newPhase in
+                    if newPhase == .interacting {
+                        isScrolling = true
+                        if phase.beforeRefreshing {
+                            // 현재 스크롤이 트리거스크롤임
+                            isTriggerScrolling = true
+                        }
+                    }
 
-                            if phase.beforeRefreshing {
-                                // 현재 스크롤이 트리거스크롤임
-                                isTriggerScrolling = true
+                    if oldPhase == .interacting, newPhase != .interacting {
+                        // 리프레시가 시작된 후 스크롤이 끝났을 때
+                        if phase.isRefreshing {
+                            // 투명뷰를 추가한다.
+                            isClearRectNeeded = true
+                            // 스크롤 옵셋이 천천히 되돌아가도록 하기 위한 애니메이션
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                // 로고와 패딩 영역이 천천히 줄어들도록 하기 위함
+                                pullToRefreshViewHeight = hangingHeight
+                                clearRectHeight = hangingHeight
                             }
                         }
-                        .onEnded { value in
-                            // 리프레시가 시작된 후 스크롤이 끝났을 때
-                            if phase.isRefreshing {
-                                // 투명뷰를 추가한다.
-                                isClearRectNeeded = true
-                                // 스크롤 옵셋이 천천히 되돌아가도록 하기 위한 애니메이션
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    // 로고와 패딩 영역이 천천히 줄어들도록 하기 위함
-                                    pullToRefreshViewHeight = hangingHeight
-                                    clearRectHeight = hangingHeight
-                                }
-                            }
 
-                            // 리프레시가 끝나기 전에 스크롤을 드래그하여 위로 던지는 경우
-                            if phase
-                                .isRefreshing
-                                && (value.predictedEndTranslation.height < 0 || scrollYOffset < 0)
-                            {
-                                task?.cancel()
-                            }
-
-                            // 리프레시가 끝난 후 스크롤이 끝났을 때
-                            if phase.isWaitingToEnd {
-                                // 스크롤 옵셋 복귀 애니메이션 시작점 설정
-                                clearRectHeight = hangingHeight + value.translation.height / 2
-                                // 엔딩 애니메이션 수행
-                                phase = .ending
-                            }
-
-                            isTriggerScrolling = false
-                            isScrolling = false
+                        // 리프레시가 끝나기 전에 스크롤을 드래그하여 위로 던지는 경우
+                        if phase.isRefreshing && scrollYOffset < 0 {
+                            task?.cancel()
                         }
-                )
+
+                        // 리프레시가 끝난 후 스크롤이 끝났을 때
+                        if phase.isWaitingToEnd {
+                            // 엔딩 애니메이션 수행
+                            clearRectHeight = hangingHeight
+                            phase = .ending
+                        }
+
+                        isTriggerScrolling = false
+                        isScrolling = false
+                    }
+                }
             }
-            .onChange(of: scrollYOffset) { scrollPosition in
+            .onChange(of: scrollYOffset) { _, scrollPosition in
                 // 트리거스크롤이 끝날때까지
                 if isTriggerScrolling {
                     // 스크롤 옵셋 복귀 애니메이션 시작점을 업데이트
@@ -132,7 +127,7 @@ public enum PullToRefresh {
                     phase = .pulledDown(ratio: pullDownRatio)
                 }
             }
-            .onChange(of: phase) { phase in
+            .onChange(of: phase) { _, phase in
                 switch phase {
                 case .idle:
                     break
@@ -238,7 +233,7 @@ public enum PullToRefresh {
                 .frame(width: 48, height: 36)
                 .opacity(opacity)
                 .scaleEffect(scale)
-                .onChange(of: phase) { phase in
+                .onChange(of: phase) { _, phase in
                     switch phase {
                     case .idle:
                         opacity = 1


### PR DESCRIPTION
## Summary
- PullToRefresh의 `simultaneousGesture(DragGesture)`를 `onScrollPhaseChange`로 교체하여 TabView 페이지 스와이프 차단 문제 수정
- `onChange(of:)` deprecated API를 새로운 two-parameter form으로 업데이트
- `@available(iOS 18, *)` 어노테이션을 PullToRefresh enum 레벨로 이동

## Related Issue
- https://wantedlab.atlassian.net/browse/PI-81596

## Test Plan
- [x] 마이원티드 탭에서 당겨서 새로고침 동작 확인
- [x] 마이원티드 탭에서 좌우 탭 슬라이딩 정상 동작 확인
- [x] PullToRefresh가 적용된 다른 화면에서도 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * Pull to Refresh 기능의 상호작용 방식을 개선했습니다. 스크롤 단계 변경에 기반한 새로운 제어 흐름으로 업데이트되어 더욱 반응적이고 부드러운 새로고침 경험을 제공합니다.
  * iOS 18 이상에서 지원되는 기능으로 가용성이 명확히 표시되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->