### PR TITLE
feat: Button에 negative·xsmall variant 및 사이즈 토큰 갱신

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
@@ -47,14 +47,10 @@ struct ButtonPreview: View {
                 
                 let color = colors[colorIndex]
                 let size = sizes[sizeIndex]
-                let isUnsupported = variants[variantIndex] == .outlined && color == .negative
 
                 HStack {
                     Spacer(minLength: 0)
-                    if isUnsupported {
-                        Text("Outlined + Negative는 지원되지 않는 조합입니다.")
-                            .foregroundColor(.semantic(.statusNegative))
-                    } else if iconOnly {
+                    if iconOnly {
                         Button(
                             variant: variants[variantIndex],
                             color: color,
@@ -141,8 +137,10 @@ struct ButtonPreview: View {
                     Switch(checked: contentColor) { contentColor = $0 }
                     Text("background")
                     Switch(checked: backgroundColor) { backgroundColor = $0 }
-                    Text("border")
-                    Switch(checked: borderColor) { borderColor = $0 }
+                    if variants[variantIndex] == .outlined {
+                        Text("border")
+                        Switch(checked: borderColor) { borderColor = $0 }
+                    }
                 }
                 Divider()
                 Text("font")
@@ -159,6 +157,9 @@ struct ButtonPreview: View {
         .onChange(of: iconOnly) { _ in
             leadingIcon = false
             trailingIcon = false
+        }
+        .onChange(of: variantIndex) { _ in
+            borderColor = false
         }
         .transparentChecking(isPresented: showTransparentChecker, checkerSize: 51, checkerColor: .red)
         .background(SwiftUI.Color.semantic(.backgroundNormal))

--- a/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
@@ -28,8 +28,8 @@ struct ButtonPreview: View {
     @State private var loading = false
     
     private let variants: [Montage.Button.Variant] = [.solid, .outlined]
-    private let colors: [Montage.Button.Color] = [.primary, .assistive]
-    private let sizes: [Montage.Button.Size] = [.small, .medium, .large]
+    private let colors: [Montage.Button.Color] = [.primary, .assistive, .negative]
+    private let sizes: [Montage.Button.Size] = [.xsmall, .small, .medium, .large]
     
     var body: some View {
         SwiftUI.ScrollView {
@@ -47,10 +47,14 @@ struct ButtonPreview: View {
                 
                 let color = colors[colorIndex]
                 let size = sizes[sizeIndex]
-                
+                let isUnsupported = variants[variantIndex] == .outlined && color == .negative
+
                 HStack {
                     Spacer(minLength: 0)
-                    if iconOnly {
+                    if isUnsupported {
+                        Text("Outlined + Negative는 지원되지 않는 조합입니다.")
+                            .foregroundColor(.semantic(.statusNegative))
+                    } else if iconOnly {
                         Button(
                             variant: variants[variantIndex],
                             color: color,
@@ -85,7 +89,7 @@ struct ButtonPreview: View {
                         .fontWeight(fontWeight ? .regular : nil)
                         .loading(loading)
                     }
-                    
+
                     Spacer(minLength: 0)
                 }
                 

--- a/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
@@ -137,7 +137,7 @@ struct ButtonPreview: View {
                     Switch(checked: contentColor) { contentColor = $0 }
                     Text("background")
                     Switch(checked: backgroundColor) { backgroundColor = $0 }
-                    if variants[variantIndex] == .outlined {
+                    if variants[variantIndex] == .outlined && colors[colorIndex] != .negative {
                         Text("border")
                         Switch(checked: borderColor) { borderColor = $0 }
                     }
@@ -160,6 +160,11 @@ struct ButtonPreview: View {
         }
         .onChange(of: variantIndex) { _ in
             borderColor = false
+        }
+        .onChange(of: colorIndex) { _ in
+            if variants[variantIndex] == .outlined && colors[colorIndex] == .negative {
+                borderColor = false
+            }
         }
         .transparentChecking(isPresented: showTransparentChecker, checkerSize: 51, checkerColor: .red)
         .background(SwiftUI.Color.semantic(.backgroundNormal))

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -353,7 +353,12 @@ public struct Button: View {
             
             if loading {
                 Loading(kind: .circular(), size: loadingSize)
-                    .foregroundColor(loadingColor)
+                    .overlay {
+                        if let loadingColor {
+                            loadingColor.blendMode(.sourceAtop)
+                        }
+                    }
+                    .compositingGroup()
             }
         }
         .fixedSize(horizontal: !fillHorizontal, vertical: !fillVertical)

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -49,10 +49,17 @@ public struct Button: View {
         case primary
         /// 보조 스타일 - 덜 중요한 액션에 사용
         case assistive
+        /// 부정적·위험 액션 스타일 - 삭제, 경고 등에 사용
+        ///
+        /// > Important: `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않으며,
+        /// > 해당 조합으로 버튼을 생성하면 `preconditionFailure`가 발생합니다.
+        case negative
     }
-    
+
     /// 버튼의 크기를 정의합니다.
     public enum Size: String {
+        /// 가장 작은 크기
+        case xsmall
         /// 작은 크기
         case small
         /// 중간 크기
@@ -96,6 +103,10 @@ public struct Button: View {
         trailingIcon: Icon? = nil,
         handler: (() -> Void)? = nil
     ) {
+        precondition(
+            !(variant == .outlined && color == .negative),
+            "Button: variant `.outlined` does not support color `.negative`."
+        )
         self.init(
             InternalVariant(rawValue: variant.rawValue) ?? .solid,
             color: color,
@@ -128,6 +139,10 @@ public struct Button: View {
         icon: Icon,
         handler: (() -> Void)? = nil
     ) {
+        precondition(
+            !(variant == .outlined && color == .negative),
+            "Button: variant `.outlined` does not support color `.negative`."
+        )
         self.init(
             InternalVariant(rawValue: variant.rawValue) ?? .solid,
             color: color,
@@ -318,7 +333,7 @@ public struct Button: View {
         ZStack {
             SwiftUI.Color.clear
             
-            HStack(alignment: .center, spacing: 4) {
+            HStack(alignment: .center, spacing: gap) {
                 if let leadingIcon {
                     icon(leadingIcon)
                 }
@@ -385,6 +400,7 @@ private extension Button {
                     switch color {
                     case .primary: .semantic(.primaryNormal)
                     case .assistive: .semantic(.fillNormal)
+                    case .negative: .semantic(.statusNegative).opacity(0.12)
                     }
                 }
             }
@@ -425,6 +441,7 @@ private extension Button {
                 switch color {
                 case .primary: .semantic(.staticWhite)
                 case .assistive: .semantic(.labelNeutral)
+                case .negative: .semantic(.accentForegroundRed)
                 }
             }
         case .outlined, .text:
@@ -436,6 +453,7 @@ private extension Button {
                 switch color {
                 case .primary: .semantic(.primaryNormal)
                 case .assistive: .semantic(variant == .outlined ? .labelNormal : .labelAlternative)
+                case .negative: .semantic(.accentForegroundRed)
                 }
             }
         }
@@ -450,11 +468,13 @@ private extension Button {
                 switch color {
                 case .primary: .semantic(.staticWhite)
                 case .assistive: .semantic(.labelAssistive)
+                case .negative: .semantic(.accentForegroundRed)
                 }
             default:
                 switch color {
                 case .primary: .semantic(.primaryNormal)
                 case .assistive: .semantic(.labelAssistive)
+                case .negative: .semantic(.accentForegroundRed)
                 }
             }
         }
@@ -472,23 +492,27 @@ private extension Button {
     
     var iconSize: CGSize {
         switch size {
+        case .xsmall:
+            .init(width: 14, height: 14)
         case .small:
             .init(width: 16, height: 16)
         case .medium:
-                .init(width: variant == .text ? 20 : 18, height: variant == .text ? 20 : 18)
+            .init(width: variant == .text ? 20 : 18, height: variant == .text ? 20 : 18)
         case .large:
             .init(width: 20, height: 20)
         }
     }
-    
+
     var typoVariant: Typography.Variant {
         switch size {
+        case .xsmall:
+            variant == .text ? .label2 : .caption1
         case .small:
-            variant == .text ? .label1 : .label2
+            variant == .text ? .label1 : .caption1
         case .medium:
-            variant == .text ? .body1 : .body2
+            variant == .text ? .body1 : .label1
         case .large:
-            .body1
+            variant == .text ? .body1 : .body2
         }
     }
     
@@ -496,6 +520,7 @@ private extension Button {
         switch color {
         case .primary: .bold
         case .assistive: variant == .text ? .bold : .medium
+        case .negative: .bold
         }
     }
     
@@ -504,39 +529,52 @@ private extension Button {
             6.0
         } else {
             switch size {
-            case .large: 12.0
-            case .medium: 10.0
-            case .small: 8.0
+            case .xsmall: 10.0
+            case .small: 10.0
+            case .medium: 12.0
+            case .large: 14.0
             }
         }
     }
-    
+
     var contentHeight: CGFloat {
         switch size {
-        case .small: variant == .text ? 20 : 18
-        case .medium: variant == .text ? 24 : 22
-        case .large: 24
+        case .xsmall: 16
+        case .small: variant == .text ? 20 : 16
+        case .medium: variant == .text ? 24 : 20
+        case .large: variant == .text ? 24 : 22
         }
     }
-    
+
     var edgeInsets: EdgeInsets {
         if variant == .text {
             .init()
         } else {
             switch size {
-            case .small:
+            case .xsmall:
                 text == nil && leadingIcon != nil
                 ? .init(top: 7, leading: 7, bottom: 7, trailing: 7)
-                : .init(top: 7, leading: 14, bottom: 7, trailing: 14)
+                : .init(top: 6, leading: 10, bottom: 6, trailing: 10)
+            case .small:
+                text == nil && leadingIcon != nil
+                ? .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+                : .init(top: 8, leading: 12, bottom: 8, trailing: 12)
             case .medium:
                 text == nil && leadingIcon != nil
                 ? .init(top: 10, leading: 10, bottom: 10, trailing: 10)
-                : .init(top: 9, leading: 20, bottom: 9, trailing: 20)
+                : .init(top: 10, leading: 16, bottom: 10, trailing: 16)
             case .large:
                 text == nil && leadingIcon != nil
-                ? .init(top: 12, leading: 12, bottom: 12, trailing: 12)
-                : .init(top: 12, leading: 28, bottom: 12, trailing: 28)
+                ? .init(top: 14, leading: 14, bottom: 14, trailing: 14)
+                : .init(top: 13, leading: 20, bottom: 13, trailing: 20)
             }
+        }
+    }
+
+    var gap: CGFloat {
+        switch size {
+        case .xsmall, .small, .medium: 4
+        case .large: 6
         }
     }
     
@@ -544,13 +582,15 @@ private extension Button {
         switch color {
         case .primary: variant == .solid ? .strong : .normal
         case .assistive: variant == .solid ? .normal : .light
+        case .negative: .strong
         }
     }
-    
+
     var interactionColor: Montage.Color.Semantic {
         switch color {
         case .primary: variant == .solid ? .labelNormal : .primaryNormal
         case .assistive: .labelNormal
+        case .negative: .labelNormal
         }
     }
 
@@ -558,7 +598,12 @@ private extension Button {
     var interactionHorizontalOffset: CGFloat { variant == .text ? 7 : 0 }
     
     var loadingSize: CGSize {
-        let textHeight = (fontVariant ?? typoVariant).fontHeight
-        return .init(width: textHeight, height: textHeight)
+        let dim: CGFloat
+        switch size {
+        case .xsmall, .small: dim = 12
+        case .medium: dim = 14
+        case .large: dim = 16
+        }
+        return .init(width: dim, height: dim)
     }
 }

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -51,8 +51,8 @@ public struct Button: View {
         case assistive
         /// 부정적·위험 액션 스타일 - 삭제, 경고 등에 사용
         ///
-        /// > Important: `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않으며,
-        /// > 해당 조합으로 버튼을 생성하면 `preconditionFailure`가 발생합니다.
+        /// > Important: `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않습니다.
+        /// > 해당 조합으로 버튼을 생성하면 자동으로 `.solid`로 대체됩니다.
         case negative
     }
 
@@ -103,12 +103,15 @@ public struct Button: View {
         trailingIcon: Icon? = nil,
         handler: (() -> Void)? = nil
     ) {
-        precondition(
-            !(variant == .outlined && color == .negative),
-            "Button: variant `.outlined` does not support color `.negative`."
-        )
+        let resolvedVariant: InternalVariant
+        if variant == .outlined && color == .negative {
+            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to `.solid`.")
+            resolvedVariant = .solid
+        } else {
+            resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
+        }
         self.init(
-            InternalVariant(rawValue: variant.rawValue) ?? .solid,
+            resolvedVariant,
             color: color,
             size: size,
             text: text,
@@ -139,12 +142,15 @@ public struct Button: View {
         icon: Icon,
         handler: (() -> Void)? = nil
     ) {
-        precondition(
-            !(variant == .outlined && color == .negative),
-            "Button: variant `.outlined` does not support color `.negative`."
-        )
+        let resolvedVariant: InternalVariant
+        if variant == .outlined && color == .negative {
+            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to `.solid`.")
+            resolvedVariant = .solid
+        } else {
+            resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
+        }
         self.init(
-            InternalVariant(rawValue: variant.rawValue) ?? .solid,
+            resolvedVariant,
             color: color,
             size: size,
             leadingIcon: icon,

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -628,16 +628,16 @@ private extension TextField {
         
         var textColor: Color.Semantic {
             switch variant {
-            case .primary:
+            case .primary, .negative:
                 .primaryNormal
             case .assistive:
                 .labelNormal
             }
         }
-        
+
         var typoWeight: Typography.Weight {
             switch variant {
-            case .primary: .bold
+            case .primary, .negative: .bold
             case .assistive: .medium
             }
         }

--- a/documentation/components/actions/button/ios.md
+++ b/documentation/components/actions/button/ios.md
@@ -310,6 +310,18 @@ Button(text: "저장")
 </details>
 <details>
 
+<summary>``case negative``</summary>
+
+
+부정적·위험 액션 스타일 - 삭제, 경고 등에 사용
+- **Discussion**
+  >  **Important**
+  >
+  > `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않으며, 해당 조합으로 버튼을 생성하면 `preconditionFailure`가 발생합니다.
+
+</details>
+<details>
+
 <summary>``case primary``</summary>
 
 
@@ -353,6 +365,13 @@ Button(text: "저장")
 
 
 작은 크기
+</details>
+<details>
+
+<summary>``case xsmall``</summary>
+
+
+가장 작은 크기
 </details>
 
 #### Initializers

--- a/documentation/components/actions/button/ios.md
+++ b/documentation/components/actions/button/ios.md
@@ -317,7 +317,7 @@ Button(text: "저장")
 - **Discussion**
   >  **Important**
   >
-  > `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않으며, 해당 조합으로 버튼을 생성하면 `preconditionFailure`가 발생합니다.
+  > `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않습니다. 해당 조합으로 버튼을 생성하면 자동으로 `.solid`로 대체됩니다.
 
 </details>
 <details>

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -390,6 +390,7 @@
           "summary": "버튼의 색상 스타일을 정의합니다.",
           "cases": [
             "assistive",
+            "negative",
             "primary"
           ]
         },
@@ -419,7 +420,8 @@
           "cases": [
             "large",
             "medium",
-            "small"
+            "small",
+            "xsmall"
           ]
         },
         {


### PR DESCRIPTION
# 개요
- 이슈 링크 :

# 수정사항
- `Button.Color`에 `negative` 케이스 추가 (Solid 전용)
  - `Outlined` + `negative` 조합은 init에서 `preconditionFailure`로 차단
- `Button.Size`에 `xsmall` 케이스 추가 (h:28)
- 사이즈별 디자인 토큰을 시안 스펙으로 일괄 갱신
  - `cornerRadius`: large 12→14, medium 10→12, small 8→10, xsmall 10
  - `edgeInsets`: 시안 padding 반영 (large px:20/py:13 등)
  - `typoVariant`: large body1→body2, medium body2→label1, small label2→caption1, xsmall caption1
  - `iconSize` / `contentHeight` / `gap` / `loadingSize` 시안 기준으로 정렬
- Blueprint `ButtonPreview`에 negative/xsmall 노출, outlined+negative 조합 안내 메시지 처리
- `TextField`의 `Button.Color` switch에 `negative` 케이스 보강 (primary와 동일 매핑)
- DocC 문서·MCP 데이터 `make`로 자동 갱신

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷