### PR TITLE
fix: icon_sync에서 Opaque 아이콘 흰색 rect 크기 보존

### DIFF
--- a/scripts/icon_sync.js
+++ b/scripts/icon_sync.js
@@ -61,10 +61,9 @@ const main = async () => {
       fs.writeFileSync(
         path.join(iconAssetsDir, `${iconName}.imageset`, `${iconName}.svg`),
         svgContent
-          .replaceAll('width="24"', '')
-          .replaceAll('height="24"', '')
-          .replaceAll('width="12"', '')
-          .replaceAll('height="12"', '')
+          // 루트 <svg> 태그의 width/height만 제거(viewBox로 스케일). 안쪽 요소
+          // (예: Opaque 아이콘의 흰색 <rect width="12" height="12">)의 크기는 보존한다.
+          .replace(/<svg\b[^>]*>/, (svgTag) => svgTag.replace(/\s(?:width|height)="\d+"/g, ''))
           .replaceAll('fill="none"', '')
           .replaceAll('fill="#171719"', '')
       );


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

Figma 아이콘 동기화(`figma-icon-sync` → `scripts/icon_sync.js`)로 가져온 **Opaque 아이콘**(`circleCheckOpaque` 등)의 안쪽 흰색 배경이 사라져 Fill 아이콘과 동일하게 보이던 문제를 수정합니다.

# 수정사항

`icon_sync.js`의 SVG 후처리에서 루트 `<svg>` 크기 속성을 지우려는 전역 치환이 파일 전체에 적용되어, Opaque 아이콘 안쪽 흰색 `<rect width="12" height="12">`의 크기까지 제거 → 0×0으로 렌더되어 흰 배경이 사라졌습니다.

```js
// before — 파일 전체 무조건 치환 (안쪽 rect 크기까지 제거됨)
.replaceAll('width="12"', '')
.replaceAll('height="12"', '')

// after — 루트 <svg> 여는 태그의 width/height만 제거
.replace(/<svg\b[^>]*>/, (svgTag) => svgTag.replace(/\s(?:width|height)="\d+"/g, ''))
```

- 변경 파일: `scripts/icon_sync.js`
- 검증: 샘플 SVG 변환 테스트로 루트 `<svg>` width/height 제거 + 안쪽 `<rect width="12" height="12">` 보존 확인

> 후속: 이 PR이 `main`에 머지된 후 `figma-icon-sync` 워크플로우를 실행해야 Opaque 아이콘이 흰 배경 보존 상태로 재생성됩니다(워크플로우는 `main`의 스크립트를 실행). 기존에 깨진 채 들어온 Opaque SVG는 재동기화로 교체됩니다.

# 미리보기
작업 전|작업 후
---|---
`<rect x="6" y="6"   fill="white"/>` (0×0 → 안 보임, Fill과 동일)|`<rect x="6" y="6" width="12" height="12" fill="white"/>` (흰 배경 보존)
