### PR TITLE
fix: Blueprint MARKETING_VERSION을 3.12.0으로 수정

### DIFF
--- a/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
+++ b/Sources/Blueprint/Blueprint.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 3.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wantedlab.Blueprint;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -594,7 +594,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 3.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wantedlab.Blueprint;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
# 개요
- 이슈 링크 :

Blueprint TestFlight 배포 시 `MARKETING_VERSION`이 `1.0`으로 남아 있어 앱 버전이 1.0으로 올라가던 문제를 수정합니다.

# 수정사항
- `Blueprint.xcodeproj`의 `MARKETING_VERSION`을 `1.0` → `3.12.0`으로 갱신 (Debug/Release 모두)
- 원인: 배포 스킬이 `agvtool new-marketing-version`을 사용했으나, 이 명령은 `Info.plist`의 `CFBundleShortVersionString`만 갱신하고 pbxproj의 `MARKETING_VERSION` 빌드 세팅은 건드리지 않음. Blueprint는 `GENERATE_INFOPLIST_FILE = YES`라 빌드가 `MARKETING_VERSION` 빌드 세팅을 사용하므로 변경이 무효였음
- 배포 스킬(`montage-blueprint-deploy`)도 pbxproj를 직접 갱신하고 아카이브 버전을 검증하도록 별도 수정함

# 미리보기
작업 전|작업 후
---|---
TestFlight 앱 버전 1.0|TestFlight 앱 버전 3.12.0
