### PR TITLE
feat: iOS 26 대응 — PullToRefresh, TopNavigation, BottomSheet 개선

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/BottomSheetPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/BottomSheetPreview.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct BottomSheetPreview: View {
     @State private var show = true
 
+    @State private var showTransparentChecker: Bool = false
     @State private var isFullModal = false
     @State private var resizeIndex = 0
     @State private var itemCountsIndex: Int = 0
@@ -33,6 +34,11 @@ struct BottomSheetPreview: View {
         SwiftUI.Button("PUSH") {
             show.toggle()
         }
+        .transparentChecking(
+            isPresented: showTransparentChecker,
+            checkerSize: 202,
+            checkerColor: .blue
+        )
         .bottomSheet(
             isPresented: $show,
             isFullScreenCover: isFullModal,
@@ -94,6 +100,12 @@ struct BottomSheetPreview: View {
                         presentationMode.wrappedValue.dismiss()
                     }) {
                         Image.icon(.flipBackward).foregroundColor(.semantic(.primaryNormal))
+                    }
+                    Button(action: {
+                        showTransparentChecker.toggle()
+                    }) {
+                        Image(systemName: "checkerboard.rectangle")
+                            .foregroundColor(.semantic(.primaryNormal))
                     }
                 }
                 HStack {

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -93,6 +93,8 @@ public struct TopNavigation: View {
     private var searchTerm: Binding<String>?
     private var searchFieldFocused: Binding<Bool>?
     private var onSearch: (() -> Void)?
+    private var onSearchTextChange: ((String) -> Void)?
+    private var onSearchFocusChange: ((Bool) -> Void)?
     
     /// 내비게이션 바의 스타일(Variant)을 설정합니다.
     ///
@@ -179,18 +181,24 @@ public struct TopNavigation: View {
     ///   - searchTerm: 검색어 바인딩 변수
     ///   - focused: 검색 필드의 포커스 상태 바인딩 변수, 생략하면 기본값으로 `nil` 적용
     ///   - onSubmit: 검색어 제출 시 호출될 클로저, 생략하면 기본값으로 `nil` 적용
+    ///   - onTextChange: 검색어 텍스트 변경 시 호출될 클로저, 생략하면 기본값으로 `nil` 적용
+    ///   - onFocusChange: 검색 필드 포커스 변경 시 호출될 클로저, 생략하면 기본값으로 `nil` 적용
     /// - Returns: 수정된 인스턴스를 반환합니다.
     public func searchField(
         placeholder: String? = nil,
         searchTerm: Binding<String>,
         focused: Binding<Bool>? = nil,
-        onSubmit: (() -> Void)? = nil
+        onSubmit: (() -> Void)? = nil,
+        onTextChange: ((String) -> Void)? = nil,
+        onFocusChange: ((Bool) -> Void)? = nil
     ) -> Self {
         var zelf = self
         zelf.searchFieldPlaceholder = placeholder
         zelf.searchTerm = searchTerm
         zelf.searchFieldFocused = focused
         zelf.onSearch = onSubmit
+        zelf.onSearchTextChange = onTextChange
+        zelf.onSearchFocusChange = onFocusChange
         return zelf
     }
     
@@ -210,7 +218,9 @@ public struct TopNavigation: View {
                 searchPlaceholder: searchFieldPlaceholder,
                 searchTerm: searchTerm ?? $defaultSearchTerm,
                 focused: searchFieldFocused,
-                onSubmit: onSearch
+                onSubmit: onSearch,
+                onSearchTextChange: onSearchTextChange,
+                onSearchFocusChange: onSearchFocusChange
             )
             .background {
                 ZStack {
@@ -240,7 +250,7 @@ public struct TopNavigation: View {
     }
     
     @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
-    
+
     private var backgroundOpacity: CGFloat {
         if variant.isFloating {
             return 1
@@ -266,6 +276,8 @@ public struct TopNavigation: View {
         private let externalSearchTerm: Binding<String>?
         private let externalFocused: Binding<Bool>?
         private let onSubmit: (() -> Void)?
+        private let onSearchTextChange: ((String) -> Void)?
+        private let onSearchFocusChange: ((Bool) -> Void)?
         
         init(
             variant: Variant,
@@ -276,7 +288,9 @@ public struct TopNavigation: View {
             searchPlaceholder: String? = nil,
             searchTerm: Binding<String>? = nil,
             focused: Binding<Bool>? = nil,
-            onSubmit: (() -> Void)? = nil
+            onSubmit: (() -> Void)? = nil,
+            onSearchTextChange: ((String) -> Void)? = nil,
+            onSearchFocusChange: ((Bool) -> Void)? = nil
         ) {
             self.variant = variant
             self.titleText = titleText
@@ -287,6 +301,8 @@ public struct TopNavigation: View {
             self.externalSearchTerm = searchTerm
             self.externalFocused = focused
             self.onSubmit = onSubmit
+            self.onSearchTextChange = onSearchTextChange
+            self.onSearchFocusChange = onSearchFocusChange
         }
         
         private var actionItemsMaxWidth: CGFloat {
@@ -385,7 +401,7 @@ public struct TopNavigation: View {
                     )
             }
         }
-        
+
         @ViewBuilder
         private var searchField: some View {
             HStack(alignment: .center, spacing: 4) {
@@ -425,7 +441,11 @@ public struct TopNavigation: View {
                     .onChange(of: $focusState.wrappedValue) {
                         if focused.wrappedValue != $0 {
                             focused.wrappedValue = $0
+                            onSearchFocusChange?($0)
                         }
+                    }
+                    .onChange(of: searchTerm.wrappedValue) {
+                        onSearchTextChange?($0)
                     }
                     
                     if searchTerm.wrappedValue.isNotEmpty {

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -231,15 +231,6 @@ public struct TopNavigation: View {
                 .ignoresSafeArea(.container, edges: .top)
             }
         }
-        .onAppear {
-            Task { @MainActor in
-                // UIKit 네비게이션 바를 숨겨 SwiftUI TopNavigation과의 충돌을 방지합니다.
-                if let vc = UIApplication.topViewController() {
-                    vc.navigationController?.setNavigationBarHidden(true, animated: false)
-                    vc.setNavigationBar(type: .hideShadow)
-                }
-            }
-        }
     }
     
     // MARK: - Computed properties

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -321,6 +321,7 @@ public struct TopNavigation: View {
                                 .padding(.vertical, 10)
                             Spacer(minLength: actionItemsMaxWidth)
                         }
+                        .frame(height: 44)
                     }
                 case .display:
                     ZStack {
@@ -332,6 +333,7 @@ public struct TopNavigation: View {
                                 .padding(.vertical, 16)
                             Spacer(minLength: actionItemsMaxWidth)
                         }
+                        .frame(height: 64)
                     }
                 case .search:
                     HStack(spacing: 12) {

--- a/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
+++ b/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
@@ -289,6 +289,7 @@ struct BottomSheetModifier: ViewModifier {
     private let ignoresEdgeInsets: Bool
     private let actionAreaModel: ActionArea.Model?
     private let navigation: (() -> ModalNavigation)?
+    private let onDismiss: (() -> Void)?
     private let bottomSheetContent: () -> AnyView
     
     init<V: View>(
@@ -299,6 +300,7 @@ struct BottomSheetModifier: ViewModifier {
         ignoresEdgeInsets: Bool = false,
         actionAreaModel: ActionArea.Model? = nil,
         navigation: (() -> ModalNavigation)? = nil,
+        onDismiss: (() -> Void)? = nil,
         @ViewBuilder _ content: @escaping () -> V
     ) {
         _isPresented = isPresented
@@ -308,6 +310,7 @@ struct BottomSheetModifier: ViewModifier {
         self.ignoresEdgeInsets = ignoresEdgeInsets
         self.actionAreaModel = actionAreaModel
         self.navigation = navigation
+        self.onDismiss = onDismiss
         bottomSheetContent = { AnyView(content()) }
     }
     
@@ -315,7 +318,10 @@ struct BottomSheetModifier: ViewModifier {
         content
             .modifying {
                 if isFullScreenCover {
-                    $0.fullScreenCover(isPresented: $isPresented) {
+                    $0.fullScreenCover(
+                        isPresented: $isPresented,
+                        onDismiss: onDismiss
+                    ) {
                         BottomSheet {
                             bottomSheetContent()
                         }
@@ -326,7 +332,10 @@ struct BottomSheetModifier: ViewModifier {
                         .modalActionArea(actionAreaModel)
                     }
                 } else {
-                    $0.sheet(isPresented: $isPresented) {
+                    $0.sheet(
+                        isPresented: $isPresented,
+                        onDismiss: onDismiss
+                    ) {
                         BottomSheet {
                             bottomSheetContent()
                         }
@@ -356,6 +365,7 @@ extension View {
     ///   - ignoresEdgeInsets: 모달 내용이 Edge 인셋을 무시할지 여부
     ///   - actionAreaModel: 모달 하단에 표시할 액션 영역 모델, 생략하면 기본값으로 `nil` 적용
     ///   - navigation: 모달 상단에 표시할 네비게이션 클로저, 생략하면 기본값으로 `nil` 적용
+    ///   - onDismiss: 모달이 닫힐때 호출될 클로저
     ///   - content: 모달에 표시할 콘텐츠 클로저
     /// - Returns: 바텀 시트 모달이 적용된 뷰
     public func bottomSheet<V: View>(
@@ -366,6 +376,7 @@ extension View {
         ignoresEdgeInsets: Bool = false,
         actionAreaModel: ActionArea.Model? = nil,
         navigation: (() -> ModalNavigation)? = nil,
+        onDismiss: (() -> Void)? = nil,
         @ViewBuilder _ content: @escaping () -> V
     ) -> some View {
         modifier(
@@ -377,6 +388,7 @@ extension View {
                 ignoresEdgeInsets: ignoresEdgeInsets,
                 actionAreaModel: actionAreaModel,
                 navigation: navigation,
+                onDismiss: onDismiss,
                 content
             )
         )

--- a/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
+++ b/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
@@ -143,6 +143,10 @@ public struct BottomSheet: View {
                 }
             }
         }
+        .background(
+            SwiftUI.Color.semantic(.backgroundNormal)
+                .opacity(0.8)
+        )
         .presentationDetents(detents)
         .presentationDragIndicator(.hidden)
     }

--- a/Sources/Montage/1 Components/9 Utilities/PullToRefresh.swift
+++ b/Sources/Montage/1 Components/9 Utilities/PullToRefresh.swift
@@ -8,8 +8,8 @@
 import Lottie
 import SwiftUI
 
+@available(iOS 18, *)
 public enum PullToRefresh {
-    @available(iOS 18, *)
     struct Modifier: ViewModifier {
         @Binding private var scrollYOffset: CGFloat
         private let refresh: () async -> Void
@@ -70,51 +70,46 @@ public enum PullToRefresh {
 
                     content
                 }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 1)
-                        .onChanged { _ in
-                            isScrolling = true
+                .onScrollPhaseChange { oldPhase, newPhase in
+                    if newPhase == .interacting {
+                        isScrolling = true
+                        if phase.beforeRefreshing {
+                            // 현재 스크롤이 트리거스크롤임
+                            isTriggerScrolling = true
+                        }
+                    }
 
-                            if phase.beforeRefreshing {
-                                // 현재 스크롤이 트리거스크롤임
-                                isTriggerScrolling = true
+                    if oldPhase == .interacting, newPhase != .interacting {
+                        // 리프레시가 시작된 후 스크롤이 끝났을 때
+                        if phase.isRefreshing {
+                            // 투명뷰를 추가한다.
+                            isClearRectNeeded = true
+                            // 스크롤 옵셋이 천천히 되돌아가도록 하기 위한 애니메이션
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                // 로고와 패딩 영역이 천천히 줄어들도록 하기 위함
+                                pullToRefreshViewHeight = hangingHeight
+                                clearRectHeight = hangingHeight
                             }
                         }
-                        .onEnded { value in
-                            // 리프레시가 시작된 후 스크롤이 끝났을 때
-                            if phase.isRefreshing {
-                                // 투명뷰를 추가한다.
-                                isClearRectNeeded = true
-                                // 스크롤 옵셋이 천천히 되돌아가도록 하기 위한 애니메이션
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    // 로고와 패딩 영역이 천천히 줄어들도록 하기 위함
-                                    pullToRefreshViewHeight = hangingHeight
-                                    clearRectHeight = hangingHeight
-                                }
-                            }
 
-                            // 리프레시가 끝나기 전에 스크롤을 드래그하여 위로 던지는 경우
-                            if phase
-                                .isRefreshing
-                                && (value.predictedEndTranslation.height < 0 || scrollYOffset < 0)
-                            {
-                                task?.cancel()
-                            }
-
-                            // 리프레시가 끝난 후 스크롤이 끝났을 때
-                            if phase.isWaitingToEnd {
-                                // 스크롤 옵셋 복귀 애니메이션 시작점 설정
-                                clearRectHeight = hangingHeight + value.translation.height / 2
-                                // 엔딩 애니메이션 수행
-                                phase = .ending
-                            }
-
-                            isTriggerScrolling = false
-                            isScrolling = false
+                        // 리프레시가 끝나기 전에 스크롤을 드래그하여 위로 던지는 경우
+                        if phase.isRefreshing && scrollYOffset < 0 {
+                            task?.cancel()
                         }
-                )
+
+                        // 리프레시가 끝난 후 스크롤이 끝났을 때
+                        if phase.isWaitingToEnd {
+                            // 엔딩 애니메이션 수행
+                            clearRectHeight = hangingHeight
+                            phase = .ending
+                        }
+
+                        isTriggerScrolling = false
+                        isScrolling = false
+                    }
+                }
             }
-            .onChange(of: scrollYOffset) { scrollPosition in
+            .onChange(of: scrollYOffset) { _, scrollPosition in
                 // 트리거스크롤이 끝날때까지
                 if isTriggerScrolling {
                     // 스크롤 옵셋 복귀 애니메이션 시작점을 업데이트
@@ -132,7 +127,7 @@ public enum PullToRefresh {
                     phase = .pulledDown(ratio: pullDownRatio)
                 }
             }
-            .onChange(of: phase) { phase in
+            .onChange(of: phase) { _, phase in
                 switch phase {
                 case .idle:
                     break
@@ -238,7 +233,7 @@ public enum PullToRefresh {
                 .frame(width: 48, height: 36)
                 .opacity(opacity)
                 .scaleEffect(scale)
-                .onChange(of: phase) { phase in
+                .onChange(of: phase) { _, phase in
                     switch phase {
                     case .idle:
                         opacity = 1

--- a/documentation/components/navigations/topnavigation/ios.md
+++ b/documentation/components/navigations/topnavigation/ios.md
@@ -193,7 +193,7 @@ TopNavigation을 초기화합니다.
 </details>
 <details>
 
-<summary>``func searchField(placeholder: String?, searchTerm: Binding<String>, focused: Binding<Bool>?, onSubmit: (() -> Void)?) -> TopNavigation``</summary>
+<summary>``func searchField(placeholder: String?, searchTerm: Binding<String>, focused: Binding<Bool>?, onSubmit: (() -> Void)?, onTextChange: ((String) -> Void)?, onFocusChange: ((Bool) -> Void)?) -> TopNavigation``</summary>
 
 
 검색 필드의 속성과 동작을 설정합니다. variant가   일 때만 적용됩니다.
@@ -205,6 +205,8 @@ TopNavigation을 초기화합니다.
   | `searchTerm` | 검색어 바인딩 변수 |
   | `focused` | 검색 필드의 포커스 상태 바인딩 변수, 생략하면 기본값으로 `nil` 적용 |
   | `onSubmit` | 검색어 제출 시 호출될 클로저, 생략하면 기본값으로 `nil` 적용 |
+  | `onTextChange` | 검색어 텍스트 변경 시 호출될 클로저, 생략하면 기본값으로 `nil` 적용 |
+  | `onFocusChange` | 검색 필드 포커스 변경 시 호출될 클로저, 생략하면 기본값으로 `nil` 적용 |
 - **Return Value**
 
   수정된 인스턴스를 반환합니다.

--- a/documentation/components/presentation/bottomsheet/ios.md
+++ b/documentation/components/presentation/bottomsheet/ios.md
@@ -217,7 +217,7 @@ YourView()
 
 <details>
 
-<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, () -> V) -> some View``</summary>
+<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, onDismiss: (() -> Void)?, () -> V) -> some View``</summary>
 
 
 바텀 시트 모달을 표시합니다.
@@ -232,6 +232,7 @@ YourView()
   | `ignoresEdgeInsets` | 모달 내용이 Edge 인셋을 무시할지 여부 |
   | `actionAreaModel` | 모달 하단에 표시할 액션 영역 모델, 생략하면 기본값으로 `nil` 적용 |
   | `navigation` | 모달 상단에 표시할 네비게이션 클로저, 생략하면 기본값으로 `nil` 적용 |
+  | `onDismiss` | 모달이 닫힐때 호출될 클로저 |
   | `content` | 모달에 표시할 콘텐츠 클로저 |
 - **Return Value**
 

--- a/documentation/utilities/ios-extensions/swiftuicore.md
+++ b/documentation/utilities/ios-extensions/swiftuicore.md
@@ -106,7 +106,7 @@ View를 UIImage로 변환합니다.
 </details>
 <details>
 
-<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, () -> V) -> some View``</summary>
+<summary>``func bottomSheet<V>(isPresented: Binding<Bool>, isFullScreenCover: Bool, needHandle: Bool, resize: BottomSheet.Resize, ignoresEdgeInsets: Bool, actionAreaModel: ActionArea.Model?, navigation: (() -> ModalNavigation)?, onDismiss: (() -> Void)?, () -> V) -> some View``</summary>
 
 
 바텀 시트 모달을 표시합니다.
@@ -121,6 +121,7 @@ View를 UIImage로 변환합니다.
   | `ignoresEdgeInsets` | 모달 내용이 Edge 인셋을 무시할지 여부 |
   | `actionAreaModel` | 모달 하단에 표시할 액션 영역 모델, 생략하면 기본값으로 `nil` 적용 |
   | `navigation` | 모달 상단에 표시할 네비게이션 클로저, 생략하면 기본값으로 `nil` 적용 |
+  | `onDismiss` | 모달이 닫힐때 호출될 클로저 |
   | `content` | 모달에 표시할 콘텐츠 클로저 |
 - **Return Value**
 


### PR DESCRIPTION
## Summary
- PullToRefresh: DragGesture를 onScrollPhaseChange로 교체 (iOS 26 대응)
- TopNavigation: searchField에 onTextChange, onFocusChange 콜백 추가 및 최소 높이 수정, UINavigationBar 자동숨김 처리 제거
- BottomSheet: onDismiss 클로저 추가
- 이력서 코칭 에이전트 바텀시트 모달 네비게이션 불투명 이슈 수정

## Test plan
- [ ] PullToRefresh 동작 확인 (iOS 26 시뮬레이터)
- [ ] TopNavigation searchField 콜백 동작 확인
- [ ] BottomSheet onDismiss 호출 확인
- [ ] 기존 iOS 17~18 기기에서 regression 없는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 검색 필드에서 텍스트 변경 및 포커스 변경을 수신하는 신규 콜백 추가
  * 하단 시트 모달이 닫힐 때 호출되는 onDismiss 콜백 추가
  * 미리보기에서 투명도 체크용 체크보드(transparent checker) 토글 및 오버레이 추가

* **Improvements**
  * PullToRefresh의 스크롤/상태 처리 로직 개선 및 iOS 18 가용성 정리

* **Documentation**
  * TopNavigation과 BottomSheet 관련 API 문서에 새로운 파라미터 및 설명 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->