### PR TITLE
feat(Button): spec 정합 — radius·minHeight·컬러·타이포 갱신 및 폴백 정책 변경

### DIFF
--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -52,7 +52,7 @@ public struct Button: View {
         /// 부정적·위험 액션 스타일 - 삭제, 경고 등에 사용
         ///
         /// > Important: `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않습니다.
-        /// > 해당 조합으로 버튼을 생성하면 자동으로 `.solid`로 대체됩니다.
+        /// > 해당 조합으로 버튼을 생성하면 color가 `.primary`로 폴백됩니다.
         case negative
     }
 
@@ -103,13 +103,7 @@ public struct Button: View {
         trailingIcon: Icon? = nil,
         handler: (() -> Void)? = nil
     ) {
-        let resolvedColor: Color
-        if variant == .outlined && color == .negative {
-            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to color `.primary`.")
-            resolvedColor = .primary
-        } else {
-            resolvedColor = color
-        }
+        let resolvedColor = Self.resolveColor(variant: variant, color: color)
         let resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
         self.init(
             resolvedVariant,
@@ -143,13 +137,7 @@ public struct Button: View {
         icon: Icon,
         handler: (() -> Void)? = nil
     ) {
-        let resolvedColor: Color
-        if variant == .outlined && color == .negative {
-            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to color `.primary`.")
-            resolvedColor = .primary
-        } else {
-            resolvedColor = color
-        }
+        let resolvedColor = Self.resolveColor(variant: variant, color: color)
         let resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
         self.init(
             resolvedVariant,
@@ -401,6 +389,14 @@ public struct Button: View {
 }
 
 private extension Button {
+    static func resolveColor(variant: Variant, color: Color) -> Color {
+        if variant == .outlined && color == .negative {
+            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to color `.primary`.")
+            return .primary
+        }
+        return color
+    }
+    
     var backgroundColor: SwiftUI.Color {
         switch variant {
         case .solid:
@@ -530,11 +526,7 @@ private extension Button {
     }
     
     var typoWeight: Typography.Weight {
-        switch color {
-        case .primary: .bold
-        case .assistive: .bold
-        case .negative: .bold
-        }
+        .bold
     }
     
     var cornerRadius: CGFloat {

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -103,16 +103,17 @@ public struct Button: View {
         trailingIcon: Icon? = nil,
         handler: (() -> Void)? = nil
     ) {
-        let resolvedVariant: InternalVariant
+        let resolvedColor: Color
         if variant == .outlined && color == .negative {
-            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to `.solid`.")
-            resolvedVariant = .solid
+            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to color `.primary`.")
+            resolvedColor = .primary
         } else {
-            resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
+            resolvedColor = color
         }
+        let resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
         self.init(
             resolvedVariant,
-            color: color,
+            color: resolvedColor,
             size: size,
             text: text,
             leadingIcon: leadingIcon,
@@ -142,16 +143,17 @@ public struct Button: View {
         icon: Icon,
         handler: (() -> Void)? = nil
     ) {
-        let resolvedVariant: InternalVariant
+        let resolvedColor: Color
         if variant == .outlined && color == .negative {
-            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to `.solid`.")
-            resolvedVariant = .solid
+            print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to color `.primary`.")
+            resolvedColor = .primary
         } else {
-            resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
+            resolvedColor = color
         }
+        let resolvedVariant = InternalVariant(rawValue: variant.rawValue) ?? .solid
         self.init(
             resolvedVariant,
-            color: color,
+            color: resolvedColor,
             size: size,
             leadingIcon: icon,
             handler: handler
@@ -369,7 +371,7 @@ public struct Button: View {
         }
         .fixedSize(horizontal: !fillHorizontal, vertical: !fillVertical)
         .contentShape(Rectangle())
-        .frame(height: contentHeight)
+        .frame(minHeight: contentHeight)
         .padding(edgeInsets)
         .background {
             RoundedRectangle(cornerRadius: cornerRadius)
@@ -428,7 +430,7 @@ private extension Button {
     var borderColor: SwiftUI.Color {
         if variant == .outlined {
             if disable {
-                .semantic(.lineNormal)
+                .semantic(.lineNeutral)
             } else {
                 if let customBorderColor {
                     customBorderColor
@@ -445,7 +447,7 @@ private extension Button {
         switch variant {
         case .solid:
             if disable {
-                .semantic(.labelAssistive)
+                .semantic(.labelDisable)
             } else if let contentColor {
                 contentColor
             } else {
@@ -530,7 +532,7 @@ private extension Button {
     var typoWeight: Typography.Weight {
         switch color {
         case .primary: .bold
-        case .assistive: variant == .text ? .bold : .medium
+        case .assistive: .bold
         case .negative: .bold
         }
     }
@@ -540,7 +542,7 @@ private extension Button {
             6.0
         } else {
             switch size {
-            case .xsmall: 10.0
+            case .xsmall: 8.0
             case .small: 10.0
             case .medium: 12.0
             case .large: 14.0

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -391,7 +391,9 @@ public struct Button: View {
 private extension Button {
     static func resolveColor(variant: Variant, color: Color) -> Color {
         if variant == .outlined && color == .negative {
+            #if DEBUG
             print("[Montage] Button: variant `.outlined` does not support color `.negative`. Falling back to color `.primary`.")
+            #endif
             return .primary
         }
         return color

--- a/documentation/components/actions/button/ios.md
+++ b/documentation/components/actions/button/ios.md
@@ -317,7 +317,7 @@ Button(text: "저장")
 - **Discussion**
   >  **Important**
   >
-  > `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않습니다. 해당 조합으로 버튼을 생성하면 자동으로 `.solid`로 대체됩니다.
+  > `variant`가 `.outlined`인 경우 `.negative`는 지원되지 않습니다. 해당 조합으로 버튼을 생성하면 color가 `.primary`로 폴백됩니다.
 
 </details>
 <details>


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-862

# 수정사항
- xsmall border-radius `10 → 8` (radius[8])
- height 고정 → `minHeight` 정책으로 전환해 Dynamic Type 지원
- outlined + negative 조합 시 `color → primary` 로 폴백 (variant 유지)
- solid disabled foreground: `labelAssistive → labelDisable`
- outlined disabled border: `lineNormal → lineNeutral` (enabled 와 통일)
- assistive 비-text variant typoWeight: `medium → bold`

# 참고
- Spec 출처: [Confluence — UX/Button (2026-05-27 Change Log)](https://wantedlab.atlassian.net/wiki/spaces/UX/pages/4806639757/Button)
- 시각 검증: Blueprint 앱의 ButtonPreview 에서 확인됨