### PR TITLE
[PI-82473] fix: BottomSheet 초기 렌더링 시 width 애니메이션 제거

### DIFF
--- a/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
+++ b/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
@@ -91,6 +91,7 @@ public struct BottomSheet: View {
     @State private var contentHeight: CGFloat = 0
     @State private var actionAreaHeight: CGFloat = 0
     @State private var scrollStatus: ScrollView.ScrollStatus = .init()
+    @State private var isContentMeasured = false
     
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
@@ -143,12 +144,16 @@ public struct BottomSheet: View {
                 }
             }
         }
+        .opacity(isContentMeasured ? 1 : 0)
         .background(
             SwiftUI.Color.semantic(.backgroundNormal)
                 .opacity(0.8)
         )
         .presentationDetents(detents)
         .presentationDragIndicator(.hidden)
+        .onChange(of: contentHeight) {  oldValue, newValue in
+            if newValue > 0 { isContentMeasured = true }
+        }
     }
     
     // MARK: - Modifiers
@@ -269,14 +274,17 @@ public struct BottomSheet: View {
     }
     
     private var detents: Set<PresentationDetent> {
+        guard isContentMeasured else {
+            return [.height(maxDetentHeight)]
+        }
         switch resize {
         case .flexible:
-            [
+            return [
                 .height(min(bottomSheetContentHeight, maxDetentHeight / 2 + safeAreaInsets.bottom)),
                 .height(min(bottomSheetContentHeight, maxDetentHeight))
             ]
         default:
-            [.height(bottomSheetMaxHeight)]
+            return [.height(bottomSheetMaxHeight)]
         }
     }
 }

--- a/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
+++ b/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
@@ -151,7 +151,7 @@ public struct BottomSheet: View {
         )
         .presentationDetents(detents)
         .presentationDragIndicator(.hidden)
-        .onChange(of: contentHeight) {  oldValue, newValue in
+        .onChange(of: contentHeight) { newValue in
             if newValue > 0 { isContentMeasured = true }
         }
     }


### PR DESCRIPTION
## Summary
- BottomSheet가 처음 열릴 때 왼쪽 하단에서 width가 커지며 펼쳐지는 어색한 애니메이션 수정

## 원인
컨텐츠 높이 측정 전 `detents`가 `.height(0)`으로 시작하고, SwiftUI가 레이아웃을 측정하면서 detent가 0 → 실제 높이로 커지는 과정에서 sheet 컨테이너가 왼쪽 하단 기준으로 펼쳐지는 것처럼 보임

## 변경 사항
- `isContentMeasured` 상태 추가
- 측정 완료 전: `opacity(0)`으로 숨기고 `detents`를 `maxDetentHeight`로 고정
- `contentHeight > 0`이 되는 순간 `isContentMeasured = true`로 전환하여 최종 크기로 바로 표시

## Test plan
- [ ] BottomSheet가 있는 화면에서 버튼 탭 시 애니메이션 확인
- [ ] `.hug`, `.flexible`, `.fixedRatio`, `.fixedHeight` 각 resize 옵션에서 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 하단 시트가 콘텐츠 높이 측정이 완료될 때까지 숨겨졌다가 준비되면 부드럽게 페이드인하도록 개선했습니다.
  * 초기에는 콘텐츠 측정 전 단일 최대 높이로 표시해 깜박임을 방지합니다.
  * 측정 완료 후에는 기존처럼 유연/고정 크기 동작으로 전환되어 동작이 안정화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->