### PR TITLE
feat: IconButton 시안 정합 — NormalSize enum 도입 및 사이즈 토큰 갱신

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/IconButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/IconButtonPreview.swift
@@ -13,7 +13,7 @@ struct IconButtonPreview: View {
     @State private var variantIndex = 0
     @State private var customSize: CGFloat = 24
     @State private var sizeIndex = 0
-    @State private var normalSizeIndex = 2 // 기본값 24
+    @State private var normalSizeIndex = 3 // 기본값 24 (.xlarge)
     @State private var alternative = false
     @State private var disable = false
     @State private var showPushBadge = false

--- a/Sources/Blueprint/Sources/Scene/Previews/IconButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/IconButtonPreview.swift
@@ -13,6 +13,7 @@ struct IconButtonPreview: View {
     @State private var variantIndex = 0
     @State private var customSize: CGFloat = 24
     @State private var sizeIndex = 0
+    @State private var normalSizeIndex = 2 // 기본값 24
     @State private var alternative = false
     @State private var disable = false
     @State private var showPushBadge = false
@@ -20,21 +21,36 @@ struct IconButtonPreview: View {
     @State private var iconColor: SwiftUI.Color?
     @State private var backgroundColor: SwiftUI.Color?
     @State private var borderColor: SwiftUI.Color?
-    
+
     private var variants: [IconButton.Variant] {
         [
-            .normal(size: Int(customSize)),
+            .normal(size: resolvedNormalSize),
             .background(size: Int(customSize), isAlternative: alternative),
             .outlined(size: sizes[sizeIndex]),
             .solid(size: sizes[sizeIndex])
         ]
     }
-    
+
     private let sizes: [IconButton.Size] = [
         .small,
         .medium,
         .custom(size: 8)
     ]
+
+    private let normalSizes: [IconButton.NormalSize] = [.small, .medium, .large, .xlarge]
+    private let normalSizeLabels: [String] = ["small", "medium", "large", "xlarge", "custom"]
+
+    private var isNormalCustomSize: Bool {
+        normalSizeIndex == normalSizes.count
+    }
+
+    private var resolvedNormalSize: IconButton.NormalSize {
+        if isNormalCustomSize {
+            .custom(size: Int(customSize))
+        } else {
+            normalSizes[normalSizeIndex]
+        }
+    }
     
     private var currentVariant: IconButton.Variant {
         variants[variantIndex]
@@ -122,11 +138,31 @@ struct IconButtonPreview: View {
                     )
                     .size(.small)
                 }
-                HStack {
-                    Text("size")
-                    if variantIndex == 0 || variantIndex == 1 {
+                if variantIndex == 0 {
+                    HStack {
+                        Text("size")
+                        SegmentedControl(
+                            selectedIndex: $normalSizeIndex,
+                            labels: normalSizeLabels
+                        )
+                        .size(.small)
+                    }
+                    if isNormalCustomSize {
+                        HStack {
+                            Text("custom")
+                            SwiftUI.Slider(value: $customSize, in: 10...128, step: 1)
+                            Text("\(Int(customSize))")
+                        }
+                    }
+                } else if variantIndex == 1 {
+                    HStack {
+                        Text("size")
                         SwiftUI.Slider(value: $customSize, in: 10...128, step: 1)
-                    } else {
+                        Text("\(Int(customSize))")
+                    }
+                } else {
+                    HStack {
+                        Text("size")
                         SegmentedControl(
                             selectedIndex: $sizeIndex,
                             labels: sizes.map(\.description)

--- a/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
@@ -74,7 +74,7 @@ struct TextFieldPreview: View {
             case .iconButton:
                 return {
                     IconButton(
-                        variant: .normal(size: 8),
+                        variant: .normal(size: .custom(size: 8)),
                         icon: .send
                     )
                     .iconColor(.semantic(.labelAlternative))

--- a/Sources/Montage/1 Components/2 Actions/IconButton.swift
+++ b/Sources/Montage/1 Components/2 Actions/IconButton.swift
@@ -31,12 +31,12 @@ public struct IconButton: View {
     /// 아이콘 버튼을 생성합니다.
     ///
     /// - Parameters:
-    ///   - variant: 버튼의 외관 스타일, 생략하면 기본값으로 `.normal(size: 24)` 적용
+    ///   - variant: 버튼의 외관 스타일, 생략하면 기본값으로 `.normal(size: .xlarge)` 적용
     ///   - icon: 표시할 아이콘
     ///   - handler: 버튼 탭 시 실행할 핸들러
     /// - Returns: 구성된 아이콘 버튼 뷰
     public init(
-        variant: IconButton.Variant = .normal(size: 24),
+        variant: IconButton.Variant = .normal(size: .xlarge),
         icon: Icon,
         handler: (() -> Void)? = nil
     ) {
@@ -199,7 +199,7 @@ public struct IconButton: View {
                     variant: variant.interactionVariant,
                     color: variant.interactionColor
                 )
-                .clipShape(Circle())
+                .clipShape(variant.interactionShape)
                 .padding(.vertical, -interactionOffset)
                 .padding(.horizontal, -interactionOffset)
             }
@@ -234,23 +234,23 @@ extension IconButton {
     /// 아이콘 버튼의 다양한 스타일과 크기를 정의합니다.
     public enum Variant {
         /// 기본형 아이콘 버튼 - 배경 없이 아이콘만 표시
-        /// - Parameter size: 아이콘 크기 (픽셀)
-        case normal(size: Int)
-        
+        /// - Parameter size: 아이콘 크기 (`NormalSize`)
+        case normal(size: NormalSize)
+
         /// 배경형 아이콘 버튼 - 반투명 배경을 가진 아이콘
         /// - Parameters:
         ///   - size: 아이콘 크기 (픽셀)
         ///   - isAlternative: 대체 스타일 사용 여부, 생략하면 기본값으로 `false` 적용
         case background(size: Int, isAlternative: Bool = false)
-        
+
         /// 외곽선형 아이콘 버튼 - 테두리로 둘러싸인 아이콘
         /// - Parameter size: 아이콘 크기 (Size 열거형)
         case outlined(size: Size)
-        
+
         /// 솔리드형 아이콘 버튼 - 배경색이 채워진 아이콘
         /// - Parameter size: 아이콘 크기 (Size 열거형)
         case solid(size: Size)
-        
+
         fileprivate var isBackground: Bool {
             switch self {
             case .background: true
@@ -258,7 +258,32 @@ extension IconButton {
             }
         }
     }
-    
+
+    /// Normal variant의 아이콘 사이즈를 결정하는 열거형입니다.
+    public enum NormalSize {
+        /// 작은 크기 (16px)
+        case small
+        /// 중간 크기 (18px)
+        case medium
+        /// 큰 크기 (20px)
+        case large
+        /// 가장 큰 크기 (24px)
+        case xlarge
+        /// 사용자 지정 크기
+        /// - Parameter size: 아이콘 크기 (픽셀)
+        case custom(size: Int)
+
+        fileprivate var pixelSize: Int {
+            switch self {
+            case .small: 16
+            case .medium: 18
+            case .large: 20
+            case .xlarge: 24
+            case .custom(let size): size
+            }
+        }
+    }
+
     /// 버튼 사이즈를 결정하는 열거형입니다.
     public enum Size {
         /// 작은 크기
@@ -315,22 +340,22 @@ extension IconButton.Variant {
     var inactiveColor: UIColor {
         switch self {
         case .normal, .outlined, .solid:
-                .semantic(.labelDisable).withAlphaComponent(0.16)
+                .semantic(.labelDisable)
         case .background:
                 .atomic(.coolNeutral50).withAlphaComponent(0.22)
         }
     }
-    
+
     var borderWidth: CGFloat {
         switch self {
         case .outlined: 1
         default: .zero
         }
     }
-    
+
     var borderColor: UIColor {
         switch self {
-        case .outlined: .semantic(.lineNeutral)
+        case .outlined: .semantic(.lineNeutral).withAlphaComponent(0.16)
         default: .clear
         }
     }
@@ -354,32 +379,59 @@ extension IconButton.Variant {
         case .background(_, _): 6
         case let .outlined(size), let .solid(size):
             switch size {
-            case .small: 7
-            case .medium: 10
-            case .custom(_): 6
+            case .small: 8
+            case .medium: 11
+            case .custom(_): 7
             }
         }
     }
-    
+
     var interactionOffset: CGFloat {
         switch self {
-        case .normal: 8
-        case .background(_, _), .outlined(_), .solid(_): backgroundOffset
+        case .normal(let size):
+            switch size {
+            case .small: 4    // icon 16 → interaction 24
+            case .medium: 5   // icon 18 → interaction 28
+            case .large: 6    // icon 20 → interaction 32
+            case .xlarge: 8   // icon 24 → interaction 40
+            case .custom: 6
+            }
+        case .outlined(_): backgroundOffset + 1
+        case .background(_, _), .solid(_): backgroundOffset
         }
     }
-    
+
+    var interactionShape: AnyShape {
+        switch self {
+        case .normal(let size):
+            let radius: CGFloat
+            switch size {
+            case .small: radius = 8
+            case .medium: radius = 8
+            case .large: radius = 10
+            case .xlarge: radius = 12
+            case .custom: radius = 10
+            }
+            return AnyShape(RoundedRectangle(cornerRadius: radius))
+        case .background, .outlined, .solid:
+            return AnyShape(Circle())
+        }
+    }
+
     var iconSize: CGSize {
         switch self {
-        case .normal(let size): .init(width: size, height: size)
-        case .background(let size, _): .init(width: size, height: size)
+        case .normal(let size):
+            let dim = CGFloat(size.pixelSize)
+            return .init(width: dim, height: dim)
+        case .background(let size, _): return .init(width: size, height: size)
         case .outlined(let variant), .solid(let variant):
             switch variant {
             case .small:
-                    .init(width: 18, height: 18)
+                return .init(width: 16, height: 16)
             case .medium:
-                    .init(width: 20, height: 20)
+                return .init(width: 18, height: 18)
             case .custom(let size):
-                    .init(width: size, height: size)
+                return .init(width: size, height: size)
             }
         }
     }

--- a/Sources/Montage/1 Components/2 Actions/IconButton.swift
+++ b/Sources/Montage/1 Components/2 Actions/IconButton.swift
@@ -172,8 +172,8 @@ public struct IconButton: View {
         }
     }
     
-    private var interactionOffset: CGFloat {
-        variant.interactionOffset + padding
+    private var interactionExpansion: CGFloat {
+        variant.interactionExpansion + padding
     }
     
     /// 뷰의 내용과 동작을 정의합니다.
@@ -200,8 +200,8 @@ public struct IconButton: View {
                     color: variant.interactionColor
                 )
                 .clipShape(variant.interactionShape)
-                .padding(.vertical, -interactionOffset)
-                .padding(.horizontal, -interactionOffset)
+                .padding(.vertical, -interactionExpansion)
+                .padding(.horizontal, -interactionExpansion)
             }
             .padding(.all, variant.backgroundOffset + padding)
             .background(
@@ -239,7 +239,7 @@ extension IconButton {
 
         /// 배경형 아이콘 버튼 - 반투명 배경을 가진 아이콘
         /// - Parameters:
-        ///   - size: 아이콘 크기 (픽셀)
+        ///   - size: 아이콘 크기 (포인트)
         ///   - isAlternative: 대체 스타일 사용 여부, 생략하면 기본값으로 `false` 적용
         case background(size: Int, isAlternative: Bool = false)
 
@@ -261,19 +261,19 @@ extension IconButton {
 
     /// Normal variant의 아이콘 사이즈를 결정하는 열거형입니다.
     public enum NormalSize {
-        /// 작은 크기 (16px)
+        /// 작은 크기 (16pt)
         case small
-        /// 중간 크기 (18px)
+        /// 중간 크기 (18pt)
         case medium
-        /// 큰 크기 (20px)
+        /// 큰 크기 (20pt)
         case large
-        /// 가장 큰 크기 (24px)
+        /// 가장 큰 크기 (24pt)
         case xlarge
         /// 사용자 지정 크기
-        /// - Parameter size: 아이콘 크기 (픽셀)
+        /// - Parameter size: 아이콘 크기 (포인트)
         case custom(size: Int)
 
-        fileprivate var pixelSize: Int {
+        fileprivate var points: Int {
             switch self {
             case .small: 16
             case .medium: 18
@@ -291,7 +291,7 @@ extension IconButton {
         /// 중간 크기
         case medium
         /// 사용자 지정 크기
-        /// - Parameter size: 아이콘 크기 (픽셀)
+        /// - Parameter size: 아이콘 크기 (포인트)
         case custom(size: Int)
     }
 }
@@ -386,7 +386,7 @@ extension IconButton.Variant {
         }
     }
 
-    var interactionOffset: CGFloat {
+    var interactionExpansion: CGFloat {
         switch self {
         case .normal(let size):
             switch size {
@@ -421,7 +421,7 @@ extension IconButton.Variant {
     var iconSize: CGSize {
         switch self {
         case .normal(let size):
-            let dim = CGFloat(size.pixelSize)
+            let dim = CGFloat(size.points)
             return .init(width: dim, height: dim)
         case .background(let size, _): return .init(width: size, height: size)
         case .outlined(let variant), .solid(let variant):

--- a/Sources/Montage/1 Components/3 Selection And Input/Control.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Control.swift
@@ -233,8 +233,8 @@ struct Control: View {
     /// 컨트롤을 더 조밀한 레이아웃으로 표시합니다.
     ///
     /// 이 수정자를 적용하면 컨트롤의 가로 너비가 줄어듭니다.
-    /// - medium: 24px → 20px
-    /// - small: 20px → 16px
+    /// - medium: 24pt → 20pt
+    /// - small: 20pt → 16pt
     ///
     /// - Parameter tight: 조밀한 레이아웃 적용 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 컨트롤 인스턴스

--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -376,7 +376,7 @@ public struct Select: View {
                     }
 
                     IconButton(
-                        variant: .normal(size: 16),
+                        variant: .normal(size: .small),
                         icon: .chevronDownThickSmall
                     ) {
                         menuPresented.wrappedValue.toggle()

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -335,7 +335,7 @@ private extension TextField {
                     
                     if !text.isEmpty, textFieldFocusState {
                         IconButton(
-                            variant: .normal(size: 22),
+                            variant: .normal(size: .custom(size: 22)),
                             icon: .circleCloseFill
                         ) {
                             text = ""

--- a/Sources/Montage/1 Components/4 Contents/Card.swift
+++ b/Sources/Montage/1 Components/4 Contents/Card.swift
@@ -295,7 +295,7 @@ extension Card {
 
                                 if let buttonIcon {
                                     Montage.IconButton(
-                                        variant: .normal(size: 20),
+                                        variant: .normal(size: .large),
                                         icon: buttonIcon
                                     ) {
                                         onTapButton?()

--- a/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
+++ b/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
@@ -91,7 +91,7 @@ public struct Thumbnail: View {
 
         /// 비율에 해당하는 크기를 반환합니다.
         ///
-        /// - Note: 이 값은 상대적 비율을 나타내며 실제 픽셀 크기가 아닙니다.
+        /// - Note: 이 값은 상대적 비율을 나타내며 실제 포인트 크기가 아닙니다.
         var size: CGSize {
             switch self {
             // 가로가 긴 비율

--- a/Sources/Montage/1 Components/6 Navigations/Category.swift
+++ b/Sources/Montage/1 Components/6 Navigations/Category.swift
@@ -121,7 +121,7 @@ public struct Category: View {
                 )
                 
                 if let icon, let iconButtonAction {
-                    IconButton(variant: .normal(size: iconSize), icon: icon) {
+                    IconButton(variant: .normal(size: .custom(size: iconSize)), icon: icon) {
                         iconButtonAction()
                     }
                     .padding(.trailing, horizontalPadding ? 16 : 0)

--- a/Sources/Montage/1 Components/6 Navigations/Tab.swift
+++ b/Sources/Montage/1 Components/6 Navigations/Tab.swift
@@ -172,7 +172,7 @@ public struct Tab: View {
                         }
                     
                         if resize == .hug, let icon, let iconButtonAction {
-                            IconButton(variant: .normal(size: iconSize), icon: icon) {
+                            IconButton(variant: .normal(size: .custom(size: iconSize)), icon: icon) {
                                 iconButtonAction()
                             }
                             .padding(.trailing, horizontalPadding ? 16 : 0)

--- a/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
+++ b/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
@@ -202,7 +202,7 @@ public struct SnackBar: View {
                     
                     if closeButton {
                         Spacer().frame(width: 12)
-                        IconButton(variant: .normal(size: 20), icon: .close) {
+                        IconButton(variant: .normal(size: .large), icon: .close) {
                             dismiss()
                         }
                         .iconColor(.semantic(.staticWhite).opacity(0.61))

--- a/Sources/Montage/1 Components/8 Presentation/Popover.swift
+++ b/Sources/Montage/1 Components/8 Presentation/Popover.swift
@@ -106,7 +106,7 @@ public enum Popover {
                         }
                     }
                     if closeButton {
-                        IconButton(variant: .normal(size: 16), icon: .close) {
+                        IconButton(variant: .normal(size: .small), icon: .close) {
                             isPresented = false
                         }
                         .padding(.all, 3)

--- a/documentation/components/actions/iconbutton/ios.md
+++ b/documentation/components/actions/iconbutton/ios.md
@@ -37,7 +37,7 @@ IconButton(
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `variant` | 버튼의 외관 스타일, 생략하면 기본값으로 `.normal(size: 24)` 적용 |
+  | `variant` | 버튼의 외관 스타일, 생략하면 기본값으로 `.normal(size: .xlarge)` 적용 |
   | `icon` | 표시할 아이콘 |
   | `handler` | 버튼 탭 시 실행할 핸들러 |
 </details>
@@ -169,6 +169,56 @@ IconButton(
 
 <details>
 
+<summary>``enum NormalSize``</summary>
+
+
+Normal variant의 아이콘 사이즈를 결정하는 열거형입니다.
+#### Enumeration Cases
+
+<details>
+
+<summary>``case custom(size: Int)``</summary>
+
+
+사용자 지정 크기
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `size` | 아이콘 크기 (픽셀) |
+</details>
+<details>
+
+<summary>``case large``</summary>
+
+
+큰 크기 (20px)
+</details>
+<details>
+
+<summary>``case medium``</summary>
+
+
+중간 크기 (18px)
+</details>
+<details>
+
+<summary>``case small``</summary>
+
+
+작은 크기 (16px)
+</details>
+<details>
+
+<summary>``case xlarge``</summary>
+
+
+가장 큰 크기 (24px)
+</details>
+
+</details>
+<details>
+
 <summary>``enum Size``</summary>
 
 
@@ -226,7 +276,7 @@ IconButton(
 </details>
 <details>
 
-<summary>``case normal(size: Int)``</summary>
+<summary>``case normal(size: NormalSize)``</summary>
 
 
 기본형 아이콘 버튼 - 배경 없이 아이콘만 표시
@@ -234,7 +284,7 @@ IconButton(
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `size` | 아이콘 크기 (픽셀) |
+  | `size` | 아이콘 크기 (`NormalSize`) |
 </details>
 <details>
 

--- a/documentation/components/actions/iconbutton/ios.md
+++ b/documentation/components/actions/iconbutton/ios.md
@@ -185,35 +185,35 @@ Normal variant의 아이콘 사이즈를 결정하는 열거형입니다.
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `size` | 아이콘 크기 (픽셀) |
+  | `size` | 아이콘 크기 (포인트) |
 </details>
 <details>
 
 <summary>``case large``</summary>
 
 
-큰 크기 (20px)
+큰 크기 (20pt)
 </details>
 <details>
 
 <summary>``case medium``</summary>
 
 
-중간 크기 (18px)
+중간 크기 (18pt)
 </details>
 <details>
 
 <summary>``case small``</summary>
 
 
-작은 크기 (16px)
+작은 크기 (16pt)
 </details>
 <details>
 
 <summary>``case xlarge``</summary>
 
 
-가장 큰 크기 (24px)
+가장 큰 크기 (24pt)
 </details>
 
 </details>
@@ -235,7 +235,7 @@ Normal variant의 아이콘 사이즈를 결정하는 열거형입니다.
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `size` | 아이콘 크기 (픽셀) |
+  | `size` | 아이콘 크기 (포인트) |
 </details>
 <details>
 
@@ -271,7 +271,7 @@ Normal variant의 아이콘 사이즈를 결정하는 열거형입니다.
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `size` | 아이콘 크기 (픽셀) |
+  | `size` | 아이콘 크기 (포인트) |
   | `isAlternative` | 대체 스타일 사용 여부, 생략하면 기본값으로 `false` 적용 |
 </details>
 <details>

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -1077,6 +1077,18 @@
       "staticMembers": [],
       "nestedTypes": [
         {
+          "name": "IconButton.NormalSize",
+          "kind": "enum",
+          "summary": "Normal variant의 아이콘 사이즈를 결정하는 열거형입니다.",
+          "cases": [
+            "custom",
+            "large",
+            "medium",
+            "small",
+            "xlarge"
+          ]
+        },
+        {
           "name": "IconButton.Size",
           "kind": "enum",
           "summary": "버튼 사이즈를 결정하는 열거형입니다.",

--- a/packages/montage-mcp/data/markdown/coding-guidelines.md
+++ b/packages/montage-mcp/data/markdown/coding-guidelines.md
@@ -86,7 +86,7 @@ Button(
 ## 6. 접근성
 
 - 모든 인터랙티브 컴포넌트는 의미 있는 라벨/힌트를 제공한다.
-- Dynamic Type을 깨지 않게, 폰트 크기를 직접 픽셀로 고정하지 않는다 (Typography 토큰 사용).
+- Dynamic Type을 깨지 않게, 폰트 크기를 직접 포인트로 고정하지 않는다 (Typography 토큰 사용).
 - VoiceOver 그룹핑이 필요하면 `.accessibilityElement(children: .combine)`.
 
 ## 7. 미지원 케이스 처리


### PR DESCRIPTION
# 개요
- 이슈 링크 :

# 수정사항

## API breaking change
- `IconButton.Variant.normal(size: Int)` → **`.normal(size: NormalSize)`**
- 신규 `IconButton.NormalSize` enum
  - `.small`(16) / `.medium`(18) / `.large`(20) / `.xlarge`(24) / `.custom(size:)`
- 기본값: `.normal(size: .xlarge)` (=24, 기존 동작 보존)

## Normal variant
| 항목 | Before | After |
|---|---|---|
| Interaction shape | `Circle()` | `RoundedRectangle` (사이즈별 radius) |
| Interaction radius | — | small/medium: 8, large: 10, xlarge: 12 |
| Interaction frame | 40x40 (offset 8 고정) | small: 24, medium: 28, large: 32, xlarge: 40 |
| Disable icon color | `.labelDisable.opacity(0.16)` | `.labelDisable` (시안 #37383C) |

## Outlined / Solid variant
| 항목 | Before | After |
|---|---|---|
| `.small` icon | 18 | 16 |
| `.medium` icon | 20 | 18 |
| `.small` padding | 7 | 8 |
| `.medium` padding | 10 | 11 |
| `.custom` padding | 6 | 7 |
| Outlined border | `.lineNeutral` | `.lineNeutral.opacity(0.16)` |
| Outlined Interaction | border 안쪽까지 | border 바깥 1px까지 확장 |
| Disable icon color | `.labelDisable.opacity(0.16)` | `.labelDisable` |

## 호출처 마이그레이션
`Tab` / `Category` / `Select` / `TextField` / `SnackBar` / `Card` / `Popover` / `TextFieldPreview` 모두 새 `NormalSize` enum 사용으로 갱신. 시안에 없는 픽셀값(8, 22)은 `.custom(size:)`로 변환해 시각적 픽셀값 보존.

## Blueprint
- `IconButtonPreview`의 normal size UI를 `[small][medium][large][xlarge][custom]` SegmentedControl로 변경
- custom 선택 시 슬라이더 + 현재 값 라벨 노출

## 자동 생성
- `make`로 DocC 및 MCP 데이터 갱신 (`documentation/components/actions/iconbutton/ios.md`, `packages/montage-mcp/data/components.json`)

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷