### PR TITLE
feat: SnackBar Duration에 infinity 옵션 추가

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/SnackBarPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SnackBarPreview.swift
@@ -18,10 +18,25 @@ struct SnackBarPreview: View {
     @State private var locationOption: LocationOption = .bottom
     @State private var offset: Double = 0
     @State private var closeButtonEnabled: Bool = false
+    @State private var durationOption: DurationOption = .short
 
     enum LocationOption: String, CaseIterable {
         case top = "Top"
         case bottom = "Bottom"
+    }
+
+    enum DurationOption: String, CaseIterable {
+        case short = "Short"
+        case long = "Long"
+        case infinity = "Infinity"
+
+        var duration: SnackBar.Duration {
+            switch self {
+            case .short: return .short
+            case .long: return .long
+            case .infinity: return .infinity
+            }
+        }
     }
 
     var body: some View {
@@ -66,6 +81,15 @@ struct SnackBarPreview: View {
                         Slider(value: $offset, in: 0...200, step: 10)
                     }
                     HStack {
+                        Text("duration")
+                        Picker("Duration", selection: $durationOption) {
+                            ForEach(DurationOption.allCases, id: \.self) { option in
+                                Text(option.rawValue).tag(option)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                    HStack {
                         Text("closeButton")
                         Switch(checked: closeButtonEnabled) { closeButtonEnabled = $0 }
                     }
@@ -74,6 +98,7 @@ struct SnackBarPreview: View {
                         text: "스낵바 노출"
                     ) {
                         snackBarModel = .init(
+                            duration: durationOption.duration,
                             heading: heading.isEmpty ? nil : heading,
                             description: description.isEmpty ? nil : description,
                             extraContents: {

--- a/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
+++ b/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
@@ -36,11 +36,22 @@ import SwiftUI
 /// ```
 public struct SnackBar: View {
     /// SnackBar가 자동으로 사라지는 시간을 정의하는 열거형입니다.
-    public enum Duration: Double {
+    public enum Duration {
         /// 짧은 표시 시간 (4초)
-        case short = 4.0
+        case short
         /// 긴 표시 시간 (16초)
-        case long = 16.0
+        case long
+        /// 자동으로 사라지지 않고 계속 표시 (수동으로 닫거나 액션 버튼을 눌러야 사라짐)
+        case infinity
+
+        /// 스낵바가 표시되는 시간(초). `.infinity`인 경우 `Double.infinity`를 반환합니다.
+        public var interval: Double {
+            switch self {
+            case .short: return 4.0
+            case .long: return 16.0
+            case .infinity: return .infinity
+            }
+        }
     }
 
     /// 스낵바가 표시될 위치를 정의하는 열거형입니다.
@@ -339,6 +350,11 @@ public struct SnackBar: View {
 
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
 
+            let duration = model?.duration.interval ?? 4.0
+
+            // .infinity인 경우 자동으로 사라지지 않고 계속 표시한다.
+            guard duration.isFinite else { return }
+
             let task = DispatchWorkItem {
                 dismissSnackBar()
             }
@@ -346,7 +362,7 @@ public struct SnackBar: View {
             animationWorkItem = task
 
             DispatchQueue.main.asyncAfter(
-                deadline: .now() + (model?.duration.rawValue ?? 4.0),
+                deadline: .now() + duration,
                 execute: task
             )
         }

--- a/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
+++ b/Sources/Montage/1 Components/7 Feedback/SnackBar.swift
@@ -36,7 +36,7 @@ import SwiftUI
 /// ```
 public struct SnackBar: View {
     /// SnackBar가 자동으로 사라지는 시간을 정의하는 열거형입니다.
-    public enum Duration {
+    public enum Duration: RawRepresentable {
         /// 짧은 표시 시간 (4초)
         case short
         /// 긴 표시 시간 (16초)
@@ -44,8 +44,18 @@ public struct SnackBar: View {
         /// 자동으로 사라지지 않고 계속 표시 (수동으로 닫거나 액션 버튼을 눌러야 사라짐)
         case infinity
 
+        /// 표시 시간(초)으로부터 `Duration`을 생성합니다. 정의되지 않은 값이면 `nil`을 반환합니다.
+        public init?(rawValue: Double) {
+            switch rawValue {
+            case 4.0: self = .short
+            case 16.0: self = .long
+            case .infinity: self = .infinity
+            default: return nil
+            }
+        }
+
         /// 스낵바가 표시되는 시간(초). `.infinity`인 경우 `Double.infinity`를 반환합니다.
-        public var interval: Double {
+        public var rawValue: Double {
             switch self {
             case .short: return 4.0
             case .long: return 16.0
@@ -350,7 +360,7 @@ public struct SnackBar: View {
 
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
 
-            let duration = model?.duration.interval ?? 4.0
+            let duration = model?.duration.rawValue ?? 4.0
 
             // .infinity인 경우 자동으로 사라지지 않고 계속 표시한다.
             guard duration.isFinite else { return }

--- a/documentation/components/feedback/snackbar/ios.md
+++ b/documentation/components/feedback/snackbar/ios.md
@@ -126,6 +126,13 @@ SnackBar가 자동으로 사라지는 시간을 정의하는 열거형입니다.
 
 <details>
 
+<summary>``case infinity``</summary>
+
+
+자동으로 사라지지 않고 계속 표시 (수동으로 닫거나 액션 버튼을 눌러야 사라짐)
+</details>
+<details>
+
 <summary>``case long``</summary>
 
 
@@ -139,12 +146,14 @@ SnackBar가 자동으로 사라지는 시간을 정의하는 열거형입니다.
 짧은 표시 시간 (4초)
 </details>
 
-#### Initializers
+#### Instance Properties
 
 <details>
 
-<summary>``init?(rawValue: Double)``</summary>
+<summary>``var interval: Double``</summary>
 
+
+스낵바가 표시되는 시간(초). `.infinity`인 경우 `Double.infinity`를 반환합니다.
 </details>
 
 </details>

--- a/documentation/components/feedback/snackbar/ios.md
+++ b/documentation/components/feedback/snackbar/ios.md
@@ -146,11 +146,21 @@ SnackBar가 자동으로 사라지는 시간을 정의하는 열거형입니다.
 짧은 표시 시간 (4초)
 </details>
 
+#### Initializers
+
+<details>
+
+<summary>``init?(rawValue: Double)``</summary>
+
+
+표시 시간(초)으로부터 `Duration`을 생성합니다. 정의되지 않은 값이면 `nil`을 반환합니다.
+</details>
+
 #### Instance Properties
 
 <details>
 
-<summary>``var interval: Double``</summary>
+<summary>``var rawValue: Double``</summary>
 
 
 스낵바가 표시되는 시간(초). `.infinity`인 경우 `Double.infinity`를 반환합니다.

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -2252,6 +2252,7 @@
           "kind": "enum",
           "summary": "SnackBar가 자동으로 사라지는 시간을 정의하는 열거형입니다.",
           "cases": [
+            "infinity",
             "long",
             "short"
           ]


### PR DESCRIPTION
# 개요
- 이슈 링크 : [WRP-1231](https://wantedlab.atlassian.net/browse/WRP-1231)

SnackBar가 자동으로 사라지지 않고 사용자가 닫거나 액션을 취할 때까지 계속 표시되도록 `SnackBar.Duration`에 `.infinity` 옵션을 추가했습니다.

# 수정사항
- `SnackBar.Duration`에 `.infinity` case 추가 (자동으로 사라지지 않음)
- `Duration`을 `Double` 기반 `RawRepresentable`로 수동 구현
  - `.infinity`는 enum의 리터럴 raw value로 표현할 수 없어 `init?(rawValue:)` / `var rawValue`를 직접 구현
  - `.infinity` → `Double.infinity`로 매핑
  - 기존 공개 API(`Duration.short.rawValue == 4.0`, `Duration(rawValue:)`)를 그대로 유지하여 **비파괴적**으로 case만 추가
- 자동 dismiss 스케줄링 시 duration이 무한대면 예약을 건너뛰도록 처리
- Blueprint `SnackBarPreview`에 duration 선택(Short/Long/Infinity) picker 추가
- `make`로 문서/MCP 데이터 갱신

### 사용 예시
```swift
snackBarModel = SnackBar.Model(
    duration: .infinity,
    description: "계속 표시되는 알림입니다.",
    action: "확인"
)
```
> `.infinity` 사용 시 닫기 수단(액션 버튼 또는 `closeButtonEnabled`)을 함께 제공하는 것을 권장합니다.

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷


[WRP-1231]: https://wantedlab.atlassian.net/browse/WRP-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ