### PR TITLE
chore: Blueprint 샘플 앱을 원격 Montage 3.5.0 SPM 참조로 전환

### DIFF
--- a/Montage.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Montage.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ce015d0ae6da392d3a2e82921ff7482591d1f786d188b2e9ffc091e98b11b880",
+  "originHash" : "1c9a3273da3f90d44c64c2c2c921f9b167ac803d81d27f49369b1cdc13470ed5",
   "pins" : [
     {
       "identity" : "lottie-ios",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
         "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "montage-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/wanteddev/montage-ios",
+      "state" : {
+        "revision" : "c19f92b279b2be113b746cb709a6928ca83a51a8",
+        "version" : "3.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -36,10 +36,6 @@ let package = Package(
                 .process("Asset")
             ]
         ),
-        .testTarget(
-            name: "MontageTests",
-            dependencies: ["Montage"]
-        ),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
+++ b/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		4DF7C55D2CE340F0002B241B /* TooltipPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF7C4AF2CE340F0002B241B /* TooltipPreview.swift */; };
 		4DF7C5602CE340F0002B241B /* SelectPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF7C4A62CE340F0002B241B /* SelectPreview.swift */; };
 		4DFA5A532E572464003BED22 /* ShadowPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DFA5A522E572464003BED22 /* ShadowPreview.swift */; };
+		C878B8072F975E50000F7163 /* Montage in Frameworks */ = {isa = PBXBuildFile; productRef = C878B8062F975E50000F7163 /* Montage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -141,6 +142,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C878B8072F975E50000F7163 /* Montage in Frameworks */,
 				4D5B46D82CE34625001DD48B /* Pretendard in Frameworks */,
 				4D45DAF12D910C2D002B1686 /* Montage in Frameworks */,
 			);
@@ -300,6 +302,7 @@
 			packageProductDependencies = (
 				4D5B46D72CE34625001DD48B /* Pretendard */,
 				4D45DAF02D910C2D002B1686 /* Montage */,
+				C878B8062F975E50000F7163 /* Montage */,
 			);
 			productName = Blueprint;
 			productReference = 4D9F46AC2CE32750000DBA7D /* Blueprint.app */;
@@ -331,7 +334,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				4D5B46D62CE34625001DD48B /* XCRemoteSwiftPackageReference "pretendard-ios" */,
-				4D45DAEF2D910C2D002B1686 /* XCLocalSwiftPackageReference "../../" */,
+				C878B8052F975E50000F7163 /* XCRemoteSwiftPackageReference "montage-ios" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4D9F46AD2CE32750000DBA7D /* Products */;
@@ -626,13 +629,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		4D45DAEF2D910C2D002B1686 /* XCLocalSwiftPackageReference "../../" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		4D5B46D62CE34625001DD48B /* XCRemoteSwiftPackageReference "pretendard-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -640,6 +636,14 @@
 			requirement = {
 				branch = main;
 				kind = branch;
+			};
+		};
+		C878B8052F975E50000F7163 /* XCRemoteSwiftPackageReference "montage-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/wanteddev/montage-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -653,6 +657,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4D5B46D62CE34625001DD48B /* XCRemoteSwiftPackageReference "pretendard-ios" */;
 			productName = Pretendard;
+		};
+		C878B8062F975E50000F7163 /* Montage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C878B8052F975E50000F7163 /* XCRemoteSwiftPackageReference "montage-ios" */;
+			productName = Montage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sources/Blueprint/Blueprint.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Sources/Blueprint/Blueprint.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

# 수정사항
- Blueprint.xcodeproj의 `XCLocalSwiftPackageReference("../../")`를 `XCRemoteSwiftPackageReference(montage-ios 3.0.0+)`로 전환
- `Package.swift`에서 `MontageTests` testTarget 제거

# 미리보기
해당 없음 (빌드 구성 변경, UI 변화 없음)