### PR TITLE
fix: skip check-changes guard in docs generation CI

### DIFF
--- a/.github/workflows/generate-docs-pr.yml
+++ b/.github/workflows/generate-docs-pr.yml
@@ -95,7 +95,7 @@ jobs:
           fi
 
       - name: Run make to generate documentation
-        run: make
+        run: make generate
 
       - name: Commit changes
         id: commit

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ all: generate check-changes
 # 문서/MCP 데이터 생성만 수행 (CI에서 생성 후 자동 커밋할 때 사용)
 generate: docc md license mcp-data
 
+# md와 mcp-data는 docc가 생성한 .doccarchive를 입력으로 사용하므로
+# 병렬 빌드(make -j)에서도 docc 완료 후 실행되도록 명시한다.
+md: docc
+mcp-data: docc
+
 # DocC API 문서 생성
 docc:
 	@echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@
 XCODE_VERSION=26.3
 
 # 기본 타겟(로컬용): 문서 생성 후 변경사항 가드 실행
-all: generate check-changes
+# check-changes를 prerequisite가 아닌 recipe에서 호출해야 make -j 병렬 실행 시
+# generate가 완료된 뒤 순차적으로 검사된다.
+all: generate
+	@$(MAKE) check-changes
 
 # 문서/MCP 데이터 생성만 수행 (CI에서 생성 후 자동 커밋할 때 사용)
 generate: docc md license mcp-data

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-.PHONY: all docc server md license mcp-data check-changes clean
+.PHONY: all generate docc server md license mcp-data check-changes clean
 
 # 문서 생성시 사용해야 하는 Xcode 버전
 # 빌드머신의 Xcode 버전과 동일하게 설정해야 합니다.
 XCODE_VERSION=26.3
 
-# 기본 타겟: docc, md, license, mcp-data를 순서대로 실행하고 변경사항 확인
-all: docc md license mcp-data check-changes
+# 기본 타겟(로컬용): 문서 생성 후 변경사항 가드 실행
+all: generate check-changes
+
+# 문서/MCP 데이터 생성만 수행 (CI에서 생성 후 자동 커밋할 때 사용)
+generate: docc md license mcp-data
 
 # DocC API 문서 생성
 docc:


### PR DESCRIPTION
# 개요
- 이슈 링크 : N/A
- 관련 실패 워크플로우: https://github.com/wanteddev/montage-ios/actions/runs/26081082879

# 수정사항
`generate-docs-pr.yml` 워크플로우가 `make` 실행 후 자동으로 `git add . && git commit`을 수행하도록 설계되어 있으나, Makefile의 `all` 타겟이 `check-changes` 가드(생성물이 커밋되어 있지 않으면 `exit 1`)를 마지막에 호출하여 `make` 단계 자체가 실패하고 후속 커밋 스텝이 실행되지 않는 문제가 있었습니다.

- `Makefile`: 문서/MCP 데이터 생성만 수행하는 `generate` 타겟을 분리. `all`은 `generate + check-changes` 조합으로 유지하여 로컬 개발자용 가드는 그대로 보존
- `.github/workflows/generate-docs-pr.yml`: `make` → `make generate`로 변경하여 CI에서는 가드를 우회하고 생성 → 커밋 → 푸시 흐름이 정상 동작하도록 수정

# 미리보기
| 호출 | 동작 | 용도 |
|---|---|---|
| `make` (= `make all`) | 생성 + check-changes 가드 | 로컬 개발자 (PR 전 검증) |
| `make generate` | 생성만 | CI 자동 커밋 워크플로우 |
