### PR TITLE
feat: radius full 토큰 추가

### DIFF
--- a/Sources/Montage/1 Components/9 Utilities/Primitive.swift
+++ b/Sources/Montage/1 Components/9 Utilities/Primitive.swift
@@ -37,11 +37,8 @@ public enum Primitive {
     /// 정의된 primitive 토큰 중 최소값.
     public static var min: CGFloat { allValues.first ?? 0 }
 
-    /// 정의된 primitive 토큰 중 최대 유한값(`primitiveInfinity` 제외).
-    ///
-    /// 범위 검증이나 슬라이더 제약 계산처럼 유한값이 필요한 곳에서 사용한다.
-    /// `allValues`에 포함된 `primitiveInfinity`는 제외된다.
-    public static var finiteMax: CGFloat { allValues.last(where: { $0.isFinite }) ?? 0 }
+    /// 정의된 primitive 토큰 중 최대값. `primitiveInfinity`은 포함되지 않는다.
+    public static var max: CGFloat { allValues.last(where: { $0.isFinite }) ?? 0 }
 }
 
 public extension CGFloat {

--- a/Sources/Montage/1 Components/9 Utilities/Radius.swift
+++ b/Sources/Montage/1 Components/9 Utilities/Radius.swift
@@ -35,6 +35,13 @@ public enum Radius {
 
     /// 정의된 radius 토큰 중 최대값. `full`(pill)은 포함되지 않는다.
     public static var max: CGFloat { allValues.last ?? 0 }
+
+    /// 모서리를 완전히 둥글게(pill/capsule) 만드는 radius 값.
+    ///
+    /// 실제 값은 무한대(`primitiveInfinity`)이며, 적용 시 컴포넌트의 짧은 변
+    /// 길이의 절반으로 클램프되어 항상 완전한 둥근 형태가 된다. 고정된 유한
+    /// 토큰이 아니므로 `allValues`/`max`에는 포함되지 않는다.
+    public static var full: CGFloat { .radiusFull }
 }
 
 public extension CGFloat {
@@ -56,4 +63,17 @@ public extension CGFloat {
     static let radius20: CGFloat = .primitive20
     /// 24pt의 모서리 반경
     static let radius24: CGFloat = .primitive24
+    /// 모서리를 완전히 둥글게(pill/capsule) 만드는 모서리 반경.
+    ///
+    /// 무한대 값으로, 적용 대상의 짧은 변 길이의 절반으로 클램프되어 항상
+    /// 완전한 둥근 형태를 보장한다. Figma `full` 토큰에 대응한다.
+    ///
+    /// ```swift
+    /// // SwiftUI
+    /// RoundedRectangle(cornerRadius: .radiusFull)
+    ///
+    /// // UIKit
+    /// view.layer.cornerRadius = .radiusFull
+    /// ```
+    static let radiusFull: CGFloat = .primitiveInfinity
 }

--- a/Sources/Montage/1 Components/9 Utilities/Radius.swift
+++ b/Sources/Montage/1 Components/9 Utilities/Radius.swift
@@ -27,21 +27,14 @@ public enum Radius {
     /// 토큰이 추가/삭제되면 이 배열만 갱신하면 사용처가 자동으로 반영된다.
     public static let allValues: [CGFloat] = [
         .radius0, .radius4, .radius8, .radius10, .radius12, .radius14,
-        .radius16, .radius20, .radius24
+        .radius16, .radius20, .radius24, .radiusFull
     ]
 
     /// 정의된 radius 토큰 중 최소값.
     public static var min: CGFloat { allValues.first ?? 0 }
 
-    /// 정의된 radius 토큰 중 최대값. `full`(pill)은 포함되지 않는다.
-    public static var max: CGFloat { allValues.last ?? 0 }
-
-    /// 모서리를 완전히 둥글게(pill/capsule) 만드는 radius 값.
-    ///
-    /// 실제 값은 무한대(`primitiveInfinity`)이며, 적용 시 컴포넌트의 짧은 변
-    /// 길이의 절반으로 클램프되어 항상 완전한 둥근 형태가 된다. 고정된 유한
-    /// 토큰이 아니므로 `allValues`/`max`에는 포함되지 않는다.
-    public static var full: CGFloat { .radiusFull }
+    /// 정의된 radius 토큰 중 최대값. `radiusFull`은 포함되지 않는다.
+    public static var max: CGFloat { allValues.last(where: { $0.isFinite }) ?? 0 }
 }
 
 public extension CGFloat {
@@ -63,17 +56,6 @@ public extension CGFloat {
     static let radius20: CGFloat = .primitive20
     /// 24pt의 모서리 반경
     static let radius24: CGFloat = .primitive24
-    /// 모서리를 완전히 둥글게(pill/capsule) 만드는 모서리 반경.
-    ///
-    /// 무한대 값으로, 적용 대상의 짧은 변 길이의 절반으로 클램프되어 항상
-    /// 완전한 둥근 형태를 보장한다. Figma `full` 토큰에 대응한다.
-    ///
-    /// ```swift
-    /// // SwiftUI
-    /// RoundedRectangle(cornerRadius: .radiusFull)
-    ///
-    /// // UIKit
-    /// view.layer.cornerRadius = .radiusFull
-    /// ```
+    /// 모서리를 완전히 둥글게 만드는 모서리 반경
     static let radiusFull: CGFloat = .primitiveInfinity
 }

--- a/documentation/utilities/ios-extensions/corefoundation.md
+++ b/documentation/utilities/ios-extensions/corefoundation.md
@@ -441,6 +441,25 @@ title: CoreFoundation
 </details>
 <details>
 
+<summary>``static let radiusFull: CGFloat``</summary>
+
+
+모서리를 완전히 둥글게(pill/capsule) 만드는 모서리 반경.
+- **Discussion**
+
+  무한대 값으로, 적용 대상의 짧은 변 길이의 절반으로 클램프되어 항상 완전한 둥근 형태를 보장한다. Figma `full` 토큰에 대응한다.
+
+  ```swift
+  // SwiftUI
+  RoundedRectangle(cornerRadius: .radiusFull)
+  
+  // UIKit
+  view.layer.cornerRadius = .radiusFull
+  ```
+
+</details>
+<details>
+
 <summary>``static let spacing0: CGFloat``</summary>
 
 

--- a/documentation/utilities/ios-extensions/corefoundation.md
+++ b/documentation/utilities/ios-extensions/corefoundation.md
@@ -444,19 +444,7 @@ title: CoreFoundation
 <summary>``static let radiusFull: CGFloat``</summary>
 
 
-모서리를 완전히 둥글게(pill/capsule) 만드는 모서리 반경.
-- **Discussion**
-
-  무한대 값으로, 적용 대상의 짧은 변 길이의 절반으로 클램프되어 항상 완전한 둥근 형태를 보장한다. Figma `full` 토큰에 대응한다.
-
-  ```swift
-  // SwiftUI
-  RoundedRectangle(cornerRadius: .radiusFull)
-  
-  // UIKit
-  view.layer.cornerRadius = .radiusFull
-  ```
-
+모서리를 완전히 둥글게 만드는 모서리 반경
 </details>
 <details>
 

--- a/documentation/utilities/ios-utility-components/primitive.md
+++ b/documentation/utilities/ios-utility-components/primitive.md
@@ -39,13 +39,10 @@ let custom = CGFloat.primitive18
 </details>
 <details>
 
-<summary>``static var finiteMax: CGFloat``</summary>
+<summary>``static var max: CGFloat``</summary>
 
 
-정의된 primitive 토큰 중 최대 유한값(`primitiveInfinity` 제외).
-- **Discussion**
-
-  범위 검증이나 슬라이더 제약 계산처럼 유한값이 필요한 곳에서 사용한다. `allValues`에 포함된 `primitiveInfinity`는 제외된다.
+정의된 primitive 토큰 중 최대값. `primitiveInfinity`은 포함되지 않는다.
 </details>
 <details>
 

--- a/documentation/utilities/ios-utility-components/radius.md
+++ b/documentation/utilities/ios-utility-components/radius.md
@@ -39,20 +39,10 @@ view.layer.cornerRadius = .radius12
 </details>
 <details>
 
-<summary>``static var full: CGFloat``</summary>
-
-
-모서리를 완전히 둥글게(pill/capsule) 만드는 radius 값.
-- **Discussion**
-
-  실제 값은 무한대(`primitiveInfinity`)이며, 적용 시 컴포넌트의 짧은 변 길이의 절반으로 클램프되어 항상 완전한 둥근 형태가 된다. 고정된 유한 토큰이 아니므로 `allValues`/`max`에는 포함되지 않는다.
-</details>
-<details>
-
 <summary>``static var max: CGFloat``</summary>
 
 
-정의된 radius 토큰 중 최대값. `full`(pill)은 포함되지 않는다.
+정의된 radius 토큰 중 최대값. `radiusFull`은 포함되지 않는다.
 </details>
 <details>
 

--- a/documentation/utilities/ios-utility-components/radius.md
+++ b/documentation/utilities/ios-utility-components/radius.md
@@ -39,6 +39,16 @@ view.layer.cornerRadius = .radius12
 </details>
 <details>
 
+<summary>``static var full: CGFloat``</summary>
+
+
+모서리를 완전히 둥글게(pill/capsule) 만드는 radius 값.
+- **Discussion**
+
+  실제 값은 무한대(`primitiveInfinity`)이며, 적용 시 컴포넌트의 짧은 변 길이의 절반으로 클램프되어 항상 완전한 둥근 형태가 된다. 고정된 유한 토큰이 아니므로 `allValues`/`max`에는 포함되지 않는다.
+</details>
+<details>
+
 <summary>``static var max: CGFloat``</summary>
 
 

--- a/packages/montage-mcp/data/tokens.json
+++ b/packages/montage-mcp/data/tokens.json
@@ -419,7 +419,6 @@
           "anchor": "Type-Properties",
           "identifiers": [
             "allValues",
-            "full",
             "max",
             "min"
           ]
@@ -454,7 +453,7 @@
           "anchor": "Type-Properties",
           "identifiers": [
             "allValues",
-            "finiteMax",
+            "max",
             "min"
           ]
         }

--- a/packages/montage-mcp/data/tokens.json
+++ b/packages/montage-mcp/data/tokens.json
@@ -419,6 +419,7 @@
           "anchor": "Type-Properties",
           "identifiers": [
             "allValues",
+            "full",
             "max",
             "min"
           ]


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

모서리를 완전히 둥글게(pill/capsule) 표현하기 위한 `radius full` 토큰을 추가합니다.

# 수정사항
- `CGFloat.radiusFull` 추가 — 값은 `.primitiveInfinity`(무한대, Figma `full` 토큰 대응). 적용 대상의 짧은 변 길이 절반으로 자동 클램프되어 항상 완전한 pill/capsule 형태가 됩니다.
- 고정 유한값이 아니므로 `Radius.allValues` / `min` / `max`에는 **포함하지 않음** (스냅·슬라이더 범위 계산이 무한대로 깨지지 않도록).
- `make`로 DocC 문서 및 MCP 토큰 데이터 재생성.

```swift
// SwiftUI
RoundedRectangle(cornerRadius: .radiusFull)

// UIKit
view.layer.cornerRadius = .radiusFull
```

# 미리보기
토큰 추가 변경으로 시각적 변경 없음 (N/A)