### PR TITLE
fix(ModalNavigation): bottomSheet를 fullScreenCover로 사용 시 배경색 조정 옵션 추가

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
@@ -16,6 +16,9 @@ struct ModalNavigationPreview: View {
     @State private var leadingButton = true
     @State private var leadingButtonTypeIndex = 0
     @State private var trailingButtonCount = 1
+    @State private var noMaterialBackground = false
+    @State private var useFixedOpacity = false
+    @State private var fixedOpacity: CGFloat = 0.5
     @Environment(\.presentationMode) var presentationMode
     @State private var showPreview = true
     
@@ -52,6 +55,14 @@ struct ModalNavigationPreview: View {
                         ModalNavigation(scrollOffset: $contentOffset)
                             .variant(variants[variantIndex])
                             .title("제목")
+                            .noMaterialBackground(noMaterialBackground)
+                            .modifying {
+                                if useFixedOpacity {
+                                    $0.fixedBackgroundOpacity(fixedOpacity)
+                                } else {
+                                    $0
+                                }
+                            }
                             .leadingContent {
                                 Group {
                                     if leadingButton {
@@ -120,12 +131,26 @@ struct ModalNavigationPreview: View {
                         Text("trailingButton")
                         SegmentedControl(selectedIndex: $trailingButtonCount, labels: Array(0...3).map { "\($0)" })
                             .size(.small)
-                        
+
+                    }
+                    HStack {
+                        Text("noMaterialBackground")
+                        Spacer()
+                        Switch(checked: noMaterialBackground) { noMaterialBackground = $0 }
+                    }
+                    HStack {
+                        Text("fixedBackgroundOpacity")
+                        SwiftUI.Slider(value: $fixedOpacity, in: 0...1)
+                            .disabled(!useFixedOpacity)
+                        Text(String(format: "%.2f", fixedOpacity))
+                            .monospacedDigit()
+                        Switch(checked: useFixedOpacity) { useFixedOpacity = $0 }
                     }
                 }
                 .padding()
                 .background(.regularMaterial)
             }
+            .background(Color.semantic(.backgroundNormal))
         }
     }
     

--- a/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
@@ -55,7 +55,13 @@ struct ModalNavigationPreview: View {
                         ModalNavigation(scrollOffset: $contentOffset)
                             .variant(variants[variantIndex])
                             .title("제목")
-                            .noMaterialBackground(noMaterialBackground)
+                            .modifying {
+                                if noMaterialBackground {
+                                    $0.noMaterialBackground()
+                                } else {
+                                    $0
+                                }
+                            }
                             .modifying {
                                 if useFixedOpacity {
                                     $0.fixedBackgroundOpacity(fixedOpacity)

--- a/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
@@ -35,9 +35,9 @@ public struct ModalNavigation: View {
         fileprivate enum Kind: Equatable {
             case normal, display, extended, floating, emphasized
         }
-
+        
         fileprivate let kind: Kind
-
+        
         /// 기본 스타일의 내비게이션 바
         public static let normal = Variant(kind: .normal)
         /// 제목이 별도 줄에 표시되는 확장된 스타일
@@ -46,19 +46,19 @@ public struct ModalNavigation: View {
         public static let floating = Variant(kind: .floating)
         /// 강조된 큰 제목 스타일
         public static let emphasized = Variant(kind: .emphasized)
-
+        
         /// 제목이 별도 줄에 표시되는 확장된 스타일
         @available(*, deprecated, renamed: "display", message: "이름이 `display`로 변경되었습니다. 다음 메이저 업데이트 때 제거될 예정입니다.")
         public static let extended = Variant(kind: .extended)
-
+        
         /// 플로팅 스타일
         @available(*, deprecated, message: "파라메터 제거되었습니다. `.floating`으로 사용하십시오. 다음 메이저 업데이트 때 제거될 예정입니다.")
         public static func floating(alternative: Bool = false, background: Bool = true) -> Variant {
             Variant(kind: .floating)
         }
-
+        
         fileprivate var isFloating: Bool { kind == .floating }
-
+        
         public var description: String {
             switch kind {
             case .normal: "normal"
@@ -71,7 +71,7 @@ public struct ModalNavigation: View {
     }
     
     // MARK: - Initialisers
-
+    
     @Binding private var scrollOffset: CGFloat
     
     /// 내비게이션 바를 초기화합니다.
@@ -96,7 +96,7 @@ public struct ModalNavigation: View {
                         .frame(width: 40, height: 5)
                 }
             }
-
+            
             Contents(
                 variant: variant,
                 titleText: titleText,
@@ -109,10 +109,15 @@ public struct ModalNavigation: View {
         }
         .background {
             ZStack {
-                Rectangle().fill(.ultraThinMaterial)
-                    .opacity(backgroundOpacity)
-                backgroundColor
-                    .opacity(backgroundOpacity * 0.70)
+                if noMaterialBackground {
+                    SwiftUI.Color.semantic(.backgroundNormal)
+                        .opacity(backgroundOpacity)
+                } else {
+                    Rectangle().fill(.ultraThinMaterial)
+                        .opacity(backgroundOpacity)
+                    SwiftUI.Color.semantic(.backgroundNormal)
+                        .opacity(backgroundOpacity * 0.7)
+                }
             }
             .if(variant.isFloating) {
                 $0.mask {
@@ -131,6 +136,8 @@ public struct ModalNavigation: View {
     
     private var variant: Variant = .normal
     private var backgroundColor: SwiftUI.Color = SwiftUI.Color.semantic(.backgroundNormal)
+    private var noMaterialBackground = false
+    private var fixedBackgroundOpacity: CGFloat?
     private var needHandleArea = false
     private var titleText: String?
     private var titleView: () -> AnyView = { AnyView(EmptyView()) }
@@ -164,6 +171,26 @@ public struct ModalNavigation: View {
     public func backgroundColor(_ backgroundColor: SwiftUI.Color) -> Self {
         var zelf = self
         zelf.backgroundColor = backgroundColor
+        return zelf
+    }
+    
+    /// 내비게이션 바의 배경에 머티리얼 효과를 적용하지 않을지 여부를 설정합니다.
+    ///
+    /// - Parameter noMaterialBackground: 머티리얼 효과 제거 여부. 생략하면 기본값으로 `true` 적용
+    /// - Returns: 수정된 내비게이션 바 뷰
+    public func noMaterialBackground(_ noMaterialBackground: Bool = true) -> Self {
+        var zelf = self
+        zelf.noMaterialBackground = noMaterialBackground
+        return zelf
+    }
+    
+    /// 내비게이션 바의 배경 불투명도를 고정값으로 설정합니다. 스크롤에 따른 자동 조절을 비활성화하고 항상 일정한 불투명도를 유지합니다.
+    ///
+    /// - Parameter fixedBackgroundOpacity: 고정 배경 불투명도 (0에서 1 사이의 값)
+    /// - Returns: 수정된 내비게이션 바 뷰
+    public func fixedBackgroundOpacity(_ fixedBackgroundOpacity: CGFloat) -> Self {
+        var zelf = self
+        zelf.fixedBackgroundOpacity = fixedBackgroundOpacity
         return zelf
     }
     
@@ -312,10 +339,10 @@ private extension ModalNavigation {
             return 1
         } else {
             let ratio = (scrollOffset / -32)
-            return max(0, min(1, ratio))
+            return fixedBackgroundOpacity ?? max(0, min(1, ratio))
         }
     }
-
+    
     var gradientMaskColors: [SwiftUI.Color] {
         [0, 0.7, 1].map { SwiftUI.Color.black.opacity($0) }
     }
@@ -330,7 +357,7 @@ private extension ModalNavigation.Variant {
         case .floating: 4
         }
     }
-
+    
     var contentBottomPadding: CGFloat {
         switch kind {
         case .normal: 10
@@ -339,7 +366,7 @@ private extension ModalNavigation.Variant {
         case .floating: 8
         }
     }
-
+    
     var topNavigationVariant: TopNavigation.Variant {
         switch kind {
         case .normal: .normal
@@ -348,7 +375,7 @@ private extension ModalNavigation.Variant {
         case .emphasized: .normal
         }
     }
-
+    
     var typoVariant: Typography.Variant {
         switch kind {
         case .normal: .headline2
@@ -357,7 +384,7 @@ private extension ModalNavigation.Variant {
         case .emphasized: .heading2
         }
     }
-
+    
     var typoWeight: Typography.Weight {
         switch kind {
         case .normal: .bold

--- a/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
@@ -109,7 +109,7 @@ public struct ModalNavigation: View {
         }
         .background {
             ZStack {
-                if noMaterialBackground {
+                if isMaterialBackgroundDisabled {
                     SwiftUI.Color.semantic(.backgroundNormal)
                         .opacity(backgroundOpacity)
                 } else {
@@ -136,7 +136,7 @@ public struct ModalNavigation: View {
     
     private var variant: Variant = .normal
     private var backgroundColor: SwiftUI.Color = SwiftUI.Color.semantic(.backgroundNormal)
-    private var noMaterialBackground = false
+    private var isMaterialBackgroundDisabled = false
     private var fixedBackgroundOpacity: CGFloat?
     private var needHandleArea = false
     private var titleText: String?
@@ -174,13 +174,12 @@ public struct ModalNavigation: View {
         return zelf
     }
     
-    /// 내비게이션 바의 배경에 머티리얼 효과를 적용하지 않을지 여부를 설정합니다.
+    /// 내비게이션 바의 배경에 머티리얼 효과를 적용하지 않습니다.
     ///
-    /// - Parameter noMaterialBackground: 머티리얼 효과 제거 여부. 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 내비게이션 바 뷰
-    public func noMaterialBackground(_ noMaterialBackground: Bool = true) -> Self {
+    public func noMaterialBackground() -> Self {
         var zelf = self
-        zelf.noMaterialBackground = noMaterialBackground
+        zelf.isMaterialBackgroundDisabled = true
         return zelf
     }
     

--- a/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
+++ b/Sources/Montage/1 Components/9 Utilities/ModalNavigation.swift
@@ -110,12 +110,12 @@ public struct ModalNavigation: View {
         .background {
             ZStack {
                 if isMaterialBackgroundDisabled {
-                    SwiftUI.Color.semantic(.backgroundNormal)
+                    backgroundColor
                         .opacity(backgroundOpacity)
                 } else {
                     Rectangle().fill(.ultraThinMaterial)
                         .opacity(backgroundOpacity)
-                    SwiftUI.Color.semantic(.backgroundNormal)
+                    backgroundColor
                         .opacity(backgroundOpacity * 0.7)
                 }
             }

--- a/Sources/Montage/Asset/Localizable.xcstrings
+++ b/Sources/Montage/Asset/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "ko",
   "strings" : {
+    "" : {
+
+    },
     "*" : {
 
     },
@@ -13,6 +16,26 @@
     "%@" : {
 
     },
+    "%@ %@" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        }
+      }
+    },
+    "%@ %lld" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$lld"
+          }
+        }
+      }
+    },
     "%@x%@" : {
       "localizations" : {
         "ko" : {
@@ -22,6 +45,12 @@
           }
         }
       }
+    },
+    "%lld" : {
+
+    },
+    "99+" : {
+
     },
     "N" : {
 

--- a/documentation/utilities/ios-utility-components/modalnavigation.md
+++ b/documentation/utilities/ios-utility-components/modalnavigation.md
@@ -146,6 +146,21 @@ ModalNavigation()
 </details>
 <details>
 
+<summary>``func fixedBackgroundOpacity(CGFloat) -> ModalNavigation``</summary>
+
+
+내비게이션 바의 배경 불투명도를 고정값으로 설정합니다. 스크롤에 따른 자동 조절을 비활성화하고 항상 일정한 불투명도를 유지합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `fixedBackgroundOpacity` | 고정 배경 불투명도 (0에서 1 사이의 값) |
+- **Return Value**
+
+  수정된 내비게이션 바 뷰
+</details>
+<details>
+
 <summary>``func leadingContent<V>(() -> V) -> ModalNavigation``</summary>
 
 
@@ -178,6 +193,21 @@ ModalNavigation()
   >
   > titleView(_:)와 함께 사용될 경우 이 메서드로 설정된 텍스트만 표시됩니다.
 
+</details>
+<details>
+
+<summary>``func noMaterialBackground(Bool) -> ModalNavigation``</summary>
+
+
+내비게이션 바의 배경에 머티리얼 효과를 적용하지 않을지 여부를 설정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `noMaterialBackground` | 머티리얼 효과 제거 여부. 생략하면 기본값으로 `true` 적용 |
+- **Return Value**
+
+  수정된 내비게이션 바 뷰
 </details>
 <details>
 

--- a/documentation/utilities/ios-utility-components/modalnavigation.md
+++ b/documentation/utilities/ios-utility-components/modalnavigation.md
@@ -196,15 +196,10 @@ ModalNavigation()
 </details>
 <details>
 
-<summary>``func noMaterialBackground(Bool) -> ModalNavigation``</summary>
+<summary>``func noMaterialBackground() -> ModalNavigation``</summary>
 
 
-내비게이션 바의 배경에 머티리얼 효과를 적용하지 않을지 여부를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `noMaterialBackground` | 머티리얼 효과 제거 여부. 생략하면 기본값으로 `true` 적용 |
+내비게이션 바의 배경에 머티리얼 효과를 적용하지 않습니다.
 - **Return Value**
 
   수정된 내비게이션 바 뷰


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-357

`.bottomSheet`를 `fullScreenCover`로 감싸 사용할 때 TopNavigation 영역의 머티리얼 배경이 이중으로 겹쳐 원하는 배경색이 표현되지 않는 문제를 해결하기 위해 `ModalNavigation`에 배경 제어 옵션 두 개를 추가.

# 수정사항
- `noMaterialBackground(_:)` 추가 — `.ultraThinMaterial` 효과를 비활성화하고 `backgroundNormal` 컬러만으로 배경을 구성
- `fixedBackgroundOpacity(_:)` 추가 — 스크롤 오프셋이 전달되지 않는 상황(예: fullScreenCover 내부)에서 배경 불투명도를 고정값으로 유지
- Blueprint `ModalNavigationPreview`에 두 옵션을 토글/슬라이더로 노출해 회귀 검증 가능하게 함
- `make` 실행으로 `documentation/` 갱신

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**신기능**
- 모달 내비게이션 배경의 새로운 커스터마이징 옵션 추가
  - 머티리얼 배경 효과를 제거할 수 있는 옵션
  - 스크롤 기반 불투명도 자동 조정을 비활성화하고 고정 불투명도를 설정할 수 있는 옵션

**문서**
- 새로운 모달 내비게이션 커스터마이징 옵션 관련 설명서 업데이트

**지역화**
- 새로운 문자열 형식에 대한 다국어 지원 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->