### PR TITLE
chore: Slack 메시지 형식을 standard markdown으로 변경

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -55,7 +55,7 @@ $ARGUMENTS
    claude plugin add slack
    ```
 3. **사용 가능 시**:
-   - body를 Slack mrkdwn으로 변환하여 **메시지 미리보기를 사용자에게 표시**
+   - body를 Slack standard markdown으로 변환하여 **메시지 미리보기를 사용자에게 표시**
    - AskUserQuestion으로 확인: "아래 메시지를 #design_system_updates, #ios-developers 채널에 발송할까요?"
      - 옵션: "발송", "수정 후 발송", "발송하지 않음"
    - 확인 후 두 채널에 발송:
@@ -64,12 +64,13 @@ $ARGUMENTS
 
 **메시지 형식**:
 ```
-:appleinc:*Montage {version} Release 되었습니다.*
+:appleinc:**Montage {version} Release 되었습니다.**
 {release_url}
 
-*What's Changed*
-• {changes...}
-Full Changelog: {compare_url}
+**What's Changed**
+• {changes... (PR 링크는 [#번호](url) 형식으로 변환)}
+
+Full Changelog: [{old_version}...{new_version}]({compare_url})
 ```
 
 ---
@@ -106,6 +107,6 @@ AskUserQuestion으로 경고 메시지 표시:
 
 **메시지 형식**:
 ```
-:warning:*Montage {version} 릴리즈가 취소되었습니다.*
+:warning:**Montage {version} 릴리즈가 취소되었습니다.**
 해당 버전의 태그와 릴리즈가 삭제되었습니다.
 ```


### PR DESCRIPTION
## Summary
- Slack 릴리즈 알림 메시지 형식을 mrkdwn에서 standard markdown으로 변경
- Bold 구문을 `*text*` → `**text**`로 통일
- PR 링크를 `[#번호](url)` 형식으로 변환하도록 가이드 추가
- Full Changelog에 비교 URL 링크 형식 추가

## Test plan
- [x] 릴리즈 스킬 실행 시 Slack 메시지가 올바른 markdown 형식으로 표시되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * Slack 알림 형식이 표준 마크다운으로 개선되어 더욱 일관되고 읽기 쉬운 메시지 표시를 제공합니다.
  * 릴리스 노트의 구조가 개선되어 변경사항이 더 명확하게 표현됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->