### PR TITLE
feat: add auto docs sync/deploy workflow on release

### DIFF
--- a/.github/workflows/auto-deploy-docs.yml
+++ b/.github/workflows/auto-deploy-docs.yml
@@ -1,0 +1,34 @@
+name: Auto Docs Sync/Deploy on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sync:
+    uses: wanteddev/montage-web/.github/workflows/docs-sync.yml@main
+    secrets: inherit
+
+  deploy:
+    needs: sync
+    if: needs.sync.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          owner: wanteddev
+          repositories: montage-web
+
+      - name: Trigger docs-deploy on sync branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run docs-deploy.yml \
+            --repo wanteddev/montage-web \
+            --ref "${{ needs.sync.outputs.branch }}" \
+            -f server_type=www

--- a/.github/workflows/auto-deploy-docs.yml
+++ b/.github/workflows/auto-deploy-docs.yml
@@ -31,4 +31,5 @@ jobs:
           gh workflow run docs-deploy.yml \
             --repo wanteddev/montage-web \
             --ref "${{ needs.sync.outputs.branch }}" \
-            -f server_type=www
+            -f server_type=www \
+            -f algolia=true


### PR DESCRIPTION
# 개요
- 이슈 링크 :

# 수정사항
- GitHub Release 발행(`release: published`) 시 montage-web의 `docs-sync.yml`을 호출하는 워크플로우 추가
- sync 결과 `has_changes == true`인 경우에만 deploy job 수행
- GitHub App 토큰으로 `montage-web` 레포의 `docs-deploy.yml`을 `sync.outputs.branch` 기준으로 트리거 (`server_type=www`)

# 미리보기
워크플로우 변경이라 UI 미리보기 N/A. 동작은 릴리즈 발행 후 Actions 로그로 확인.