### PR TITLE
feat: Checkbox/Checkmark/Radio label에 fillWidth 파라미터 추가

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/ControlPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ControlPreview.swift
@@ -20,6 +20,7 @@ struct ControlPreview: View {
     @State private var sizeIndex = 0
     @State private var disabled: Bool = false
     @State private var tight: Bool = false
+    @State private var fillWidth: Bool = true
     @State private var label: String = ""
     @State private var bold: Bool = false
     @State private var customTypography = false
@@ -56,7 +57,7 @@ struct ControlPreview: View {
                         .disable(disabled)
                         .bold(bold)
                         .tight(tight)
-                        .label(label)
+                        .label(label, fillWidth: fillWidth)
                         .if(customTypography) {
                             $0.labelTypography(.heading2, weight: .medium, color: .semantic(.accentBackgroundPink))
                         }
@@ -74,7 +75,7 @@ struct ControlPreview: View {
                         .disable(disabled)
                         .bold(bold)
                         .tight(tight)
-                        .label(label)
+                        .label(label, fillWidth: fillWidth)
                         .if(customTypography) {
                             $0.labelTypography(.heading2, weight: .bold, color: .semantic(.accentBackgroundPink))
                         }
@@ -92,7 +93,7 @@ struct ControlPreview: View {
                         .disable(disabled)
                         .bold(bold)
                         .tight(tight)
-                        .label(label)
+                        .label(label, fillWidth: fillWidth)
                         .if(customTypography) {
                             $0.labelTypography(.heading2, weight: .bold, color: .semantic(.accentBackgroundPink))
                         }
@@ -132,8 +133,12 @@ struct ControlPreview: View {
                     Switch(checked: disabled) { disabled = $0 }
                     Text("bold")
                     Switch(checked: bold) { bold = $0 }
+                }
+                HStack {
                     Text("tight")
                     Switch(checked: tight) { tight = $0 }
+                    Text("fillWidth")
+                    Switch(checked: fillWidth) { fillWidth = $0 }
                 }
                 HStack {
                     Text("label")

--- a/Sources/Montage/1 Components/3 Selection And Input/Checkbox.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Checkbox.swift
@@ -110,10 +110,12 @@ public struct Checkbox: View {
 
     /// 레이블 텍스트를 설정합니다.
     ///
-    /// - Parameter text: 레이블에 표시할 텍스트
+    /// - Parameters:
+    ///  - text: 레이블에 표시할 텍스트
+    ///  - fillWidth: 수평으로 주어진 공간을 다 채우도록 설정합니다. 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 체크박스 컴포넌트
-    public func label(_ text: String) -> Self {
-        .init(base: base.label(text))
+    public func label(_ text: String, fillWidth: Bool = true) -> Self {
+        .init(base: base.label(text, fillWidth: fillWidth))
     }
 
     /// 레이블의 타이포그래피 속성을 설정합니다.

--- a/Sources/Montage/1 Components/3 Selection And Input/Checkmark.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Checkmark.swift
@@ -46,10 +46,12 @@ public struct Checkmark: View {
 
     /// 레이블 텍스트를 설정합니다.
     ///
-    /// - Parameter text: 레이블에 표시할 텍스트
+    /// - Parameters:
+    ///  - text: 레이블에 표시할 텍스트
+    ///  - fillWidth: 수평으로 주어진 공간을 다 채우도록 설정합니다. 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 체크마크 컴포넌트
-    public func label(_ text: String) -> Self {
-        .init(base: base.label(text))
+    public func label(_ text: String, fillWidth: Bool = true) -> Self {
+        .init(base: base.label(text, fillWidth: fillWidth))
     }
 
     /// 레이블의 타이포그래피 속성을 설정합니다.

--- a/Sources/Montage/1 Components/3 Selection And Input/Control.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Control.swift
@@ -158,7 +158,7 @@ struct Control: View {
                             color: labelTypography.color
                         )
                         .multilineTextAlignment(.leading)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .frame(maxWidth: fillWidth ? .infinity : nil, alignment: .leading)
                         .padding(.vertical, size == .medium ? 1 : 0)
                         .contentShape(Rectangle())
                         .onTapGesture {
@@ -177,6 +177,7 @@ struct Control: View {
     // MARK: - Modifiers
 
     private var label: String = ""
+    private var fillWidth = false
     private var labelVariant: Typography.Variant?
     private var labelWeight: Typography.Weight?
     private var labelColor: SwiftUI.Color?
@@ -186,13 +187,16 @@ struct Control: View {
 
     /// 레이블 텍스트를 설정합니다.
     ///
-    /// - Parameter text: 레이블에 표시할 텍스트
+    /// - Parameters:
+    ///  - text: 레이블에 표시할 텍스트
+    ///  - fillWidth: 수평으로 주어진 공간을 다 채우도록 설정합니다. 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 입력 컴포넌트
     ///
     /// - Note: `.switch` 변형에서는 레이블이 표시되지 않습니다.
-    func label(_ text: String) -> Self {
+    func label(_ text: String, fillWidth: Bool = true) -> Self {
         var zelf = self
         zelf.label = text
+        zelf.fillWidth = fillWidth
         return zelf
     }
 

--- a/Sources/Montage/1 Components/3 Selection And Input/Radio.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Radio.swift
@@ -51,10 +51,12 @@ public struct Radio: View {
 
     /// 레이블 텍스트를 설정합니다.
     ///
-    /// - Parameter text: 레이블에 표시할 텍스트
+    /// - Parameters:
+    ///  - text: 레이블에 표시할 텍스트
+    ///  - fillWidth: 수평으로 주어진 공간을 다 채우도록 설정합니다. 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 라디오 버튼 컴포넌트
-    public func label(_ text: String) -> Self {
-        .init(base: base.label(text))
+    public func label(_ text: String, fillWidth: Bool = true) -> Self {
+        .init(base: base.label(text, fillWidth: fillWidth))
     }
 
     /// 레이블의 타이포그래피 속성을 설정합니다.

--- a/documentation/components/selection and input/checkbox/ios.md
+++ b/documentation/components/selection and input/checkbox/ios.md
@@ -122,18 +122,17 @@ Checkbox(state: .unchecked, size: .small) { state in
 </details>
 <details>
 
-<summary>``func label(String) -> Checkbox``</summary>
+<summary>``func label(String, fillWidth: Bool) -> Checkbox``</summary>
 
 
 레이블 텍스트를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `text` | 레이블에 표시할 텍스트 |
 - **Return Value**
 
   수정된 체크박스 컴포넌트
+- **Discussion**
+  - text: 레이블에 표시할 텍스트
+  - fillWidth: 수평으로 주어진 공간을 다 채우도록 설정합니다. 생략하면 기본값으로 `true` 적용
+
 </details>
 <details>
 

--- a/documentation/components/selection and input/checkmark/ios.md
+++ b/documentation/components/selection and input/checkmark/ios.md
@@ -89,18 +89,17 @@ Checkmark(checked: true) { checked in
 </details>
 <details>
 
-<summary>``func label(String) -> Checkmark``</summary>
+<summary>``func label(String, fillWidth: Bool) -> Checkmark``</summary>
 
 
 레이블 텍스트를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `text` | 레이블에 표시할 텍스트 |
 - **Return Value**
 
   수정된 체크마크 컴포넌트
+- **Discussion**
+  - text: 레이블에 표시할 텍스트
+  - fillWidth: 수평으로 주어진 공간을 다 채우도록 설정합니다. 생략하면 기본값으로 `true` 적용
+
 </details>
 <details>
 

--- a/documentation/components/selection and input/radio/ios.md
+++ b/documentation/components/selection and input/radio/ios.md
@@ -94,18 +94,17 @@ Radio(checked: false, size: .small) { checked in
 </details>
 <details>
 
-<summary>``func label(String) -> Radio``</summary>
+<summary>``func label(String, fillWidth: Bool) -> Radio``</summary>
 
 
 레이블 텍스트를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `text` | 레이블에 표시할 텍스트 |
 - **Return Value**
 
   수정된 라디오 버튼 컴포넌트
+- **Discussion**
+  - text: 레이블에 표시할 텍스트
+  - fillWidth: 수평으로 주어진 공간을 다 채우도록 설정합니다. 생략하면 기본값으로 `true` 적용
+
 </details>
 <details>
 

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -614,8 +614,8 @@
           "kind": "method"
         },
         {
-          "name": "label(_:)",
-          "signature": "func label(String) -> Checkbox",
+          "name": "label(_:fillWidth:)",
+          "signature": "func label(String, fillWidth: Bool) -> Checkbox",
           "summary": "레이블 텍스트를 설정합니다.",
           "kind": "method"
         },
@@ -681,8 +681,8 @@
           "kind": "method"
         },
         {
-          "name": "label(_:)",
-          "signature": "func label(String) -> Checkmark",
+          "name": "label(_:fillWidth:)",
+          "signature": "func label(String, fillWidth: Bool) -> Checkmark",
           "summary": "레이블 텍스트를 설정합니다.",
           "kind": "method"
         },
@@ -1809,8 +1809,8 @@
           "kind": "method"
         },
         {
-          "name": "label(_:)",
-          "signature": "func label(String) -> Radio",
+          "name": "label(_:fillWidth:)",
+          "signature": "func label(String, fillWidth: Bool) -> Radio",
           "summary": "레이블 텍스트를 설정합니다.",
           "kind": "method"
         },


### PR DESCRIPTION
# 개요
- 이슈 링크 :

Checkbox/Checkmark/Radio의 `label()`에 `fillWidth` 파라미터를 추가하여 레이블이 수평 공간을 다 채울지 여부를 선택할 수 있도록 했습니다. 기본값은 `true`로 기존 동작을 유지합니다.

# 수정사항
- `Checkbox.label(_:fillWidth:)`, `Checkmark.label(_:fillWidth:)`, `Radio.label(_:fillWidth:)`에 `fillWidth` 파라미터 추가 (기본값 `true`)
- `Control` 내부에서 `fillWidth` 값에 따라 `frame(maxWidth:)`를 `.infinity` 또는 `nil`로 분기
- Blueprint `ControlPreview`에 `fillWidth` 토글 추가
- DocC 문서 재생성

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷
