### PR TITLE
chore: 릴리즈 시 docs-sync workflow 직접 호출하도록 단순화

### DIFF
--- a/.github/workflows/auto-deploy-docs.yml
+++ b/.github/workflows/auto-deploy-docs.yml
@@ -1,6 +1,7 @@
 name: Auto Docs Sync/Deploy on Release
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/auto-deploy-docs.yml
+++ b/.github/workflows/auto-deploy-docs.yml
@@ -5,13 +5,7 @@ on:
     types: [published]
 
 jobs:
-  sync:
-    uses: wanteddev/montage-web/.github/workflows/docs-sync.yml@main
-    secrets: inherit
-
-  deploy:
-    needs: sync
-    if: needs.sync.outputs.has_changes == 'true'
+  sync-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token
@@ -28,8 +22,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          gh workflow run docs-deploy.yml \
+          gh workflow run docs-sync.yml \
             --repo wanteddev/montage-web \
-            --ref "${{ needs.sync.outputs.branch }}" \
-            -f server_type=www \
-            -f algolia=true
+            --ref "main" \
+            -f platform=mobile \
+            -f deploy=true


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

# 수정사항
- 릴리즈 발행 시 `docs-deploy.yml`을 직접 호출하던 구조를 `docs-sync.yml` 호출로 변경
- sync/deploy 두 잡을 단일 `sync-and-deploy` 잡으로 통합
- `docs-sync.yml`의 `platform=mobile`, `deploy=true` 입력을 전달하여 sync 이후 배포까지 한 번에 트리거

# 미리보기
워크플로 변경 — 미리보기 해당 없음