### PR TITLE
fix(TopNavigation): TrailingContents, LeadingButton contentShape를 고정 패딩으로 변경

### DIFF
--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -503,7 +503,7 @@ public struct TopNavigation: View {
             HStack(alignment: .center, spacing: 16) {
                 ForEach(contents.indices, id: \.self) { index in
                     contents[index]()
-                        .contentShape(Rectangle().scale(2), eoFill: true) // 터치영역 확장
+                        .contentShape(Rectangle().inset(by: -10)) // 터치영역 확장 (고정 패딩)
                 }
             }
         }
@@ -560,7 +560,7 @@ extension TopNavigation {
                         .frame(height: 24)
                     }
                 }
-                .contentShape(Rectangle().scale(2), eoFill: true)
+                .contentShape(Rectangle().inset(by: -10)) // 터치영역 확장 (고정 패딩)
             } else {
                 SwiftUI.Color.clear
                     .frame(width: 24, height: 24)


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-271

# 수정사항
- `TopNavigation.TrailingContents`와 `LeadingButton`의 `contentShape(Rectangle().scale(2))`를 `contentShape(Rectangle().inset(by: -10))`으로 변경
- 2배 스케일링 대신 고정 10pt 패딩으로 터치 영역을 확장하여, 넓은 커스텀 버튼(예: 이력서 상세의 리뷰 버튼)이 인접 버튼과 접근성 프레임이 겹치는 문제 해결

# 미리보기
N/A (접근성 프레임 변경으로 시각적 차이 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 상단 네비게이션 버튼의 터치 타겟 영역을 개선하여 더 정확한 탭 인식성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->