### PR TITLE
feat(accordion): trailingContent에 확장 상태 인자 추가 및 leadingContent 오버로드 추가

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/AccordionPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/AccordionPreview.swift
@@ -18,10 +18,10 @@ struct AccordionPreview: View {
     @State private var hideDivider = false
     @State private var fillWidth = false
     @State private var recursive = false
-    @State private var leadingIcon = false
-    
+    @State private var leadingContent = false
+
     let verticalPaddings: [Accordion.VerticalPadding] = [.small, .medium, .large]
-    
+
     var body: some View {
         SwiftUI.ScrollView {
             VStack(alignment: .leading) {
@@ -55,10 +55,28 @@ struct AccordionPreview: View {
                     .verticalPadding(verticalPaddings[verticalPaddingIndex])
                     .hideDivider(hideDivider)
                     .fillWidth(fillWidth)
-                    .leadingIcon(leadingIcon ? .alignJustify : nil)
-                    .trailingContent {
+                    .leadingContent({
+                        if leadingContent {
+                            Thumbnail(urlString: "https://images.icon-icons.com/4128/PNG/512/hero_main_heading_title_icon_260510.png", ratio: .r1x1)
+                                .frame(width: 24, height: 24)
+                        }
+                    })
+                    .trailingContent { isExpanded in
                         if trailingContent {
-                            ContentBadge(variant: .solid, text: "뱃지")
+                            HStack(spacing: 4) {
+                                TextButton(
+                                    color: .assistive,
+                                    size: .small,
+                                    text: isExpanded ? "접기" : "펼치기"
+                                )
+                                Image.icon(isExpanded ? .chevronUp : .chevronDown)
+                                    .resizable()
+                                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                                    .foregroundStyle(SwiftUI.Color.semantic(.labelAlternative))
+                                    .frame(width: 16, height: 16)
+                            }
+                            .frame(height: 24)
+                            .allowsHitTesting(false)
                         }
                     }
                 }
@@ -74,8 +92,8 @@ struct AccordionPreview: View {
                     Switch(checked: content) { content = $0 }
                 }
                 HStack {
-                    Text("leadingIcon")
-                    Switch(checked: leadingIcon) { leadingIcon = $0 }
+                    Text("leadingContent")
+                    Switch(checked: leadingContent) { leadingContent = $0 }
                     Text("trailingContent")
                     Switch(checked: trailingContent) { trailingContent = $0 }
                 }

--- a/Sources/Montage/1 Components/4 Contents/Accordion.swift
+++ b/Sources/Montage/1 Components/4 Contents/Accordion.swift
@@ -114,9 +114,8 @@ public struct Accordion: View {
     private var verticalPadding: VerticalPadding = .large
     private var fillWidth = false
     private var hideDivider = false
-    private var leadingIcon: Icon? = nil
-    private var leadingIconColor: SwiftUI.Color? = nil
-    private var trailingContent: () -> AnyView = { AnyView(EmptyView()) }
+    private var leadingContent: (() -> AnyView)? = nil
+    private var trailingContent: (Bool) -> AnyView = { _ in AnyView(EmptyView()) }
     
     /// 타이틀 텍스트의 타이포그래피 속성을 조정합니다.
     ///
@@ -190,14 +189,39 @@ public struct Accordion: View {
     
     /// 아코디언 제목 앞에 아이콘을 추가합니다.
     ///
+    /// `leadingContent { ... }`와 동일한 슬롯을 공유하므로, 두 모디파이어를 함께 호출하면 마지막에 호출된 쪽이 적용됩니다.
+    ///
     /// - Parameters:
     ///   - leadingIcon: 표시할 아이콘, 생략하면 기본값으로 `nil` 적용
     ///   - color: 아이콘 색상, 생략하면 기본값으로 `nil` 적용 (기본 색상 사용)
     /// - Returns: 수정된 아코디언 인스턴스
     public func leadingIcon(_ leadingIcon: Icon? = nil, color: SwiftUI.Color? = nil) -> Self {
         var zelf = self
-        zelf.leadingIcon = leadingIcon
-        zelf.leadingIconColor = color
+        if let leadingIcon {
+            zelf.leadingContent = {
+                AnyView(
+                    Image.icon(leadingIcon)
+                        .resizable()
+                        .if(color != nil) { $0.foregroundStyle(color!) }
+                        .padding(2)
+                        .frame(width: 24, height: 24)
+                )
+            }
+        } else {
+            zelf.leadingContent = nil
+        }
+        return zelf
+    }
+
+    /// 아코디언 제목 앞에 커스텀 컨텐츠를 추가합니다.
+    ///
+    /// `leadingIcon`과 동일한 슬롯을 공유하므로, 두 모디파이어를 함께 호출하면 마지막에 호출된 쪽이 적용됩니다.
+    ///
+    /// - Parameter leadingContent: 표시할 커스텀 컨텐츠 뷰
+    /// - Returns: 수정된 아코디언 인스턴스
+    public func leadingContent<V: View>(@ViewBuilder _ leadingContent: @escaping () -> V) -> Self {
+        var zelf = self
+        zelf.leadingContent = { AnyView(leadingContent()) }
         return zelf
     }
     
@@ -207,9 +231,22 @@ public struct Accordion: View {
     ///
     /// - Parameter trailingContent: 표시할 커스텀 컨텐츠 뷰
     /// - Returns: 수정된 아코디언 인스턴스
+    @available(*, deprecated, message: "확장 상태를 인자로 받는 오버로드를 사용하세요: trailingContent { isExpanded in ... }")
     public func trailingContent<V: View>(@ViewBuilder _ trailingContent: @escaping () -> V) -> Self {
         var zelf = self
-        zelf.trailingContent = { AnyView(trailingContent()) }
+        zelf.trailingContent = { _ in AnyView(trailingContent()) }
+        return zelf
+    }
+    
+    /// 아코디언 헤더 우측에 커스텀 컨텐츠를 추가합니다.
+    ///
+    /// 이 수정자를 사용하면 기본 화살표 아이콘이 대체됩니다.
+    ///
+    /// - Parameter trailingContent: 표시할 컨텐츠를 생성하는 클로져 (아코디언이 펼쳐진 상태를 파라미터로 받음)
+    /// - Returns: 수정된 아코디언 인스턴스
+    public func trailingContent<V: View>(@ViewBuilder _ trailingContent: @escaping (Bool) -> V) -> Self {
+        var zelf = self
+        zelf.trailingContent = { AnyView(trailingContent($0)) }
         return zelf
     }
     
@@ -225,16 +262,10 @@ public struct Accordion: View {
         ZStack(alignment: .bottom) {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .top, spacing: 8) {
-                    if let leadingIcon {
-                        Image.icon(leadingIcon)
-                            .resizable()
-                            .if(leadingIconColor != nil) {
-                                $0.foregroundStyle(leadingIconColor!)
-                            }
-                            .padding(2)
-                            .frame(width: 24, height: 24)
+                    if let leadingContent {
+                        leadingContent()
                     }
-                    
+
                     Text(title)
                         .paragraph(
                             variant: titleTypography.variant,
@@ -243,7 +274,7 @@ public struct Accordion: View {
                         )
                     Spacer(minLength: 0)
                     
-                    trailingContent()
+                    trailingContent(isExpanded)
                         .ifEmptyView { trailingContentEmpty = $0 }
                     
                     if trailingContentEmpty {

--- a/Sources/Montage/1 Components/4 Contents/Accordion.swift
+++ b/Sources/Montage/1 Components/4 Contents/Accordion.swift
@@ -242,7 +242,7 @@ public struct Accordion: View {
     ///
     /// 이 수정자를 사용하면 기본 화살표 아이콘이 대체됩니다.
     ///
-    /// - Parameter trailingContent: 표시할 컨텐츠를 생성하는 클로져 (아코디언이 펼쳐진 상태를 파라미터로 받음)
+    /// - Parameter trailingContent: 표시할 컨텐츠를 생성하는 클로저 (아코디언이 펼쳐진 상태를 파라미터로 받음)
     /// - Returns: 수정된 아코디언 인스턴스
     public func trailingContent<V: View>(@ViewBuilder _ trailingContent: @escaping (Bool) -> V) -> Self {
         var zelf = self

--- a/documentation/components/contents/accordion/ios.md
+++ b/documentation/components/contents/accordion/ios.md
@@ -219,7 +219,7 @@ Accordion(title: "커스텀 스타일")
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `trailingContent` | 표시할 컨텐츠를 생성하는 클로져 (아코디언이 펼쳐진 상태를 파라미터로 받음) |
+  | `trailingContent` | 표시할 컨텐츠를 생성하는 클로저 (아코디언이 펼쳐진 상태를 파라미터로 받음) |
 - **Return Value**
 
   수정된 아코디언 인스턴스

--- a/documentation/components/contents/accordion/ios.md
+++ b/documentation/components/contents/accordion/ios.md
@@ -135,6 +135,24 @@ Accordion(title: "커스텀 스타일")
 </details>
 <details>
 
+<summary>``func leadingContent<V>(() -> V) -> Accordion``</summary>
+
+
+아코디언 제목 앞에 커스텀 컨텐츠를 추가합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `leadingContent` | 표시할 커스텀 컨텐츠 뷰 |
+- **Return Value**
+
+  수정된 아코디언 인스턴스
+- **Discussion**
+
+  `leadingIcon`과 동일한 슬롯을 공유하므로, 두 모디파이어를 함께 호출하면 마지막에 호출된 쪽이 적용됩니다.
+</details>
+<details>
+
 <summary>``func leadingIcon(Icon?, color: SwiftUI.Color?) -> Accordion``</summary>
 
 
@@ -148,6 +166,9 @@ Accordion(title: "커스텀 스타일")
 - **Return Value**
 
   수정된 아코디언 인스턴스
+- **Discussion**
+
+  `leadingContent { ... }`와 동일한 슬롯을 공유하므로, 두 모디파이어를 함께 호출하면 마지막에 호출된 쪽이 적용됩니다.
 </details>
 <details>
 
@@ -168,7 +189,29 @@ Accordion(title: "커스텀 스타일")
 </details>
 <details>
 
-<summary>``func trailingContent<V>(() -> V) -> Accordion``</summary>
+<summary>~~``func trailingContent<V>(() -> V) -> Accordion``~~</summary>
+
+
+아코디언 헤더 우측에 커스텀 컨텐츠를 추가합니다.
+>  **Deprecated**
+>
+>  확장 상태를 인자로 받는 오버로드를 사용하세요: trailingContent { isExpanded in ... }
+
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `trailingContent` | 표시할 커스텀 컨텐츠 뷰 |
+- **Return Value**
+
+  수정된 아코디언 인스턴스
+- **Discussion**
+
+  이 수정자를 사용하면 기본 화살표 아이콘이 대체됩니다.
+</details>
+<details>
+
+<summary>``func trailingContent<V>((Bool) -> V) -> Accordion``</summary>
 
 
 아코디언 헤더 우측에 커스텀 컨텐츠를 추가합니다.
@@ -176,7 +219,7 @@ Accordion(title: "커스텀 스타일")
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `trailingContent` | 표시할 커스텀 컨텐츠 뷰 |
+  | `trailingContent` | 표시할 컨텐츠를 생성하는 클로져 (아코디언이 펼쳐진 상태를 파라미터로 받음) |
 - **Return Value**
 
   수정된 아코디언 인스턴스

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -36,6 +36,12 @@
           "kind": "method"
         },
         {
+          "name": "leadingContent(_:)",
+          "signature": "func leadingContent<V>(() -> V) -> Accordion",
+          "summary": "아코디언 제목 앞에 커스텀 컨텐츠를 추가합니다.",
+          "kind": "method"
+        },
+        {
           "name": "leadingIcon(_:color:)",
           "signature": "func leadingIcon(Icon?, color: SwiftUI.Color?) -> Accordion",
           "summary": "아코디언 제목 앞에 아이콘을 추가합니다.",
@@ -50,6 +56,12 @@
         {
           "name": "trailingContent(_:)",
           "signature": "func trailingContent<V>(() -> V) -> Accordion",
+          "summary": "아코디언 헤더 우측에 커스텀 컨텐츠를 추가합니다.",
+          "kind": "method"
+        },
+        {
+          "name": "trailingContent(_:)",
+          "signature": "func trailingContent<V>((Bool) -> V) -> Accordion",
           "summary": "아코디언 헤더 우측에 커스텀 컨텐츠를 추가합니다.",
           "kind": "method"
         },


### PR DESCRIPTION
## Summary

Accordion 컴포넌트의 trailing / leading 컨텐츠 API 확장.

### trailingContent — 확장 상태 인자 추가 (Breaking-ish)

확장 상태(Bool)를 인자로 받는 새 시그니처를 추가하고, 기존 시그니처는 deprecated.

| 구분 | 시그니처 | 상태 |
|---|---|---|
| 신규 | `trailingContent { isExpanded in ... }` (`(Bool) -> V`) | 권장 |
| 기존 | `trailingContent { ... }` (`() -> V`) | `@available(*, deprecated)` |

→ 이제 컨슈머가 아코디언의 펼침 상태에 반응하여 trailing 컨텐츠를 다르게 렌더할 수 있음. 예: chevron 회전 직접 제어.

```swift
Accordion(title: "예시")
    .trailingContent { isExpanded in
        Image.icon(.chevronDown)
            .resizable()
            .frame(width: 20, height: 20)
            .rotationEffect(.degrees(isExpanded ? 180 : 0))
    }
```

### leadingContent — 신규 오버로드 추가

표준 사이즈(24x24)를 벗어난 leading 컨텐츠가 필요한 케이스(예: 작은 불릿 아이콘)를 위한 escape hatch.

```swift
Accordion(title: "예시")
    .leadingContent {
        Image.icon(.circleFill)
            .resizable()
            .padding(9)
            .frame(width: 24, height: 24)
            .foregroundStyle(.semantic(.labelAlternative))
    }
```

### leadingIcon — 내부 리팩터

`leadingIcon`이 내부적으로 `leadingContent` 슬롯을 공유하도록 변경. SwiftUI 표준 룰에 따라 두 모디파이어를 함께 호출하면 **마지막에 호출된 쪽이 적용**됨. 기존 호출부의 동작은 변경 없음.

## Why

Wanted iOS의 OneID 회원가입 약관 화면([PI-83023](https://wantedlab.atlassian.net/browse/PI-83023))에서:
- Figma 디자인의 작은 circleFill 불릿 아이콘을 leading 슬롯에 표시해야 했으나 기존 `leadingIcon`은 사이즈 고정
- 아코디언 펼침 상태에 따라 chevron을 직접 제어해야 했으나 기존 `trailingContent`는 상태를 알 수 없었음

## Test plan

- [x] AccordionPreview에서 `leadingContent`로 적용 시 정상 렌더 확인
- [x] `leadingIcon` → `leadingContent` 순서로 호출 시 `leadingContent`가 적용
- [x] `leadingContent` → `leadingIcon` 순서로 호출 시 `leadingIcon`이 적용
- [x] `trailingContent { isExpanded in ... }`로 펼침 상태에 따라 변경 확인
- [x] 구 `trailingContent { ... }` 호출 시 deprecation 경고 노출 + 동작은 유지


[PI-83023]: https://wantedlab.atlassian.net/browse/PI-83023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ