### PR TITLE
fix(ContentBadge): 사이즈별 radius·icon·spacing 디자인 스펙 반영

### DIFF
--- a/Sources/Montage/1 Components/4 Contents/ContentBadge.swift
+++ b/Sources/Montage/1 Components/4 Contents/ContentBadge.swift
@@ -180,7 +180,7 @@ private extension ContentBadge {
         case .small:
             .init(width: 14, height: 14)
         case .medium:
-            .init(width: 16, height: 16)
+            .init(width: 14, height: 14)
         }
     }
     
@@ -229,7 +229,7 @@ private extension ContentBadge {
         case .xsmall:
             2
         case .small:
-            3
+            4
         case .medium:
             4
         }
@@ -251,11 +251,11 @@ private extension ContentBadge {
     var cornerRadius: CGFloat {
         switch size {
         case .xsmall:
-            6.0
-        case .small:
-            6.0
-        case .medium:
             8.0
+        case .small:
+            8.0
+        case .medium:
+            10.0
         }
     }
 }

--- a/Sources/Montage/1 Components/4 Contents/ContentBadgeUIView.swift
+++ b/Sources/Montage/1 Components/4 Contents/ContentBadgeUIView.swift
@@ -52,7 +52,7 @@ public final class ContentBadgeUIView: UIView {
     ///
     /// - `.xsmall`: 가장 작은 크기 (12pt 아이콘)
     /// - `.small`: 작은 크기 (14pt 아이콘)
-    /// - `.medium`: 중간 크기 (16pt 아이콘)
+    /// - `.medium`: 중간 크기 (14pt 아이콘)
     public var size: ContentBadge.Size = .small {
         didSet {
             setupUpdateableConstraints()
@@ -290,7 +290,7 @@ extension ContentBadgeUIView {
         case .small:
             .init(width: 14, height: 14)
         case .medium:
-            .init(width: 16, height: 16)
+            .init(width: 14, height: 14)
         }
     }
     
@@ -319,11 +319,11 @@ extension ContentBadgeUIView {
     var cornerRadius: CGFloat {
         switch size {
         case .xsmall:
-            6.0
-        case .small:
-            6.0
-        case .medium:
             8.0
+        case .small:
+            8.0
+        case .medium:
+            10.0
         }
     }
     
@@ -332,7 +332,7 @@ extension ContentBadgeUIView {
         case .xsmall:
             2
         case .small:
-            3
+            4
         case .medium:
             4
         }


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

# 수정사항
- `cornerRadius`: xsmall/small `6` → `8`, medium `8` → `10`
- small `spacing`: `3` → `4`
- medium `iconSize`: `16` → `14` (관련 docstring 동기화)
- SwiftUI `ContentBadge`와 deprecated `ContentBadgeUIView` 둘 다 동일하게 반영

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷