### PR TITLE
[DEF-1647] TextField 스크롤 프리즈 방지

### DIFF
--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -257,7 +257,8 @@ public struct TextField: View {
     
     @Environment(\.safeAreaInsets) private var safeAreaInsets
     @Environment(\.colorScheme) private var colorScheme
-    @State private var textFieldFrame: CGRect = .zero
+    @State private var textFieldSize: CGSize = .zero
+    @State private var textFieldGlobalFrame: CGRect = .zero
     @FocusState private var textFieldFocusState: Bool
     @State private var autoCompletionContentHeight: CGFloat = .zero
     @State private var fixAutocorrection = false
@@ -383,16 +384,24 @@ private extension TextField {
                             Rectangle()
                                 .offset(x: 1, y: .zero)
                         )
-                        .frame(height: textFieldFrame.height)
+                        .frame(height: textFieldSize.height)
                 }
                 .fixedSize(horizontal: true, vertical: false)
             }
         }
         .frame(minHeight: 48)
         .onGeometryChange(
+            for: CGSize.self,
+            of: { $0.size },
+            action: { textFieldSize = $0 }
+        )
+        .onGeometryChange(
             for: CGRect.self,
-            of: { $0.frame(in: .global) },
-            action: { textFieldFrame = $0 }
+            of: { proxy in
+                guard autoCompletionDataSource != nil else { return .zero }
+                return proxy.frame(in: .global)
+            },
+            action: { textFieldGlobalFrame = $0 }
         )
         .background {
             if disable {
@@ -443,7 +452,7 @@ private extension TextField {
                         autoCompletionContent
                     }
                     .frame(
-                        width: textFieldFrame.width,
+                        width: textFieldGlobalFrame.width,
                         height: min(autoCompletionContentHeight, autoCompletionDataSource?.maxHeight ?? 0)
                     )
                     .background(SwiftUI.Color.semantic(.backgroundNormal))
@@ -455,8 +464,8 @@ private extension TextField {
                     .scrollDisabled(autoCompletionContentHeight <= autoCompletionDataSource?.maxHeight ?? 0)
                     .accessibilityIdentifier("autocomplete_container")
                     .position(
-                        x: textFieldFrame.midX,
-                        y: textFieldFrame.maxY - safeAreaInsets.top
+                        x: textFieldGlobalFrame.midX,
+                        y: textFieldGlobalFrame.maxY - safeAreaInsets.top
                     )
                     .offset(
                         y: 8 + min(autoCompletionContentHeight, autoCompletionDataSource?.maxHeight ?? 0) / 2


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/DEF-1647

# 수정사항
- TextField가 항상 global CGRect 전체를 추적하던 구조를 크기 추적과 autocomplete 위치 추적으로 분리했습니다.
- 일반 TextField 사용 시 스크롤 중 불필요한 global frame state 갱신이 발생하지 않도록 변경했습니다.
- autocomplete가 설정된 경우에만 global frame을 계산해 기존 float 위치 계산 동작을 유지했습니다.

# 미리보기
작업 전|작업 후
---|---
수신용 이메일 폼 표시 후 짧은 ScrollView에서 스크롤 시 프리즈 가능|global frame 갱신 범위를 줄여 스크롤 중 layout invalidation 완화

# 검증
- lsp_diagnostics: No diagnostics found
- make: BUILD DOCUMENTATION SUCCEEDED / 문서 변경사항 없음
- swift build: 기존 MontageTests 경로 설정 문제로 실패 (Tests/MontageTests 없음)