### PR TITLE
feat: TextButton 타이포·아이콘·모서리·Interaction 토큰 갱신

### DIFF
--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -508,7 +508,7 @@ private extension Button {
         case .small:
             .init(width: 16, height: 16)
         case .medium:
-            .init(width: variant == .text ? 20 : 18, height: variant == .text ? 20 : 18)
+            .init(width: 18, height: 18)
         case .large:
             .init(width: 20, height: 20)
         }
@@ -521,7 +521,7 @@ private extension Button {
         case .small:
             variant == .text ? .label1 : .caption1
         case .medium:
-            variant == .text ? .body1 : .label1
+            variant == .text ? .body2 : .label1
         case .large:
             variant == .text ? .body1 : .body2
         }
@@ -533,7 +533,10 @@ private extension Button {
     
     var cornerRadius: CGFloat {
         if variant == .text {
-            6.0
+            switch size {
+            case .xsmall, .small: 8.0
+            case .medium, .large: 10.0
+            }
         } else {
             switch size {
             case .xsmall: 8.0
@@ -548,8 +551,8 @@ private extension Button {
         switch size {
         case .xsmall: 16
         case .small: variant == .text ? 20 : 16
-        case .medium: variant == .text ? 24 : 20
-        case .large: variant == .text ? 24 : 22
+        case .medium: variant == .text ? 22 : 20
+        case .large: 22
         }
     }
 
@@ -602,15 +605,21 @@ private extension Button {
     }
 
     var interactionVerticalOffset: CGFloat { variant == .text ? 4 : 0 }
-    var interactionHorizontalOffset: CGFloat { variant == .text ? 7 : 0 }
+    var interactionHorizontalOffset: CGFloat {
+        guard variant == .text else { return 0 }
+        return switch size {
+        case .xsmall, .small: 6
+        case .medium, .large: 8
+        }
+    }
     
     var loadingSize: CGSize {
-        let dim: CGFloat
+        let dimension: CGFloat
         switch size {
-        case .xsmall, .small: dim = 12
-        case .medium: dim = 14
-        case .large: dim = 16
+        case .xsmall, .small: dimension = 12
+        case .medium: dimension = 14
+        case .large: dimension = 16
         }
-        return .init(width: dim, height: dim)
+        return .init(width: dimension, height: dimension)
     }
 }


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-941

TextButton(Button의 `.text` variant) 사이즈 토큰을 디자인 시안에 맞춰 갱신합니다. 변경은 `.text` 분기에 한정되어 `solid`/`outlined` 버튼에는 영향이 없습니다.

# 수정사항
| 속성 | Small | Medium |
|---|---|---|
| 타이포 | Label1 (변경 없음) | Body1 → **Body2** |
| 아이콘 | 16 (변경 없음) | 20 → **18** |
| 모서리(Interaction) | 6 → **8** | 6 → **10** |
| Interaction 가로 오프셋 | 7 → **6** | 7 → **8** |
| Interaction 세로 오프셋 | 4 (변경 없음) | 4 (변경 없음) |

- Loading 크기·min-height는 4.0 사이즈 토큰 갱신(`c40638cb5`)·기존 `minHeight: contentHeight`에 이미 반영되어 변경하지 않았습니다.
- Figma dev 스펙 재확인 결과 Small 가로 오프셋도 `7→6`으로 함께 정정했습니다(티켓엔 Medium만 명시).

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷

> Figma 시안(node `26933-125045`) 기준 구현. Ready 전환 전 Blueprint 스크린샷 첨부 예정.
