### PR TITLE
fix: TopNavigation/ModalNavigation 디자인 스펙 패딩 불일치 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # 문서 생성시 사용해야 하는 Xcode 버전
 # 빌드머신의 Xcode 버전과 동일하게 설정해야 합니다.
-XCODE_VERSION=16.4
+XCODE_VERSION=26.2
 
 # 기본 타겟: docc, md, license를 순서대로 실행하고 변경사항 확인
 all: docc md license check-changes

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -338,7 +338,6 @@ public struct TopNavigation: View {
                         HStack(spacing: 6) {
                             titleContent
                                 .frame(height: 32, alignment: variant.textAlignment)
-                                .padding(.horizontal, 4)
                                 .padding(.vertical, 16)
                             Spacer(minLength: actionItemsMaxWidth)
                         }
@@ -367,6 +366,7 @@ public struct TopNavigation: View {
         private var titleContent: some View {
             if let titleText {
                 TitleView(variant: variant, title: titleText)
+                    .padding(.horizontal, 4)
             } else {
                 titleView()
             }

--- a/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
@@ -86,52 +86,44 @@ public struct ModalNavigation: View {
     
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
-        ZStack(alignment: .bottom) {
-            VStack(spacing: 0) {
-                if needHandleArea {
-                    ZStack(alignment: .bottom) {
-                        SwiftUI.Color.clear
-                            .frame(height: 12)
-                        RoundedRectangle(cornerRadius: 1000)
-                            .foregroundStyle(SwiftUI.Color.semantic(.fillStrong))
-                            .frame(width: 40, height: 5)
-                    }
+        VStack(spacing: 0) {
+            if needHandleArea {
+                ZStack(alignment: .bottom) {
+                    SwiftUI.Color.clear
+                        .frame(height: 12)
+                    RoundedRectangle(cornerRadius: 1000)
+                        .foregroundStyle(SwiftUI.Color.semantic(.fillStrong))
+                        .frame(width: 40, height: 5)
                 }
-                
-                Contents(
-                    variant: variant,
-                    titleText: titleText,
-                    titleView: titleView,
-                    leadingContent: leadingContent,
-                    trailingContents: trailingContents
-                )
-                .padding(.vertical, 20)
-                .padding(.horizontal, 16)
             }
-            .background {
-                ZStack {
-                    Rectangle().fill(.ultraThinMaterial)
-                        .opacity(backgroundOpacity)
-                    backgroundColor
-                        .opacity(backgroundOpacity * 0.70)
+
+            Contents(
+                variant: variant,
+                titleText: titleText,
+                titleView: titleView,
+                leadingContent: leadingContent,
+                trailingContents: trailingContents
+            )
+            .padding(.top, variant.contentTopPadding)
+            .padding(.bottom, variant.contentBottomPadding)
+        }
+        .background {
+            ZStack {
+                Rectangle().fill(.ultraThinMaterial)
+                    .opacity(backgroundOpacity)
+                backgroundColor
+                    .opacity(backgroundOpacity * 0.70)
+            }
+            .if(variant.isFloating) {
+                $0.mask {
+                    LinearGradient(
+                        colors: gradientMaskColors,
+                        startPoint: .init(x: 0, y: 1),
+                        endPoint: .init(x: 0, y: 0)
+                    )
                 }
-                .if(variant.isFloating) {
-                    $0.mask {
-                        LinearGradient(
-                            colors: gradientMaskColors,
-                            startPoint: .init(x: 0, y: 1),
-                            endPoint: .init(x: 0, y: 0)
-                        )
-                    }
-                }
-                .ignoresSafeArea(.container, edges: .top)
             }
-            
-            if scrolled && variant.isFloating == false {
-                Rectangle()
-                    .foregroundStyle(SwiftUI.Color.semantic(.lineNeutral).opacity(backgroundOpacity))
-                    .frame(height: 0.5)
-            }
+            .ignoresSafeArea(.container, edges: .top)
         }
     }
     
@@ -273,6 +265,7 @@ public struct ModalNavigation: View {
                         }
                     }
                 }
+                .padding(.horizontal, 16)
             }
         }
         
@@ -308,13 +301,12 @@ extension ModalNavigation {
                     semantic: .labelStrong
                 )
                 .lineLimit(1)
+                .padding(.horizontal, 4)
         }
     }
 }
 
 private extension ModalNavigation {
-    var scrolled: Bool { scrollOffset < .zero }
-
     var backgroundOpacity: CGFloat {
         if variant.isFloating {
             return 1
@@ -330,6 +322,24 @@ private extension ModalNavigation {
 }
 
 private extension ModalNavigation.Variant {
+    var contentTopPadding: CGFloat {
+        switch kind {
+        case .normal: 10
+        case .display, .extended: 4
+        case .emphasized: 20
+        case .floating: 4
+        }
+    }
+
+    var contentBottomPadding: CGFloat {
+        switch kind {
+        case .normal: 10
+        case .display, .extended: 4
+        case .emphasized: 20
+        case .floating: 8
+        }
+    }
+
     var topNavigationVariant: TopNavigation.Variant {
         switch kind {
         case .normal: .normal

--- a/documentation/utilities/ios-utility-components/flowlayout.md
+++ b/documentation/utilities/ios-utility-components/flowlayout.md
@@ -47,6 +47,10 @@ Conforms To
 
 `Swift.Copyable`
 
+`Swift.Sendable`
+
+`Swift.SendableMetatype`
+
 `SwiftUICore.Animatable`
 
 `SwiftUICore.Layout`


### PR DESCRIPTION
# 개요
- 🔗  JIRA 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-82108

# 수정 내용
TopNavigation과 ModalNavigation의 디자인 스펙 대비 패딩 불일치를 수정합니다.

- **TopNavigation Floating**: bottom padding 32 → 20 (스펙: top 16 + 24 + bottom 20 = 60)
- **ModalNavigation**: 대칭 `contentVerticalPadding`을 비대칭 `contentTopPadding` / `contentBottomPadding`으로 분리
  - emphasized: 18 → top 20 / bottom 20
  - floating: 0 → top 4 / bottom 8

### 검증 (스펙 대비 최종 높이)
| Variant | 계산 | 합계 | 스펙 |
|---|---|---|---|
| Normal | 10+(10+24+10)+10 | 64 | 64 ✅ |
| Display | 4+(16+32+16)+4 | 72 | 72 ✅ |
| Emphasized | 20+content+20 | ≥64 | ✅ |
| Floating | 4+(16+24+20)+8 | 72 | 72 ✅ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 도구 버전 업데이트

* **Refactor**
  * 네비게이션 컴포넌트 내부 구조 개선으로 코드 유지보수성 강화
  * UI 레이아웃 패딩 조정을 통한 일관성 개선

* **Documentation**
  * 유틸리티 컴포넌트 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->