### PR TITLE
chore: Claude Code 설정 파일 추가 및 빈 테스트 파일 정리

### DIFF
--- a/.claude/skills/figma-to-swiftui/SKILL.md
+++ b/.claude/skills/figma-to-swiftui/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: figma-to-swiftui
+description: Figma 디자인을 Montage 디자인 시스템의 SwiftUI 코드로 변환
+---
+
+# Figma to SwiftUI (Montage Design System)
+
+피그마 디자인을 Montage 디자인 시스템의 SwiftUI 코드로 변환합니다.
+
+## 입력
+
+$ARGUMENTS
+
+## 절차
+
+### 1단계: 피그마 디자인 분석
+
+피그마 URL에서 fileKey와 nodeId를 추출합니다.
+- URL 형식: `https://figma.com/design/:fileKey/:fileName?node-id=:int1-:int2`
+- fileKey: URL path의 `:fileKey` 부분
+- nodeId: `node-id` 쿼리 파라미터의 값 (하이픈을 콜론으로 변환, 예: `1-2` → `1:2`)
+
+`mcp__figma__get_design_context` 도구를 사용하여 디자인 컨텍스트를 가져옵니다.
+- clientLanguages: "swift"
+- clientFrameworks: "swiftui"
+
+필요하다면 `mcp__figma__get_screenshot` 도구로 스크린샷도 확인합니다.
+
+### 2단계: Montage 컴포넌트 매핑
+
+디자인에서 사용되는 UI 요소를 분석하고, 아래 Montage 컴포넌트 목록에서 매칭되는 컴포넌트를 식별합니다.
+
+**Actions (액션)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| ActionArea | 화면 하단 액션 버튼 영역 | `Projects/Views/Montage/documentation/components/actions/actionarea/ios.md` |
+| Button | 버튼 (solid, outlined) | `Projects/Views/Montage/documentation/components/actions/button/ios.md` |
+| Chip | 칩 | `Projects/Views/Montage/documentation/components/actions/chip/ios.md` |
+| IconButton | 아이콘 버튼 | `Projects/Views/Montage/documentation/components/actions/iconbutton/ios.md` |
+| TextButton | 텍스트 버튼 | `Projects/Views/Montage/documentation/components/actions/textbutton/ios.md` |
+
+**Contents (콘텐츠)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| Accordion | 접을 수 있는 콘텐츠 | `Projects/Views/Montage/documentation/components/contents/accordion/ios.md` |
+| Avatar | 프로필 이미지 | `Projects/Views/Montage/documentation/components/contents/avatar/ios.md` |
+| AvatarGroup | 그룹 아바타 | `Projects/Views/Montage/documentation/components/contents/avatargroup/ios.md` |
+| Card | 썸네일+콘텐츠 카드 | `Projects/Views/Montage/documentation/components/contents/card/ios.md` |
+| ContentBadge | 텍스트/아이콘 뱃지 | `Projects/Views/Montage/documentation/components/contents/contentbadge/ios.md` |
+| ListCard | 수평 리스트 카드 | `Projects/Views/Montage/documentation/components/contents/listcard/ios.md` |
+| ListCell | 리스트 아이템 | `Projects/Views/Montage/documentation/components/contents/listcell/ios.md` |
+| PlayBadge | 재생 버튼 뱃지 | `Projects/Views/Montage/documentation/components/contents/playbadge/ios.md` |
+| SectionHeader | 섹션 헤더 | `Projects/Views/Montage/documentation/components/contents/sectionheader/ios.md` |
+| Thumbnail | 이미지 썸네일 | `Projects/Views/Montage/documentation/components/contents/thumbnail/ios.md` |
+
+**Feedback (피드백)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| FallbackView | 빈 화면/에러 대체 | `Projects/Views/Montage/documentation/components/feedback/fallbackview/ios.md` |
+| PushBadge | 알림 뱃지 | `Projects/Views/Montage/documentation/components/feedback/pushbadge/ios.md` |
+| SnackBar | 알림 메시지 | `Projects/Views/Montage/documentation/components/feedback/snackbar/ios.md` |
+| Toast | 짧은 알림 | `Projects/Views/Montage/documentation/components/feedback/toast/ios.md` |
+
+**Loading (로딩)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| Loading | 로딩 애니메이션 | `Projects/Views/Montage/documentation/components/loading/loading/ios.md` |
+| Skeleton | 스켈레톤 UI | `Projects/Views/Montage/documentation/components/loading/skeleton/ios.md` |
+
+**Navigations (네비게이션)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| Category | 카테고리 선택 | `Projects/Views/Montage/documentation/components/navigations/category/ios.md` |
+| PageCounter | 숫자 페이지 표시기 | `Projects/Views/Montage/documentation/components/navigations/pagecounter/ios.md` |
+| PaginationDots | 점 페이지 표시기 | `Projects/Views/Montage/documentation/components/navigations/paginationdots/ios.md` |
+| ProgressIndicator | 진행 인디케이터 | `Projects/Views/Montage/documentation/components/navigations/progressindicator/ios.md` |
+| ProgressTracker | 단계별 진행 표시 | `Projects/Views/Montage/documentation/components/navigations/progresstracker/ios.md` |
+| Tab | 탭 메뉴 | `Projects/Views/Montage/documentation/components/navigations/tab/ios.md` |
+| TopNavigation | 상단 내비게이션 바 | `Projects/Views/Montage/documentation/components/navigations/topnavigation/ios.md` |
+
+**Presentation (프레젠테이션)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| BottomSheet | 바텀 시트 모달 | `Projects/Views/Montage/documentation/components/presentation/bottomsheet/ios.md` |
+| Popover | 팝오버 | `Projects/Views/Montage/documentation/components/presentation/popover/ios.md` |
+| Popup | 팝업 모달 | `Projects/Views/Montage/documentation/components/presentation/popup/ios.md` |
+| Tooltip | 툴팁 | `Projects/Views/Montage/documentation/components/presentation/tooltip/ios.md` |
+
+**Selection & Input (선택/입력)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| Checkbox | 체크박스 | `Projects/Views/Montage/documentation/components/selection and input/checkbox/ios.md` |
+| Checkmark | 체크마크 | `Projects/Views/Montage/documentation/components/selection and input/checkmark/ios.md` |
+| FilterButton | 필터 버튼 | `Projects/Views/Montage/documentation/components/selection and input/filterbutton/ios.md` |
+| FramedStyle | 프레임 스타일 | `Projects/Views/Montage/documentation/components/selection and input/framedstyle/ios.md` |
+| Radio | 라디오 버튼 | `Projects/Views/Montage/documentation/components/selection and input/radio/ios.md` |
+| SegmentedControl | 세그먼트 컨트롤 | `Projects/Views/Montage/documentation/components/selection and input/segmentedcontrol/ios.md` |
+| Select | 드롭다운 선택 | `Projects/Views/Montage/documentation/components/selection and input/select/ios.md` |
+| Slider | 슬라이더 | `Projects/Views/Montage/documentation/components/selection and input/slider/ios.md` |
+| Switch | 스위치 | `Projects/Views/Montage/documentation/components/selection and input/switch/ios.md` |
+| TextArea | 여러 줄 텍스트 입력 | `Projects/Views/Montage/documentation/components/selection and input/textarea/ios.md` |
+| TextField | 단일 줄 텍스트 입력 | `Projects/Views/Montage/documentation/components/selection and input/textfield/ios.md` |
+
+**Utilities (유틸리티)**
+| 컴포넌트 | 설명 | 문서 경로 |
+|---|---|---|
+| Color | 디자인 시스템 컬러 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/color.md` |
+| FlowLayout | 흐름 레이아웃 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/flowlayout.md` |
+| Icon | 아이콘 세트 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/icon.md` |
+| Interaction | 상호작용 장식 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/interaction.md` |
+| ModalNavigation | 모달 내비게이션 바 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/modalnavigation.md` |
+| Opacity | 투명도 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/opacity.md` |
+| PullToRefresh | 당겨서 새로고침 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/pulltorefresh.md` |
+| ScrollView | 커스텀 스크롤뷰 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/scrollview.md` |
+| Shadow | 그림자 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/shadow.md` |
+| Spacing | 간격 시스템 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/spacing.md` |
+| Typography | 타이포그래피 | `Projects/Views/Montage/documentation/utilities/ios-utility-components/typography.md` |
+
+### 3단계: API 문서 참조
+
+식별된 각 컴포넌트와 유틸리티 토큰의 API 문서를 **반드시** 읽습니다. 문서 소스 우선순위:
+
+**1순위: doccarchive JSON** (소스 코드에서 자동 생성된 정확한 API 스펙)
+```
+# 컴포넌트 개요 — initializers, methods, enums, 코드 예시 포함
+Projects/Views/Montage/.build/derived_data/Build/Products/Debug-iphoneos/Montage.doccarchive/data/documentation/montage/{컴포넌트명 lowercase}.json
+
+# 중첩 타입 세부 정보 — enum case, nested struct 등
+Projects/Views/Montage/.build/derived_data/Build/Products/Debug-iphoneos/Montage.doccarchive/data/documentation/montage/{컴포넌트명 lowercase}/{중첩타입 lowercase}.json
+```
+- 2단계에서 식별된 **모든 컴포넌트**의 doccarchive JSON을 읽을 것
+- 컴포넌트에서 사용하는 enum/nested type도 함께 읽을 것 (예: Button이면 `button/variant.json`, `button/size.json`, `button/color.json`도 확인)
+
+**2순위: markdown 문서** (doccarchive에 해당 컴포넌트가 없는 경우 fallback)
+- 2단계 테이블의 문서 경로를 프로젝트 루트에서 참조
+
+**유틸리티 토큰 문서** (항상 읽을 것):
+
+| 토큰 | doccarchive (1순위) | markdown (2순위) |
+|------|---------------------|------------------|
+| Color | `montage/color.json` + `montage/color/{semantic,atomic}.json` | `Projects/Views/Montage/documentation/utilities/ios-utility-components/color.md` |
+| Typography | `montage/typography.json` + `montage/typography/{variant,weight}.json` | `Projects/Views/Montage/documentation/utilities/ios-utility-components/typography.md` |
+| Spacing | `montage/spacing.json` | `Projects/Views/Montage/documentation/utilities/ios-utility-components/spacing.md` |
+| Icon | `montage/icon.json` | `Projects/Views/Montage/documentation/utilities/ios-utility-components/icon.md` |
+
+> **중요**: 이 단계에서 읽은 문서가 코드 생성의 유일한 진실의 원천(single source of truth)입니다. 사전 지식이나 추측으로 API를 사용하지 마세요.
+
+### 4단계: SwiftUI 코드 생성
+
+다음 규칙을 따라 코드를 생성합니다:
+
+1. **import**: `import Montage` 사용
+2. **컴포넌트 우선**: 표준 SwiftUI 뷰보다 Montage 컴포넌트를 우선 사용 (예: `SwiftUI.Button` 대신 `Montage.Button`)
+3. **디자인 토큰 사용**: 하드코딩된 값 대신, **3단계에서 읽은 문서에 명시된** Montage 토큰 API를 그대로 사용. 색상/타이포그래피/간격 모두 문서에서 확인한 정확한 시그니처를 따를 것
+4. **피그마 속성 매핑**:
+   - 피그마의 variant/property → 3단계에서 확인한 Montage enum 값으로 매핑
+   - 피그마의 색상 토큰 → 3단계에서 확인한 Color 토큰으로 매핑
+   - 피그마의 텍스트 스타일 → 3단계에서 확인한 Typography variant로 매핑
+5. **코드 스타일**: CLAUDE.md의 Swift 문법 규칙을 따름
+
+### 5단계: API 검증
+
+생성한 코드에서 사용한 Montage API가 실제로 존재하는지 검증합니다.
+
+1. 코드에서 사용한 모든 Montage 타입, initializer, modifier, enum case를 목록으로 추출
+2. 각 항목이 3단계에서 읽은 doccarchive/문서에 **실제로 존재하는지** 대조
+3. 문서에서 확인할 수 없는 API가 있다면, Swift 소스 파일에서 직접 확인:
+   ```
+   Projects/Views/Montage/Sources/Montage/{컴포넌트명}.swift
+   ```
+4. 존재하지 않는 API를 사용한 경우, 문서에서 확인된 올바른 API로 교체
+
+### 6단계: 결과 출력
+
+생성된 코드와 함께 다음을 출력합니다:
+- 사용된 Montage 컴포넌트 목록
+- 5단계 검증 결과 (수정된 API가 있다면 무엇을 왜 바꿨는지)
+- 피그마 디자인과 1:1 매핑이 되지 않는 부분이 있다면 설명
+- Montage에 없는 커스텀 UI가 필요한 부분이 있다면 안내

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: montage-release
+description: Montage GitHub Release 생성 및 취소 (릴리즈/태그 관리, Slack 알림)
+---
+
+# Montage Release
+
+Montage 디자인 시스템(wanteddev/montage-ios)의 GitHub Release를 생성하거나 취소합니다.
+
+## 입력
+
+$ARGUMENTS
+
+## 0단계 — 액션 선택
+
+- `$ARGUMENTS`에 "취소" 또는 "cancel"이 포함되면 → **릴리즈 취소 플로우**로 진입
+- 그 외 → **릴리즈 생성 플로우**로 진입
+
+---
+
+## [릴리즈 생성 플로우]
+
+### 1단계 — 버전 선택
+
+1. `gh release list --repo wanteddev/montage-ios --limit 1`로 최신 버전(latest) 확인
+2. `$ARGUMENTS`에 버전(`v`로 시작)이 있으면 사용, 없으면 AskUserQuestion으로 bump 유형 질문:
+   - Patch (v3.3.1 → v3.3.2)
+   - Minor (v3.3.1 → v3.4.0)
+   - Major (v3.3.1 → v4.0.0)
+   - Other (직접 입력)
+3. **버전 입력 검증**: 입력된 버전이 semver 형식(`v{major}.{minor}.{patch}`)인지 확인. `v` 접두사가 없으면 자동 추가. 형식이 잘못되면 재입력 요청
+
+### 2단계 — Release 브랜치 확인
+
+`git ls-remote --heads origin release/{version_without_v}`로 release 브랜치 존재 여부 확인
+
+- **브랜치 있음**:
+  1. `gh pr list --repo wanteddev/montage-ios --head release/{version_without_v} --base main`으로 PR 상태 확인
+  2. PR이 이미 merged → 3단계(릴리즈 생성)로 진행
+  3. PR이 open → PR URL을 알려주고 "PR이 머지된 후 다시 실행해주세요." 안내 후 **중단**
+  4. PR 없음 → PR 생성(`release/{ver} → main`) 후 **중단**
+- **브랜치 없음** → main에서 릴리즈할지 AskUserQuestion으로 확인. 거부 시 중단
+
+### 3단계 — GitHub Release 생성
+
+1. **`--latest` 플래그 조건부 적용**: 선택한 버전이 현재 latest 버전보다 높은 경우에만 `--latest` 추가. 낮은 버전(hotfix 등)이면 `--latest` 생략
+2. `gh release create {version} --repo wanteddev/montage-ios --target main --generate-notes [--latest] --title "{version}"`
+3. `gh release view {version} --repo wanteddev/montage-ios --json url,body`로 릴리즈 URL과 body 가져오기
+
+### 4단계 — Slack 알림
+
+1. Slack MCP 사용 가능 여부 확인 (`mcp__plugin_slack_slack__slack_send_message` 도구 존재 여부)
+2. **사용 불가 시**: "Slack MCP가 설정되어 있지 않습니다. 아래 명령어로 설정해주세요:" 안내 후 메시지 텍스트 출력
+   ```
+   claude plugin add slack
+   ```
+3. **사용 가능 시**:
+   - body를 Slack mrkdwn으로 변환하여 **메시지 미리보기를 사용자에게 표시**
+   - AskUserQuestion으로 확인: "아래 메시지를 #design_system_updates, #ios-developers 채널에 발송할까요?"
+     - 옵션: "발송", "수정 후 발송", "발송하지 않음"
+   - 확인 후 두 채널에 발송:
+     - `C068KCRS2LD` (#design_system_updates)
+     - `C0136G84N87` (#ios-developers)
+
+**메시지 형식**:
+```
+:appleinc:*Montage {version} Release 되었습니다.*
+{release_url}
+
+*What's Changed*
+• {changes...}
+Full Changelog: {compare_url}
+```
+
+---
+
+## [릴리즈 취소 플로우]
+
+### 1단계 — 취소할 버전 선택
+
+1. `gh release list --repo wanteddev/montage-ios --limit 5`로 최근 릴리즈 목록 표시
+2. `$ARGUMENTS`에 버전이 있으면 사용, 없으면 AskUserQuestion으로 취소할 버전 선택
+   - 최근 5개 릴리즈를 옵션으로 제시
+
+### 2단계 — 경고 및 확인
+
+AskUserQuestion으로 경고 메시지 표시:
+- 질문: "`{version}` 릴리즈를 취소하면 해당 태그와 릴리즈가 모두 삭제됩니다. 이미 이 버전을 의존성으로 사용 중인 프로젝트가 있다면 빌드가 깨질 수 있습니다. 정말 취소하시겠습니까?"
+- 옵션: "취소 진행", "중단"
+- "중단" 선택 시 작업 종료
+
+### 3단계 — 릴리즈 및 태그 삭제
+
+1. `gh release delete {version} --repo wanteddev/montage-ios --yes`로 릴리즈 삭제
+2. `git push origin --delete {version}`으로 원격 태그 삭제
+3. **latest 복원**: 삭제한 버전이 latest였으면, 이전 릴리즈를 latest로 설정
+   - `gh release list --repo wanteddev/montage-ios --limit 1`로 현재 최신 확인
+   - `gh release edit {prev_version} --repo wanteddev/montage-ios --latest`
+
+### 4단계 — Slack 취소 알림
+
+1. Slack MCP 사용 가능 여부 확인 (생성 플로우와 동일한 방식)
+2. 두 채널에 취소 메시지 발송 (미리보기 없이 바로 발송):
+   - `C068KCRS2LD` (#design_system_updates)
+   - `C0136G84N87` (#ios-developers)
+
+**메시지 형식**:
+```
+:warning:*Montage {version} 릴리즈가 취소되었습니다.*
+해당 버전의 태그와 릴리즈가 삭제되었습니다.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Montage는 Wanted Lab의 iOS 디자인 시스템으로, SwiftUI 기반의 SPM(Swift Package Manager) 패키지이다. iOS 16.0+을 지원하며 Swift 5로 작성되어 있다. 상위 프로젝트(Wanted iOS 앱)의 Views 프레임워크에서 의존성으로 사용된다.
+
+## Build & Development Commands
+
+```bash
+# Xcode workspace 열기
+open Montage.xcworkspace
+
+# 문서 생성 (DocC -> Markdown -> 라이선스, Xcode 버전 확인 포함)
+make
+
+# DocC 문서만 생성
+make docc
+
+# 로컬 문서 서버 실행 (make docc 이후)
+make server
+```
+
+## Architecture
+
+### Source Structure
+
+```
+Sources/
+  Montage/
+    1 Components/       # UI 컴포넌트 (번호 접두사로 카테고리 정렬)
+      2 Actions/        # Button, IconButton, TextButton, FilterButton 등
+      3 Selection And Input/  # Checkbox, Radio, Select, TextField, TextArea, Switch 등
+      4 Contents/       # Avatar, Card, ListCell, Thumbnail, Typography 등
+      5 Loading/        # Loading, Skeleton, ProgressIndicator 등
+      6 Navigations/    # Tab, TopNavigation, SegmentedControl 등
+      7 Feedback/       # Toast, SnackBar, Tooltip 등
+      8 Presentation/   # BottomSheet, Popup, Popover 등
+      9 Utilities/      # Color, Icon, Spacing, Shadow, Opacity 등
+    2 Utilities/        # 확장(Extension), 모디파이어(Modifiers), 프로토콜(Protocols)
+    Asset/              # Color.xcassets, Icon.xcassets, Image.xcassets, Lottie
+  Blueprint/            # 컴포넌트 쇼케이스 샘플 앱 (Xcode 프로젝트)
+```
+
+### Dependencies
+
+- **Pretendard** (pretendard-ios): 폰트
+- **Lottie** (lottie-ios 4.5.0): 애니메이션
+- **SDWebImageSwiftUI** (3.0.0+): 원격 이미지 로딩
+- **swift-docc-plugin**: 문서 생성용 (런타임 의존성 아님)
+
+## Code Conventions
+
+### 파일명 = 타입명
+
+파일명(`.swift` 제거)이 DocC 문서의 컴포넌트 제목으로 사용된다. 파일 내 주요 `public struct`/`enum` 이름과 파일명을 반드시 일치시켜야 한다. 예: `Button.swift` -> `public struct Button`.
+
+### public 키워드 필수
+
+`docc_to_md.js` 스크립트가 `public` 키워드를 정규식으로 파싱하여 문서화한다. `public`이 없으면 문서에 나타나지 않는다.
+
+### 관련 타입은 같은 파일에
+
+메인 컴포넌트와 관련된 extension, protocol 등은 같은 파일에 정의한다. Public View struct는 Inner Type으로 정의하지 않는다.
+
+## Documentation Workflow
+
+Swift 소스 파일(`Sources/Montage/`)을 수정한 후에는 반드시 `make`를 실행하여 `documentation/` 폴더와 `THIRD_PARTY_LICENSES.md`를 갱신해야 한다. CI의 `verify-docs` 워크플로우가 이를 검증한다.
+
+`make` 실행 시 `Makefile`의 `XCODE_VERSION` 변수에 지정된 Xcode 버전이 필요하다 (현재 26.2).
+
+## Commit Convention
+
+[Conventional Commits](https://www.conventionalcommits.org/) 사용: `<type>(<scope>): <description>`
+
+타입: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+## Versioning
+
+시맨틱 버저닝(SemVer) 준수. Breaking change는 메이저 업데이트 시에만 반영. 메이저 업데이트 기간이 아닌 경우 `@available(*, deprecated)` 처리 후 메이저 업데이트 때 제거한다.
+
+## Git Workflow
+
+- 브랜치: `main`에서 분기하여 `main`으로 PR, 두 개 이상의 버전을 한 번에 작업할 때는 `release/x.x.x`에서 분기하여 `release/x.x.x`로 PR
+- PR 제출 전 `make` 실행하여 문서 변경사항 포함
+- GitHub Actions 워크플로우 yml 파일 수정 PR은 거부될 수 있음

--- a/Tests/MontageTests/MontageTests.swift
+++ b/Tests/MontageTests/MontageTests.swift
@@ -1,9 +1,0 @@
-//
-//  MontageTests.swift
-//  MontageTests
-//
-//  Created by Eunyeong Kim on 2021/03/18.
-//
-
-import XCTest
-@testable import Montage


### PR DESCRIPTION
## Summary
- Claude Code skills 추가 (figma-to-swiftui, release)
- CLAUDE.md 프로젝트 가이드 추가
- 빈 MontageTests.swift 삭제

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * Figma 디자인을 SwiftUI 코드로 변환하는 AI 스킬 워크플로우 문서 추가
  * 릴리스 생성 및 취소 절차에 대한 스킬 문서 추가
  * 프로젝트 개발 가이드 및 코딩 규칙 문서 추가

* **Tests**
  * 테스트 파일 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->