### PR TITLE
fix: Select 드롭다운 화살표 메뉴 열림 시 180도 회전 (PI-82363)

### DIFF
--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -388,6 +388,7 @@ public struct Select: View {
                     )
                     .padding(.horizontal, 4)
                     .frame(height: 24)
+                    .rotationEffect(.degrees(menuPresented.wrappedValue ? 180 : 0))
                 }
                 .padding(.all, 12)
                 .background {


### PR DESCRIPTION
# 개요
- 🔗  JIRA 이슈 링크 : https://wantedlab.atlassian.net/browse/PI-82363

# 수정 내용
- Select 컴포넌트의 드롭다운 화살표 아이콘에 `rotationEffect`를 추가하여 메뉴가 열려있을 때 180도 회전하도록 수정했습니다.

### 미리보기
해당 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 선택 드롭다운 메뉴가 열리고 닫힐 때 체브론 아이콘이 180도 회전하는 시각적 피드백이 추가되었습니다. 메뉴의 열림/닫힘 상태에 따라 아이콘이 동적으로 반응하여 드롭다운의 현재 상태를 시각적으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->