### PR TITLE
docs: Accordion deprecated 메시지의 코드 예시를 백틱으로 감싸기

### DIFF
--- a/Sources/Montage/1 Components/4 Contents/Accordion.swift
+++ b/Sources/Montage/1 Components/4 Contents/Accordion.swift
@@ -231,7 +231,7 @@ public struct Accordion: View {
     ///
     /// - Parameter trailingContent: 표시할 커스텀 컨텐츠 뷰
     /// - Returns: 수정된 아코디언 인스턴스
-    @available(*, deprecated, message: "확장 상태를 인자로 받는 오버로드를 사용하세요: trailingContent { isExpanded in ... }")
+    @available(*, deprecated, message: "확장 상태를 인자로 받는 오버로드를 사용하세요: `trailingContent { isExpanded in ... }`")
     public func trailingContent<V: View>(@ViewBuilder _ trailingContent: @escaping () -> V) -> Self {
         var zelf = self
         zelf.trailingContent = { _ in AnyView(trailingContent()) }

--- a/documentation/components/contents/accordion/ios.md
+++ b/documentation/components/contents/accordion/ios.md
@@ -195,7 +195,7 @@ Accordion(title: "커스텀 스타일")
 아코디언 헤더 우측에 커스텀 컨텐츠를 추가합니다.
 >  **Deprecated**
 >
->  확장 상태를 인자로 받는 오버로드를 사용하세요: trailingContent { isExpanded in ... }
+>  확장 상태를 인자로 받는 오버로드를 사용하세요: `trailingContent { isExpanded in ... }`
 
 
 - **Parameters**


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

# 수정사항
- `Accordion.trailingContent` deprecated 메시지에서 코드 예시 `trailingContent { isExpanded in ... }`를 백틱으로 감싸 가독성 개선

# 미리보기
작업 전|작업 후
---|---
N/A (문서 메시지 수정)|N/A (문서 메시지 수정)
