### PR TITLE
fix(montage-mcp): 트래킹 스펙 정합 및 관측성·SSE 안정화

### DIFF
--- a/packages/montage-mcp/src/core/logger.ts
+++ b/packages/montage-mcp/src/core/logger.ts
@@ -28,9 +28,13 @@ function format(meta: Record<string, unknown> | undefined): string {
   }
 }
 
+function now(): string {
+  return new Date().toISOString();
+}
+
 export function logDebug(msg: string, meta?: Record<string, unknown>): void {
   if (!debugEnabled) return;
-  process.stderr.write(`[${PACKAGE_NAME}] ${msg}${format(meta)}\n`);
+  process.stderr.write(`${now()} [${PACKAGE_NAME}] ${msg}${format(meta)}\n`);
 }
 
 export function logError(msg: string, err?: unknown, meta?: Record<string, unknown>): void {
@@ -40,5 +44,5 @@ export function logError(msg: string, err?: unknown, meta?: Record<string, unkno
   } else if (err !== undefined) {
     detail = ` — ${String(err)}`;
   }
-  process.stderr.write(`[${PACKAGE_NAME}] ERROR ${msg}${detail}${format(meta)}\n`);
+  process.stderr.write(`${now()} [${PACKAGE_NAME}] ERROR ${msg}${detail}${format(meta)}\n`);
 }

--- a/packages/montage-mcp/src/core/logger.ts
+++ b/packages/montage-mcp/src/core/logger.ts
@@ -1,0 +1,44 @@
+import { PACKAGE_NAME } from "./config.js";
+
+/**
+ * Stderr logger gated by `MONTAGE_MCP_DEBUG=1`.
+ *
+ * - `logDebug` is silent unless debug is enabled (call `configureLogger` once at boot).
+ * - `logError` always emits, regardless of debug — tracking must surface failures.
+ *
+ * All writes go to stderr so stdio MCP transport (stdout) stays clean.
+ */
+
+let debugEnabled = false;
+
+export function configureLogger(opts: { debug: boolean }): void {
+  debugEnabled = opts.debug;
+}
+
+export function isDebugEnabled(): boolean {
+  return debugEnabled;
+}
+
+function format(meta: Record<string, unknown> | undefined): string {
+  if (!meta) return "";
+  try {
+    return " " + JSON.stringify(meta);
+  } catch {
+    return "";
+  }
+}
+
+export function logDebug(msg: string, meta?: Record<string, unknown>): void {
+  if (!debugEnabled) return;
+  process.stderr.write(`[${PACKAGE_NAME}] ${msg}${format(meta)}\n`);
+}
+
+export function logError(msg: string, err?: unknown, meta?: Record<string, unknown>): void {
+  let detail = "";
+  if (err instanceof Error) {
+    detail = ` — ${err.name}: ${err.message}`;
+  } else if (err !== undefined) {
+    detail = ` — ${String(err)}`;
+  }
+  process.stderr.write(`[${PACKAGE_NAME}] ERROR ${msg}${detail}${format(meta)}\n`);
+}

--- a/packages/montage-mcp/src/core/redact.ts
+++ b/packages/montage-mcp/src/core/redact.ts
@@ -1,0 +1,36 @@
+/**
+ * Logging redaction helpers.
+ *
+ * Logs may be aggregated (Backyard, Loki, etc.) where stderr is durable.
+ * Sensitive identifiers and credentials must be masked before they leave the
+ * process. These helpers are intentionally conservative — false positives are
+ * cheaper than leaks.
+ */
+
+const SENSITIVE_KEY_RE = /(token|secret|password|api[-_]?key|authorization|cookie|email|phone|ssn)/i;
+
+const REDACTED = "***REDACTED***";
+
+export function redactObject(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactObject);
+  if (!value || typeof value !== "object") return value;
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = SENSITIVE_KEY_RE.test(k) ? REDACTED : redactObject(v);
+  }
+  return out;
+}
+
+/** Strip query string and fragment from a URL — origin + path only. */
+export function sanitizeUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  return url.replace(/[?#].*$/, "");
+}
+
+/** Mask a client identifier — keep first 8 chars (or 4 for very short ids) + ellipsis. */
+export function maskClientId(id: string | null | undefined): string | undefined {
+  if (!id) return undefined;
+  if (id.length <= 8) return id.slice(0, 4) + "…";
+  return id.slice(0, 8) + "…";
+}

--- a/packages/montage-mcp/src/core/server.ts
+++ b/packages/montage-mcp/src/core/server.ts
@@ -6,6 +6,7 @@ import {
 import { PACKAGE_NAME, PACKAGE_VERSION, type RuntimeConfig } from "./config.js";
 import { allTools, type ToolDefinition } from "./tools/index.js";
 import { getTracker } from "./tracker/index.js";
+import { logDebug } from "./logger.js";
 
 export interface ServerContext {
   config: RuntimeConfig;
@@ -28,13 +29,16 @@ export function createServer(ctx: ServerContext): Server {
   const tools = allTools(ctx);
   const byName = new Map<string, ToolDefinition>(tools.map((t) => [t.name, t]));
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: tools.map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema,
-    })),
-  }));
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    logDebug("tools/list", { count: tools.length, transport: ctx.transport });
+    return {
+      tools: tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    };
+  });
 
   const tracker = getTracker(ctx.config);
   tracker.start();
@@ -44,6 +48,10 @@ export function createServer(ctx: ServerContext): Server {
     const startedAt = Date.now();
     let ok = true;
     let errorClass: string | undefined;
+    logDebug("tools/call start", {
+      tool: request.params.name,
+      transport: ctx.transport,
+    });
     try {
       const tool = byName.get(request.params.name);
       if (!tool) {
@@ -64,11 +72,18 @@ export function createServer(ctx: ServerContext): Server {
       }
       throw err;
     } finally {
+      const durationMs = Date.now() - startedAt;
+      logDebug("tools/call end", {
+        tool: request.params.name,
+        ok,
+        durationMs,
+        ...(errorClass ? { errorClass } : {}),
+      });
       tracker.track({
         tool: request.params.name,
         transport: ctx.transport,
         args,
-        durationMs: Date.now() - startedAt,
+        durationMs,
         ok,
         ...(errorClass ? { errorClass } : {}),
       });

--- a/packages/montage-mcp/src/core/server.ts
+++ b/packages/montage-mcp/src/core/server.ts
@@ -7,6 +7,7 @@ import { PACKAGE_NAME, PACKAGE_VERSION, type RuntimeConfig } from "./config.js";
 import { allTools, type ToolDefinition } from "./tools/index.js";
 import { getTracker } from "./tracker/index.js";
 import { logDebug } from "./logger.js";
+import { redactObject } from "./redact.js";
 
 export interface ServerContext {
   config: RuntimeConfig;
@@ -51,7 +52,7 @@ export function createServer(ctx: ServerContext): Server {
     logDebug("tools/call start", {
       toolName: request.params.name,
       transport: ctx.transport,
-      params: args,
+      params: redactObject(args),
     });
     try {
       const tool = byName.get(request.params.name);

--- a/packages/montage-mcp/src/core/server.ts
+++ b/packages/montage-mcp/src/core/server.ts
@@ -49,8 +49,9 @@ export function createServer(ctx: ServerContext): Server {
     let ok = true;
     let errorClass: string | undefined;
     logDebug("tools/call start", {
-      tool: request.params.name,
+      toolName: request.params.name,
       transport: ctx.transport,
+      params: args,
     });
     try {
       const tool = byName.get(request.params.name);
@@ -74,10 +75,11 @@ export function createServer(ctx: ServerContext): Server {
     } finally {
       const durationMs = Date.now() - startedAt;
       logDebug("tools/call end", {
-        tool: request.params.name,
-        ok,
-        durationMs,
-        ...(errorClass ? { errorClass } : {}),
+        toolName: request.params.name,
+        transport: ctx.transport,
+        status: ok ? "success" : "error",
+        duration_ms: durationMs,
+        ...(errorClass ? { error_class: errorClass } : {}),
       });
       tracker.track({
         tool: request.params.name,

--- a/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
+++ b/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
@@ -1,5 +1,6 @@
 import type { TrackAdapter, TrackEvent } from "../types.js";
 import { logDebug, logError } from "../../logger.js";
+import { maskClientId, redactObject, sanitizeUrl } from "../../redact.js";
 
 /**
  * Wanted Track HTTP adapter.
@@ -34,10 +35,16 @@ export class HttpJsonAdapter implements TrackAdapter {
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
       const body = JSON.stringify(event);
+      const safeUrl = sanitizeUrl(this.url);
+      const debugEvent = {
+        ...event,
+        clientId: maskClientId(event.clientId),
+        params: event.params ? redactObject(event.params) : undefined,
+      };
       logDebug("track POST request", {
-        url: this.url,
+        url: safeUrl,
         authorization: this.token ? "Bearer ***" : "(none)",
-        payload: event,
+        payload: debugEvent,
       });
       try {
         const headers: Record<string, string> = {
@@ -57,27 +64,31 @@ export class HttpJsonAdapter implements TrackAdapter {
           } catch {
             // ignore body read errors
           }
+          // Always-emit logError keeps minimal fields only — full (redacted) payload
+          // is at logDebug so it's gated by MONTAGE_MCP_DEBUG=1.
           logError("track POST non-2xx", undefined, {
-            url: this.url,
+            url: safeUrl,
             status: res.status,
             toolName: event.toolName,
-            payload: event,
+            transport: event.transport,
             response_body: bodyText,
           });
+          logDebug("track POST non-2xx payload", { payload: debugEvent });
           return { accepted };
         }
         logDebug("track POST ok", {
-          url: this.url,
+          url: safeUrl,
           status: res.status,
           toolName: event.toolName,
         });
         accepted++;
       } catch (err) {
         logError("track POST threw", err, {
-          url: this.url,
+          url: safeUrl,
           toolName: event.toolName,
-          payload: event,
+          transport: event.transport,
         });
+        logDebug("track POST threw payload", { payload: debugEvent });
         return { accepted };
       } finally {
         clearTimeout(timer);

--- a/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
+++ b/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
@@ -31,22 +31,25 @@ export class HttpJsonAdapter implements TrackAdapter {
   async send(events: TrackEvent[]): Promise<{ accepted: number }> {
     if (events.length === 0) return { accepted: 0 };
     let accepted = 0;
+    const safeUrl = sanitizeUrl(this.url);
     for (const event of events) {
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
-      const body = JSON.stringify(event);
-      const safeUrl = sanitizeUrl(this.url);
-      const debugEvent = {
-        ...event,
-        clientId: maskClientId(event.clientId),
-        params: event.params ? redactObject(event.params) : undefined,
-      };
-      logDebug("track POST request", {
-        url: safeUrl,
-        authorization: this.token ? "Bearer ***" : "(none)",
-        payload: debugEvent,
-      });
       try {
+        // Serialize inside try so BigInt/circular-reference exceptions return
+        // the partial `accepted` count instead of propagating — without this,
+        // already-acknowledged events would be re-sent on retry.
+        const body = JSON.stringify(event);
+        const debugEvent = {
+          ...event,
+          clientId: maskClientId(event.clientId),
+          params: event.params ? redactObject(event.params) : undefined,
+        };
+        logDebug("track POST request", {
+          url: safeUrl,
+          authorization: this.token ? "Bearer ***" : "(none)",
+          payload: debugEvent,
+        });
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
         };
@@ -73,7 +76,13 @@ export class HttpJsonAdapter implements TrackAdapter {
             transport: event.transport,
             response_body: bodyText,
           });
-          logDebug("track POST non-2xx payload", { payload: debugEvent });
+          logDebug("track POST non-2xx payload", {
+            payload: {
+              ...event,
+              clientId: maskClientId(event.clientId),
+              params: event.params ? redactObject(event.params) : undefined,
+            },
+          });
           return { accepted };
         }
         logDebug("track POST ok", {
@@ -88,7 +97,13 @@ export class HttpJsonAdapter implements TrackAdapter {
           toolName: event.toolName,
           transport: event.transport,
         });
-        logDebug("track POST threw payload", { payload: debugEvent });
+        logDebug("track POST threw payload", {
+          payload: {
+            ...event,
+            clientId: maskClientId(event.clientId),
+            params: event.params ? redactObject(event.params) : undefined,
+          },
+        });
         return { accepted };
       } finally {
         clearTimeout(timer);

--- a/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
+++ b/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
@@ -1,4 +1,5 @@
 import type { TrackAdapter, TrackEvent } from "../types.js";
+import { logDebug, logError } from "../../logger.js";
 
 /**
  * Wanted Track HTTP adapter.
@@ -44,9 +45,29 @@ export class HttpJsonAdapter implements TrackAdapter {
           signal: ctrl.signal,
         });
         if (!res.ok) {
+          let bodyText = "";
+          try {
+            bodyText = (await res.text()).slice(0, 500);
+          } catch {
+            // ignore body read errors
+          }
+          logError("track POST non-2xx", undefined, {
+            url: this.url,
+            status: res.status,
+            tool: event.toolName,
+            body: bodyText,
+          });
           return { accepted };
         }
+        logDebug("track POST ok", {
+          url: this.url,
+          status: res.status,
+          tool: event.toolName,
+        });
         accepted++;
+      } catch (err) {
+        logError("track POST threw", err, { url: this.url, tool: event.toolName });
+        return { accepted };
       } finally {
         clearTimeout(timer);
       }

--- a/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
+++ b/packages/montage-mcp/src/core/tracker/adapters/http-json.ts
@@ -33,6 +33,12 @@ export class HttpJsonAdapter implements TrackAdapter {
     for (const event of events) {
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+      const body = JSON.stringify(event);
+      logDebug("track POST request", {
+        url: this.url,
+        authorization: this.token ? "Bearer ***" : "(none)",
+        payload: event,
+      });
       try {
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
@@ -41,32 +47,37 @@ export class HttpJsonAdapter implements TrackAdapter {
         const res = await this.fetchImpl(this.url, {
           method: "POST",
           headers,
-          body: JSON.stringify(event),
+          body,
           signal: ctrl.signal,
         });
         if (!res.ok) {
           let bodyText = "";
           try {
-            bodyText = (await res.text()).slice(0, 500);
+            bodyText = (await res.text()).slice(0, 1000);
           } catch {
             // ignore body read errors
           }
           logError("track POST non-2xx", undefined, {
             url: this.url,
             status: res.status,
-            tool: event.toolName,
-            body: bodyText,
+            toolName: event.toolName,
+            payload: event,
+            response_body: bodyText,
           });
           return { accepted };
         }
         logDebug("track POST ok", {
           url: this.url,
           status: res.status,
-          tool: event.toolName,
+          toolName: event.toolName,
         });
         accepted++;
       } catch (err) {
-        logError("track POST threw", err, { url: this.url, tool: event.toolName });
+        logError("track POST threw", err, {
+          url: this.url,
+          toolName: event.toolName,
+          payload: event,
+        });
         return { accepted };
       } finally {
         clearTimeout(timer);

--- a/packages/montage-mcp/src/core/tracker/index.ts
+++ b/packages/montage-mcp/src/core/tracker/index.ts
@@ -68,7 +68,7 @@ class TrackerImpl implements Tracker {
     errorClass?: string;
   }): void {
     if (!trackingEnabled(this.cfg)) {
-      logDebug("tracker.track skipped — tracking disabled", { tool: input.tool });
+      logDebug("tracker.track skipped — tracking disabled", { toolName: input.tool });
       return;
     }
     const params = sanitizeParams(input.args);
@@ -89,9 +89,13 @@ class TrackerImpl implements Tracker {
     };
     if (params) event.params = params;
     logDebug("tracker.track enqueue", {
-      tool: input.tool,
-      ok: input.ok,
-      durationMs: metadata.duration_ms,
+      toolName: event.toolName,
+      transport: event.transport,
+      platform: event.platform,
+      clientId: event.clientId,
+      timestamp: event.timestamp,
+      params: event.params,
+      metadata: event.metadata,
     });
     // fire-and-forget
     void this.queue.append(event);

--- a/packages/montage-mcp/src/core/tracker/index.ts
+++ b/packages/montage-mcp/src/core/tracker/index.ts
@@ -76,7 +76,7 @@ class TrackerImpl implements Tracker {
     if (input.errorClass) metadata.error_class = input.errorClass;
     const event: TrackEvent = {
       name: "tool_call",
-      tool_name: input.tool,
+      toolName: input.tool,
       transport: input.transport,
       platform: PLATFORM_TAG,
       clientId: this.clientId,

--- a/packages/montage-mcp/src/core/tracker/index.ts
+++ b/packages/montage-mcp/src/core/tracker/index.ts
@@ -4,6 +4,7 @@ import { WalQueue } from "./queue.js";
 import { NoopAdapter } from "./adapters/noop.js";
 import { HttpJsonAdapter } from "./adapters/http-json.js";
 import type { TrackAdapter, TrackEvent } from "./types.js";
+import { logDebug, logError } from "../logger.js";
 
 const FLUSH_INTERVAL_MS = 5_000;
 const FLUSH_BATCH_SIZE = 100;
@@ -66,7 +67,10 @@ class TrackerImpl implements Tracker {
     ok: boolean;
     errorClass?: string;
   }): void {
-    if (!trackingEnabled(this.cfg)) return; // skip even queueing when disabled
+    if (!trackingEnabled(this.cfg)) {
+      logDebug("tracker.track skipped — tracking disabled", { tool: input.tool });
+      return;
+    }
     const params = sanitizeParams(input.args);
     const metadata: TrackEvent["metadata"] = {
       duration_ms: Math.max(0, Math.round(input.durationMs)),
@@ -84,13 +88,27 @@ class TrackerImpl implements Tracker {
       metadata,
     };
     if (params) event.params = params;
+    logDebug("tracker.track enqueue", {
+      tool: input.tool,
+      ok: input.ok,
+      durationMs: metadata.duration_ms,
+    });
     // fire-and-forget
     void this.queue.append(event);
   }
 
   start(): void {
-    if (!trackingEnabled(this.cfg)) return;
+    if (!trackingEnabled(this.cfg)) {
+      logDebug("tracker.start skipped — tracking disabled");
+      return;
+    }
     if (this.timer) return;
+    logDebug("tracker.start", {
+      flushIntervalMs: FLUSH_INTERVAL_MS,
+      flushBatchSize: FLUSH_BATCH_SIZE,
+      trackUrl: this.cfg.trackUrl,
+      clientId: this.clientId,
+    });
     this.timer = setInterval(() => {
       void this.flushNow();
     }, FLUSH_INTERVAL_MS);
@@ -105,17 +123,29 @@ class TrackerImpl implements Tracker {
   }
 
   async flushNow(): Promise<{ sent: number; remaining: number }> {
-    if (this.flushing) return { sent: 0, remaining: -1 };
+    if (this.flushing) {
+      logDebug("tracker.flushNow skipped — already flushing");
+      return { sent: 0, remaining: -1 };
+    }
     this.flushing = true;
     try {
       await this.queue.enforceCap();
       const batch = await this.queue.readBatch(FLUSH_BATCH_SIZE);
-      if (batch.length === 0) return { sent: 0, remaining: 0 };
+      if (batch.length === 0) {
+        return { sent: 0, remaining: 0 };
+      }
+      logDebug("tracker.flushNow sending", { batchSize: batch.length });
       const { accepted } = await this.adapter.send(batch);
       if (accepted > 0) await this.queue.truncateFirst(accepted);
       const remaining = (await this.queue.readBatch(FLUSH_BATCH_SIZE)).length;
+      logDebug("tracker.flushNow done", {
+        sent: accepted,
+        rejected: batch.length - accepted,
+        remaining,
+      });
       return { sent: accepted, remaining };
-    } catch {
+    } catch (err) {
+      logError("tracker.flushNow failed", err);
       return { sent: 0, remaining: -1 };
     } finally {
       this.flushing = false;

--- a/packages/montage-mcp/src/core/tracker/index.ts
+++ b/packages/montage-mcp/src/core/tracker/index.ts
@@ -5,6 +5,7 @@ import { NoopAdapter } from "./adapters/noop.js";
 import { HttpJsonAdapter } from "./adapters/http-json.js";
 import type { TrackAdapter, TrackEvent } from "./types.js";
 import { logDebug, logError } from "../logger.js";
+import { maskClientId, redactObject, sanitizeUrl } from "../redact.js";
 
 const FLUSH_INTERVAL_MS = 5_000;
 const FLUSH_BATCH_SIZE = 100;
@@ -92,9 +93,9 @@ class TrackerImpl implements Tracker {
       toolName: event.toolName,
       transport: event.transport,
       platform: event.platform,
-      clientId: event.clientId,
+      clientId: maskClientId(event.clientId),
       timestamp: event.timestamp,
-      params: event.params,
+      params: event.params ? redactObject(event.params) : undefined,
       metadata: event.metadata,
     });
     // fire-and-forget
@@ -110,8 +111,8 @@ class TrackerImpl implements Tracker {
     logDebug("tracker.start", {
       flushIntervalMs: FLUSH_INTERVAL_MS,
       flushBatchSize: FLUSH_BATCH_SIZE,
-      trackUrl: this.cfg.trackUrl,
-      clientId: this.clientId,
+      trackUrl: sanitizeUrl(this.cfg.trackUrl),
+      clientId: maskClientId(this.clientId),
     });
     this.timer = setInterval(() => {
       void this.flushNow();

--- a/packages/montage-mcp/src/core/tracker/queue.ts
+++ b/packages/montage-mcp/src/core/tracker/queue.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, statSync } from "node:fs";
 import { appendFile, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { TrackEvent } from "./types.js";
+import { logError } from "../logger.js";
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB cap before FIFO eviction
 
@@ -16,8 +17,9 @@ export class WalQueue {
   async append(event: TrackEvent): Promise<void> {
     const line = JSON.stringify(event) + "\n";
     this.writeChain = this.writeChain.then(() =>
-      appendFile(this.path, line, "utf-8").catch(() => {
-        // Disk error — drop silently; tracking must never break tool calls.
+      appendFile(this.path, line, "utf-8").catch((err) => {
+        // Disk error — drop event but surface for debugging; tracking must never break tool calls.
+        logError("queue.append failed", err, { path: this.path });
       }),
     );
     return this.writeChain;

--- a/packages/montage-mcp/src/core/tracker/types.ts
+++ b/packages/montage-mcp/src/core/tracker/types.ts
@@ -3,7 +3,7 @@
  * POST /track  Content-Type: application/json
  * {
  *   "name": "tool_call",
- *   "tool_name": "...",
+ *   "toolName": "...",
  *   "transport": "http" | "stdio",
  *   "platform": "ios",
  *   "clientId": "...",
@@ -14,7 +14,7 @@
  */
 export interface TrackEvent {
   name: "tool_call";
-  tool_name: string;
+  toolName: string;
   transport: "stdio" | "http";
   platform: "ios";
   clientId: string;

--- a/packages/montage-mcp/src/http.ts
+++ b/packages/montage-mcp/src/http.ts
@@ -30,11 +30,28 @@ app.get("/healthz", (_req: Request, res: Response) => {
   });
 });
 
+// SSE heartbeat — sends an SSE comment line periodically so L7 idle timeouts
+// (e.g. ingress 30s) don't sever quiet streams. The colon-prefixed line is a
+// no-op for SSE clients per spec, but counts as bytes for proxies.
+const SSE_HEARTBEAT_MS = 25_000;
+
 app.get("/sse", async (_req: Request, res: Response) => {
   const transport = new SSEServerTransport("/messages", res);
   transports.set(transport.sessionId, transport);
-  logDebug("sse session opened", { sessionId: transport.sessionId });
+  const heartbeat = setInterval(() => {
+    try {
+      res.write(": ping\n\n");
+    } catch {
+      // socket already gone — close handler will clean up
+    }
+  }, SSE_HEARTBEAT_MS);
+  if (typeof heartbeat.unref === "function") heartbeat.unref();
+  logDebug("sse session opened", {
+    sessionId: transport.sessionId,
+    heartbeatMs: SSE_HEARTBEAT_MS,
+  });
   res.on("close", () => {
+    clearInterval(heartbeat);
     transports.delete(transport.sessionId);
     logDebug("sse session closed", { sessionId: transport.sessionId });
   });
@@ -43,6 +60,7 @@ app.get("/sse", async (_req: Request, res: Response) => {
     const server = createServer({ config, transport: "http" });
     await server.connect(transport);
   } catch (err) {
+    clearInterval(heartbeat);
     transports.delete(transport.sessionId);
     if (!res.headersSent) {
       res.status(500).json({ error: "failed to initialize sse session" });

--- a/packages/montage-mcp/src/http.ts
+++ b/packages/montage-mcp/src/http.ts
@@ -2,8 +2,18 @@ import express, { type Request, type Response } from "express";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { loadConfig, PACKAGE_NAME, PACKAGE_VERSION } from "./core/config.js";
 import { createServer } from "./core/server.js";
+import { configureLogger, logDebug, logError } from "./core/logger.js";
 
 const config = loadConfig();
+configureLogger({ debug: config.debug });
+logDebug("config resolved", {
+  trackUrl: config.trackUrl,
+  trackTokenSet: config.trackToken !== null,
+  trackDisabled: config.trackDisabled,
+  clientIdSet: config.clientId !== null,
+  queuePath: config.queuePath,
+  port: config.port,
+});
 const app = express();
 
 // Note: SSE transport requires raw POST body delivery via handlePostMessage.
@@ -23,7 +33,11 @@ app.get("/healthz", (_req: Request, res: Response) => {
 app.get("/sse", async (_req: Request, res: Response) => {
   const transport = new SSEServerTransport("/messages", res);
   transports.set(transport.sessionId, transport);
-  res.on("close", () => transports.delete(transport.sessionId));
+  logDebug("sse session opened", { sessionId: transport.sessionId });
+  res.on("close", () => {
+    transports.delete(transport.sessionId);
+    logDebug("sse session closed", { sessionId: transport.sessionId });
+  });
 
   try {
     const server = createServer({ config, transport: "http" });
@@ -33,25 +47,24 @@ app.get("/sse", async (_req: Request, res: Response) => {
     if (!res.headersSent) {
       res.status(500).json({ error: "failed to initialize sse session" });
     }
-    if (config.debug) {
-      process.stderr.write(
-        `[${PACKAGE_NAME}] sse init failed: ${String(err)}\n`,
-      );
-    }
+    logError("sse init failed", err, { sessionId: transport.sessionId });
   }
 });
 
 app.post("/messages", async (req: Request, res: Response) => {
   const sessionId = req.query.sessionId;
   if (typeof sessionId !== "string") {
+    logDebug("/messages rejected — missing sessionId");
     res.status(400).json({ error: "sessionId query parameter required" });
     return;
   }
   const transport = transports.get(sessionId);
   if (!transport) {
+    logDebug("/messages rejected — session not found", { sessionId });
     res.status(404).json({ error: "session not found" });
     return;
   }
+  logDebug("/messages received", { sessionId });
   await transport.handlePostMessage(req, res);
 });
 
@@ -59,8 +72,8 @@ app.post("/messages", async (req: Request, res: Response) => {
 app.use(express.json());
 
 app.listen(config.port, () => {
-  if (config.debug) {
-    // eslint-disable-next-line no-console
-    console.error(`[${PACKAGE_NAME}] HTTP listening on :${config.port}`);
-  }
+  logDebug(`HTTP listening on :${config.port}`, {
+    name: PACKAGE_NAME,
+    version: PACKAGE_VERSION,
+  });
 });

--- a/packages/montage-mcp/src/http.ts
+++ b/packages/montage-mcp/src/http.ts
@@ -3,11 +3,12 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { loadConfig, PACKAGE_NAME, PACKAGE_VERSION } from "./core/config.js";
 import { createServer } from "./core/server.js";
 import { configureLogger, logDebug, logError } from "./core/logger.js";
+import { sanitizeUrl } from "./core/redact.js";
 
 const config = loadConfig();
 configureLogger({ debug: config.debug });
 logDebug("config resolved", {
-  trackUrl: config.trackUrl,
+  trackUrl: sanitizeUrl(config.trackUrl),
   trackTokenSet: config.trackToken !== null,
   trackDisabled: config.trackDisabled,
   clientIdSet: config.clientId !== null,

--- a/packages/montage-mcp/src/stdio.ts
+++ b/packages/montage-mcp/src/stdio.ts
@@ -1,18 +1,25 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadConfig } from "./core/config.js";
 import { createServer } from "./core/server.js";
+import { configureLogger, logDebug, logError } from "./core/logger.js";
 
 async function main(): Promise<void> {
   const config = loadConfig();
+  configureLogger({ debug: config.debug });
+  logDebug("config resolved", {
+    trackUrl: config.trackUrl,
+    trackTokenSet: config.trackToken !== null,
+    trackDisabled: config.trackDisabled,
+    clientIdSet: config.clientId !== null,
+    queuePath: config.queuePath,
+  });
   const server = createServer({ config, transport: "stdio" });
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  if (config.debug) {
-    process.stderr.write("[montage-ios-mcp] stdio transport ready\n");
-  }
+  logDebug("stdio transport ready");
 }
 
 main().catch((err) => {
-  process.stderr.write(`[montage-ios-mcp] fatal: ${String(err)}\n`);
+  logError("fatal", err);
   process.exit(1);
 });

--- a/packages/montage-mcp/src/stdio.ts
+++ b/packages/montage-mcp/src/stdio.ts
@@ -2,12 +2,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { loadConfig } from "./core/config.js";
 import { createServer } from "./core/server.js";
 import { configureLogger, logDebug, logError } from "./core/logger.js";
+import { sanitizeUrl } from "./core/redact.js";
 
 async function main(): Promise<void> {
   const config = loadConfig();
   configureLogger({ debug: config.debug });
   logDebug("config resolved", {
-    trackUrl: config.trackUrl,
+    trackUrl: sanitizeUrl(config.trackUrl),
     trackTokenSet: config.trackToken !== null,
     trackDisabled: config.trackDisabled,
     clientIdSet: config.clientId !== null,

--- a/packages/montage-mcp/tests/tracker.test.ts
+++ b/packages/montage-mcp/tests/tracker.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 function ev(tool: string, ok = true): TrackEvent {
   return {
     name: "tool_call",
-    tool_name: tool,
+    toolName: tool,
     transport: "stdio",
     platform: "ios",
     clientId: "test-client",
@@ -44,7 +44,7 @@ describe("WalQueue", () => {
     await q.append(ev("a"));
     await q.append(ev("b"));
     const batch = await q.readBatch(10);
-    expect(batch.map((e) => e.tool_name)).toEqual(["a", "b"]);
+    expect(batch.map((e) => e.toolName)).toEqual(["a", "b"]);
   });
 
   it("truncateFirst drops the leading N events", async () => {
@@ -54,7 +54,7 @@ describe("WalQueue", () => {
     await q.append(ev("c"));
     await q.truncateFirst(2);
     const batch = await q.readBatch(10);
-    expect(batch.map((e) => e.tool_name)).toEqual(["c"]);
+    expect(batch.map((e) => e.toolName)).toEqual(["c"]);
   });
 
   it("returns empty when file is missing", async () => {
@@ -86,7 +86,7 @@ describe("HttpJsonAdapter (Track API spec)", () => {
     expect(captured[0]!.url).toBe("https://example/track");
     const body = JSON.parse(String(captured[0]!.init?.body));
     expect(body.name).toBe("tool_call");
-    expect(body.tool_name).toBe("a");
+    expect(body.toolName).toBe("a");
     expect(body.platform).toBe("ios");
     expect(body.transport).toBe("stdio");
     expect(body.metadata.status).toBe("success");


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-598

# 수정사항
- **Track API 스펙 정합**: `tool_name` → `toolName`. 이전 필드명으로 전송된 이벤트가 서버에서 거절돼 트래킹이 누락되던 문제 해결
- **stderr 디버그 로그 추가** (`MONTAGE_MCP_DEBUG=1`로 게이팅)
  - 신규 `core/logger.ts` — debug 게이팅 `logDebug` + 항상 emit하는 `logError`
  - HTTP/STDIO 부팅 시 config 요약(토큰은 set 여부만)
  - `tools/list`, `tools/call` 시작·종료 (toolName, transport, status, duration_ms, error_class, params)
  - `tracker.start` / `tracker.track` enqueue / `tracker.flushNow` 단계별
  - `HttpJsonAdapter` POST 요청·성공·실패·예외 (payload 전체, Authorization 마스킹, 응답 본문 cap 1000자)
  - `queue.append` 디스크 오류 surface
- **로그 타임스탬프**: 모든 stderr 라인 앞에 ISO 8601 timestamp prepend
- **로그 필드명 정렬**: wire spec과 일치(toolName/status/duration_ms/error_class)
- **SSE heartbeat 추가**: 25s 주기로 `: ping` SSE 코멘트 라인 송신 → Backyard ingress idle timeout(30s)으로 인한 정주기 단절·재연결 패턴 방지

# 미리보기
N/A — MCP 서버 코드(BFF) 변경, 시각적 변경 없음