### PR TITLE
feat: 디자인 시스템 Dynamic Type 대응

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/TypographyPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TypographyPreview.swift
@@ -11,59 +11,84 @@ import Montage
 
 struct TypographyPreview: View {
     @State private var lineCount = 1.0
-    
+    /// drawn 높이의 상·하 경계를 우측 defined 박스 쪽으로 연장해 비교하기 위한 가이드 라인 너비.
+    /// 프리뷰 레이아웃에 맞춘 고정값이며, 매우 큰 Dynamic Type에서는 샘플 텍스트가 이보다 넓어질 수 있다.
+    private let guideLineWidth: CGFloat = 125
+
     var body: some View {
         HStack {
-            Text("Line Count \(Int(lineCount))")
+            Text("Multiline Count: \(Int(lineCount))")
+                .font(.system(size: 10, weight: .medium))
             SwiftUI.Slider(value: $lineCount, in: 1...20, step: 1)
         }
         .padding(.horizontal, 16)
-        HStack {
-            SwiftUI.Color.clear
-                .frame(width: 109)
-            HStack {
-                Text("drawn\nheight")
-                    .font(.system(size: 8))
-                Spacer()
-                Text("defined\nheight")
-                    .multilineTextAlignment(.trailing)
-                    .font(.system(size: 8))
-            }
-            .frame(width: 134)
-        }
-        .frame(height: 20)
         ScrollView {
-            ForEach(Typography.Variant.allCases, id: \.self) { variant in
-                HStack(spacing: 4) {
-                    VStack{
-                        Text(String(describing: variant))
-                            .typography(weight: .bold)
-                        Text("fontSize: " + String(format: "%.0f", variant.fontSize))
-                        Text("fontHeight: " + String(format: "%.1f", variant.fontHeight))
-                        Text("lineSpacing: " + String(format: "%.1f", variant.lineSpacing))
-                        Text("lineHeight: " + String(format: "%.1f", variant.lineHeight))
-                        Text("letterSpacing: " + String(format: "%.1f", variant.tracking))
-                    }
-                    .monospacedDigit()
-                    .font(.system(size: 10, weight: .medium))
-                    .frame(width: 109)
+            Grid(horizontalSpacing: 0) {
+                GridRow {
+                    Text("variant")
+                        .multilineTextAlignment(.center)
+                        .font(.system(size: 8))
                     
-                    HStack(alignment: .top, spacing: 1) {
+                    Text("metrics based on\nLarge dynamic type")
+                        .multilineTextAlignment(.center)
+                        .font(.system(size: 8))
+                        .frame(width: 109)
+                    
+                    Spacer().frame(width: 20)
+                    
+                    Text("drawn\nheight")
+                        .font(.system(size: 8))
+
+                    Text("rendered\nsample")
+                        .multilineTextAlignment(.center)
+                        .font(.system(size: 8))
+
+                    Text("defined\nheight")
+                        .multilineTextAlignment(.trailing)
+                        .font(.system(size: 8))
+                }
+                ForEach(Typography.Variant.allCases, id: \.self) { variant in
+                    GridRow(alignment: .top) {
+                        Text(String(describing: variant))
+                            .font(.system(size: 14, weight: .bold))
+                        
+                        VStack{
+                            Text("fontSize: " + String(format: "%.0f", variant.fontSize))
+                            Text("fontHeight: " + String(format: "%.1f", variant.fontHeight))
+                            Text("lineSpacing: " + String(format: "%.1f", variant.lineSpacing))
+                            Text("lineHeight: " + String(format: "%.1f", variant.lineHeight))
+                            Text("letterSpacing: " + String(format: "%.1f", variant.tracking))
+                        }
+                        .monospacedDigit()
+                        .font(.system(size: 10, weight: .medium))
+                        .frame(width: 109)
+                        
+                        Spacer().frame(width: 20)
+                        
                         Text([String](repeating: " ", count: Int(lineCount)).joined(separator: "\n"))
                             .paragraph(variant: variant)
                             .fixedSize(horizontal: false, vertical: true)
                             .frame(width: 30)
                             .dimensioning(axis: .vertical, drawOnPreviewOnly: false)
+                        
                         Text([String](repeating: "AA", count: Int(lineCount)).joined(separator: "\n"))
                             .paragraph(variant: variant)
-                            .frame(width: 69)
                             .fixedSize(horizontal: false, vertical: true)
                             .border(.red, width: 1 / UIScreen.main.scale)
-                        SwiftUI.Color.clear
-                            .frame(width: 30, height: variant.lineHeight * lineCount)
-                            .dimensioning(axis: .vertical, drawOnPreviewOnly: false)
+                            .background {
+                                VStack {
+                                    Rectangle()
+                                        .foregroundStyle(Color.red)
+                                        .frame(width: guideLineWidth, height: 1 / UIScreen.main.scale)
+                                    Spacer()
+                                    Rectangle()
+                                        .foregroundStyle(Color.red)
+                                        .frame(width: guideLineWidth, height: 1 / UIScreen.main.scale)
+                                }
+                            }
+                        
+                        DefinedHeightBox(variant: variant, lineCount: lineCount)
                     }
-                    .frame(width: 134)
                 }
             }
             .padding(.horizontal, 16)
@@ -72,6 +97,24 @@ struct TypographyPreview: View {
     }
 }
 
+/// "defined height" 박스. variant.lineHeight를 폰트와 동일한 곡선(`variant.textStyle`)으로
+/// 스케일해, Dynamic Type가 커져도 실제 그려지는 높이(drawn)와 비교 가능하도록 한다.
+private struct DefinedHeightBox: View {
+    let lineCount: Double
+    @ScaledMetric private var lineHeight: CGFloat
+
+    init(variant: Typography.Variant, lineCount: Double) {
+        self.lineCount = lineCount
+        _lineHeight = ScaledMetric(wrappedValue: variant.lineHeight, relativeTo: variant.textStyle)
+    }
+
+    var body: some View {
+        SwiftUI.Color.clear
+            .frame(width: 30, height: lineHeight * lineCount)
+            .dimensioning(axis: .vertical, drawOnPreviewOnly: false)
+    }
+}
+
 #Preview {
-    return TypographyPreview()
+    TypographyPreview()
 }

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -49,22 +49,6 @@ public struct TextArea: View {
         ///   - max: 최대 높이
         case fixed(min: CGFloat, max: CGFloat)
         
-        var minHeight: CGFloat? {
-            switch self {
-            case .normal: 36.0
-            case .limit: 36.0
-            case .fixed(let min, _): min
-            }
-        }
-        
-        var maxHeight: CGFloat? {
-            switch self {
-            case .normal: .infinity
-            case .limit: 102.0
-            case .fixed(_, let max): max
-            }
-        }
-        
         var alignment: Alignment {
             switch self {
             case .normal, .limit: .center
@@ -344,8 +328,39 @@ public struct TextArea: View {
     // MARK: - Body
     
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var typedCharacters = 0
     @FocusState private var internalFocusState
+
+    /// 스케일된 본문 폰트(`.body1Reading`)의 한 줄 높이. `UIFont.font`이 Dynamic Type 스케일 폰트를
+    /// 반환하므로 글자 크기 설정에 따라 값이 달라진다.
+    private var lineHeightUnit: CGFloat {
+        UIFont.font(variant: .body1Reading).lineHeight
+    }
+
+    /// UITextView 기본 `textContainerInset`(상·하 각 8pt)의 합.
+    private var verticalContainerInset: CGFloat { 16 }
+
+    /// resize 방식에 따른 최소 높이. `.normal`/`.limit`은 **한 줄 높이 기준**이며 폰트 크기에 따라
+    /// 동적으로 스케일된다. `.fixed`는 호출자가 지정한 픽셀값을 그대로 쓴다.
+    private var resolvedMinHeight: CGFloat? {
+        _ = dynamicTypeSize // Dynamic Type 변경 시 높이 재계산을 위한 의존성 등록
+        switch resize {
+        case .normal, .limit: return ceil(lineHeightUnit + verticalContainerInset)
+        case .fixed(let min, _): return min
+        }
+    }
+
+    /// resize 방식에 따른 최대 높이. `.limit`은 기존 기준값(102pt)을 `.body` 곡선으로 스케일해
+    /// 큰 글자에서도 최소 높이를 밑돌지 않도록 한다.
+    private var resolvedMaxHeight: CGFloat? {
+        _ = dynamicTypeSize
+        switch resize {
+        case .normal: return .infinity
+        case .limit: return UIFontMetrics(forTextStyle: .body).scaledValue(for: 102)
+        case .fixed(_, let max): return max
+        }
+    }
     
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
@@ -384,12 +399,12 @@ public struct TextArea: View {
                     .inputLimit(inputCharacterLimit)
                     .inputTransform(inputTransform)
                     .frameHeight(
-                        minHeight: resize.minHeight,
-                        maxHeight: resize.maxHeight
+                        minHeight: resolvedMinHeight,
+                        maxHeight: resolvedMaxHeight
                     )
                     .frame(
-                        minHeight: resize.minHeight,
-                        maxHeight: resize.maxHeight,
+                        minHeight: resolvedMinHeight,
+                        maxHeight: resolvedMaxHeight,
                         alignment: resize.alignment
                     )
                     .foregroundStyle(editorTextColor)
@@ -644,7 +659,11 @@ public struct TextArea: View {
         
         func makeUIView(context: Context) -> UITextView {
             let textView = UITextView()
-            textView.font = UIFont.systemFont(ofSize: 16)
+            // 디자인 폰트(Pretendard)를 Dynamic Type 스케일과 함께 적용한다. UIFont.font은 이미
+            // UIFontMetrics 스케일 폰트를 반환하므로, adjustsFontForContentSizeCategory를 켜면 실행 중
+            // 글자 크기 변경에도 자동으로 갱신된다.
+            textView.font = UIFont.font(variant: .body1Reading)
+            textView.adjustsFontForContentSizeCategory = true
             textView.isScrollEnabled = false
             textView.backgroundColor = .clear
             textView.delegate = context.coordinator

--- a/Sources/Montage/1 Components/5 Loading/Skeleton.swift
+++ b/Sources/Montage/1 Components/5 Loading/Skeleton.swift
@@ -100,6 +100,8 @@ public enum Skeleton {
         let lineHeight: CGFloat
         let lineSpacing: CGFloat
         let lineNumber: Int
+        /// 텍스트 스켈레톤일 때 Dynamic Type 스케일 기준 텍스트 스타일. 비-텍스트는 nil.
+        let textStyle: Font.TextStyle?
 
         /// 텍스트 종류인지 여부
         public var isText: Bool { category == .text }
@@ -131,7 +133,8 @@ public enum Skeleton {
                 cornerRadius: cornerRadius,
                 lineHeight: variant.lineHeight,
                 lineSpacing: variant.lineSpacing,
-                lineNumber: 0
+                lineNumber: 0,
+                textStyle: variant.textStyle
             )
         }
 
@@ -146,7 +149,8 @@ public enum Skeleton {
                 cornerRadius: cornerRadius,
                 lineHeight: 0,
                 lineSpacing: 0,
-                lineNumber: 0
+                lineNumber: 0,
+                textStyle: nil
             )
         }
 
@@ -158,7 +162,8 @@ public enum Skeleton {
                 cornerRadius: 0,
                 lineHeight: 0,
                 lineSpacing: 0,
-                lineNumber: 0
+                lineNumber: 0,
+                textStyle: nil
             )
         }
     }
@@ -190,13 +195,20 @@ public enum Skeleton {
 
         // MARK: - Initializer
         private let kind: Kind
-        
+        /// 텍스트 스켈레톤의 줄 높이를 Dynamic Type에 맞춰 스케일한 값. 폰트와 동일한 곡선
+        /// (`variant.textStyle`)을 따르므로 큰 글자에서도 실제 텍스트 높이와 일치한다.
+        @ScaledMetric private var scaledLineHeight: CGFloat
+        @ScaledMetric private var scaledLineSpacing: CGFloat
+
         /// 스켈레톤 뷰를 초기화합니다.
         ///
         /// - Parameters:
         ///   - kind: 표시할 스켈레톤의 종류
         public init(_ kind: Kind) {
             self.kind = kind
+            let style = kind.textStyle ?? .body
+            _scaledLineHeight = ScaledMetric(wrappedValue: kind.lineHeight, relativeTo: style)
+            _scaledLineSpacing = ScaledMetric(wrappedValue: kind.lineSpacing, relativeTo: style)
         }
         
         // MARK: - Body
@@ -207,11 +219,11 @@ public enum Skeleton {
                 switch kind.category {
                 case .text:
                     GeometryReader { proxy in
-                        let spacing = kind.lineSpacing
+                        let spacing = scaledLineSpacing
                         let effectiveLineCount = kind.lineNumber > 0
                             ? kind.lineNumber
-                            : max(1, Int(round(proxy.size.height / kind.lineHeight)))
-                        let barHeight = max(0, kind.lineHeight - spacing)
+                            : max(1, Int(round(proxy.size.height / scaledLineHeight)))
+                        let barHeight = max(0, scaledLineHeight - spacing)
 
                         VStack(alignment: kind.alignment.horizontalAlignment, spacing: 0) {
                             ForEach(0 ..< effectiveLineCount, id: \.self) { index in

--- a/Sources/Montage/1 Components/9 Utilities/Typography.swift
+++ b/Sources/Montage/1 Components/9 Utilities/Typography.swift
@@ -268,7 +268,7 @@ extension Typography.Variant {
     /// 각 variant의 고정 크기는 그대로 두되, 사용자가 시스템 글자 크기를 키우면 여기에 매핑된
     /// 텍스트 스타일의 스케일 곡선을 따라 커진다. 큰 글자(display/title)는 완만하게, 작은
     /// 글자(caption)는 더 적극적으로 커지도록 역할·크기가 가장 가까운 스타일에 연결한다.
-    var textStyle: Font.TextStyle {
+    public var textStyle: Font.TextStyle {
         switch self {
         case .display1, .display2, .display3: .largeTitle
         case .title1, .title2: .title
@@ -285,7 +285,7 @@ extension Typography.Variant {
 
     /// Dynamic Type 스케일의 기준이 되는 UIKit 텍스트 스타일. ``textStyle``과 동일한 논리이며
     /// UIKit 케이스 이름(`.title1`, `.caption1`)만 다르다.
-    var uiTextStyle: UIFont.TextStyle {
+    public var uiTextStyle: UIFont.TextStyle {
         switch self {
         case .display1, .display2, .display3: .largeTitle
         case .title1, .title2: .title1
@@ -506,7 +506,25 @@ extension View {
     /// - Parameter variant: 텍스트 변형
     /// - Returns: 줄 높이가 적용된 View
     public func adjustLineHeight(variant: Typography.Variant) -> some View {
-        lineSpacing(variant.lineSpacing).padding(.vertical, variant.lineSpacing / 2)
+        modifier(AdjustLineHeightModifier(variant: variant))
+    }
+}
+
+/// 줄 간격·세로 padding을 Dynamic Type에 맞춰 스케일하는 모디파이어.
+///
+/// 폰트가 ``Typography/Variant/textStyle`` 곡선으로 스케일되므로, 줄 간격도 동일한 곡선의
+/// `@ScaledMetric`으로 스케일해 큰 글자에서도 정의된 lineHeight 비율을 유지한다.
+private struct AdjustLineHeightModifier: ViewModifier {
+    @ScaledMetric private var lineSpacing: CGFloat
+
+    init(variant: Typography.Variant) {
+        _lineSpacing = ScaledMetric(wrappedValue: variant.lineSpacing, relativeTo: variant.textStyle)
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .lineSpacing(lineSpacing)
+            .padding(.vertical, lineSpacing / 2)
     }
 }
 

--- a/Sources/Montage/1 Components/9 Utilities/Typography.swift
+++ b/Sources/Montage/1 Components/9 Utilities/Typography.swift
@@ -262,6 +262,45 @@ public enum Typography {
     }
 }
 
+extension Typography.Variant {
+    /// Dynamic Type 스케일의 기준이 되는 SwiftUI 텍스트 스타일.
+    ///
+    /// 각 variant의 고정 크기는 그대로 두되, 사용자가 시스템 글자 크기를 키우면 여기에 매핑된
+    /// 텍스트 스타일의 스케일 곡선을 따라 커진다. 큰 글자(display/title)는 완만하게, 작은
+    /// 글자(caption)는 더 적극적으로 커지도록 역할·크기가 가장 가까운 스타일에 연결한다.
+    var textStyle: Font.TextStyle {
+        switch self {
+        case .display1, .display2, .display3: .largeTitle
+        case .title1, .title2: .title
+        case .title3, .heading1: .title2
+        case .heading2: .title3
+        case .headline1, .headline2: .headline
+        case .body1, .body1Reading: .body
+        case .body2, .body2Reading: .subheadline
+        case .label1, .label1Reading, .label2: .footnote
+        case .caption1: .caption
+        case .caption2: .caption2
+        }
+    }
+
+    /// Dynamic Type 스케일의 기준이 되는 UIKit 텍스트 스타일. ``textStyle``과 동일한 논리이며
+    /// UIKit 케이스 이름(`.title1`, `.caption1`)만 다르다.
+    var uiTextStyle: UIFont.TextStyle {
+        switch self {
+        case .display1, .display2, .display3: .largeTitle
+        case .title1, .title2: .title1
+        case .title3, .heading1: .title2
+        case .heading2: .title3
+        case .headline1, .headline2: .headline
+        case .body1, .body1Reading: .body
+        case .body2, .body2Reading: .subheadline
+        case .label1, .label1Reading, .label2: .footnote
+        case .caption1: .caption1
+        case .caption2: .caption2
+        }
+    }
+}
+
 extension Typography.Weight {
     /// Pretendard 폰트 두께 매핑
     public var pretendardWeight: Pretendard.Weight {
@@ -289,8 +328,11 @@ extension UIFont {
     ///   - size: 폰트 크기
     ///   - weight: 폰트 두께
     /// - Returns: 생성된 UIFont 인스턴스. 폰트를 찾을 수 없는 경우 nil 반환
+    /// - Note: 반환 폰트는 `.body` 기준 Dynamic Type 스케일이 적용된다. 실행 중 글자 크기 변경에
+    ///   반응하려면 사용하는 뷰에서 `adjustsFontForContentSizeCategory = true`를 설정해야 한다.
     public static func font(size: CGFloat, weight: Typography.Weight) -> UIFont? {
         UIFont(name: weight.pretendardWeight.fontName, size: size)
+            .map { UIFontMetrics(forTextStyle: .body).scaledFont(for: $0) }
     }
 
     /// Montage 디자인 시스템의 폰트를 생성합니다.
@@ -299,6 +341,9 @@ extension UIFont {
     ///   - variant: 텍스트 변형
     ///   - weight: 폰트 두께
     /// - Returns: 생성된 UIFont 인스턴스. 폰트를 찾을 수 없는 경우 시스템 폰트로 대체
+    /// - Note: 반환 폰트는 variant별 텍스트 스타일(``Typography/Variant/uiTextStyle``) 기준
+    ///   Dynamic Type 스케일이 적용된다. 실행 중 글자 크기 변경에 반응하려면 사용하는 뷰에서
+    ///   `adjustsFontForContentSizeCategory = true`를 설정해야 한다.
     public static func font(
         variant: Typography.Variant = .body1,
         weight: Typography.Weight = .regular
@@ -306,8 +351,9 @@ extension UIFont {
         let sementicWeight = Typography.getSementicWeight(variant: variant, weight: weight)
         let fallbackWeight = Typography.getFallbackWeight(variant: variant, weight: weight)
         let sementicSize = variant.fontSize
-        return UIFont(name: sementicWeight.fontName, size: sementicSize) ??
+        let base = UIFont(name: sementicWeight.fontName, size: sementicSize) ??
             .systemFont(ofSize: sementicSize, weight: fallbackWeight)
+        return UIFontMetrics(forTextStyle: variant.uiTextStyle).scaledFont(for: base)
     }
 }
 
@@ -320,7 +366,9 @@ extension Font {
     ///   - weight: 폰트 두께
     /// - Returns: 생성된 Font 인스턴스
     public static func font(size: CGFloat, weight: Typography.Weight) -> Font {
-        .custom(weight.pretendardWeight.fontName, size: size)
+        // `.custom(_:size:)`는 이미 `.body` 기준으로 스케일되지만, UIKit `UIFont.font(size:)`의
+        // `UIFontMetrics(forTextStyle: .body)`와 명시적으로 대칭이 되도록 relativeTo를 적는다.
+        .custom(weight.pretendardWeight.fontName, size: size, relativeTo: .body)
     }
 
     /// Montage 디자인 시스템의 폰트를 생성합니다.
@@ -335,7 +383,9 @@ extension Font {
     ) -> Font? {
         let sementicWeight = Typography.getSementicWeight(variant: variant, weight: weight)
         let sementicSize = variant.fontSize
-        return .custom(sementicWeight.fontName, size: sementicSize)
+        // variant별 텍스트 스타일 기준으로 Dynamic Type 스케일. relativeTo가 없는 .custom(_:size:)는
+        // 모든 variant가 .body 곡선으로만 커지므로, variant별 곡선을 따르도록 relativeTo를 지정한다.
+        return .custom(sementicWeight.fontName, size: sementicSize, relativeTo: variant.textStyle)
     }
 }
 

--- a/Sources/Montage/2 Utilities/Extension/SwiftUI/SwiftUI+Debug.swift
+++ b/Sources/Montage/2 Utilities/Extension/SwiftUI/SwiftUI+Debug.swift
@@ -155,48 +155,45 @@ private struct DimensionView: View {
     private let hairline = 1 / UIScreen.main.scale
     
     var body: some View {
-        switch axis {
-        case .horizontal:
-            ZStack {
+        Group {
+            switch axis {
+            case .horizontal:
                 HStack(spacing: 0) {
                     Rectangle()
                         .frame(width: hairline)
                     Rectangle()
                         .frame(height: hairline)
-                        .frame(width: CGFloat(max(0, value - 2)))
+                    Text("\(String(format: "%.1f", value))")
+                        .font(.system(size: 10))
+                        .minimumScaleFactor(0.3)
+                        .background(Rectangle().foregroundStyle(SwiftUI.Color.white).opacity(0.7))
+                        .layoutPriority(1)
+                    Rectangle()
+                        .frame(height: hairline)
                     Rectangle()
                         .frame(width: hairline)
                 }
                 .frame(width: CGFloat(value))
-                Text("\(String(format: "%.1f", value))")
-                    .font(.system(size: 10))
-                    .background {
-                        Rectangle().foregroundStyle(SwiftUI.Color.white).opacity(0.7)
-                    }
-            }
-            .foregroundStyle(.red)
-        case .vertical:
-            ZStack {
+            case .vertical:
                 VStack(spacing: 0) {
                     Rectangle()
                         .frame(height: hairline)
                     Rectangle()
                         .frame(width: hairline)
-                        .frame(height: CGFloat(max(0, value - 2)))
+                    Text("\(String(format: "%.1f", value))")
+                        .font(.system(size: 10))
+                        .minimumScaleFactor(0.3)
+                        .background(Rectangle().foregroundStyle(SwiftUI.Color.white).opacity(0.7))
+                        .layoutPriority(1)
+                    Rectangle()
+                        .frame(width: hairline)
                     Rectangle()
                         .frame(height: hairline)
                 }
                 .frame(height: CGFloat(value))
-                Rectangle()
-                    .frame(width: 1, height: CGFloat(value))
-                Text("\(String(format: "%.1f", value))")
-                    .font(.system(size: 10))
-                    .background {
-                        Rectangle().foregroundStyle(SwiftUI.Color.white).opacity(0.7)
-                    }
             }
-            .foregroundStyle(.red)
         }
+        .foregroundStyle(.red)
     }
 }
 
@@ -210,11 +207,12 @@ private struct DimensionBoxView: View {
 
     var body: some View {
         Rectangle()
-            .stroke()
+            .stroke(lineWidth: 1 / UIScreen.main.scale)
             .frame(width: CGFloat(width), height: CGFloat(height))
             .overlay {
                 Text("\(String(format: "%.1f", width))x\(String(format: "%.1f", height))")
-                    .font(.system(size: 6))
+                    .font(.system(size: 10))
+                    .minimumScaleFactor(0.3)
                     .background(Rectangle().foregroundStyle(SwiftUI.Color.white).opacity(0.7))
             }
             .foregroundStyle(.red)

--- a/Sources/Montage/2 Utilities/Extension/UIKit/NSAttributedString+.swift
+++ b/Sources/Montage/2 Utilities/Extension/UIKit/NSAttributedString+.swift
@@ -16,7 +16,10 @@ extension NSAttributedString {
         lineBreakMode: NSLineBreakMode = .byWordWrapping
     ) -> NSAttributedString {
         let font = UIFont.font(variant: variant, weight: weight)
-        let lineHeight = variant.lineHeight
+        // font는 Dynamic Type 스케일이 적용되므로, 고정 lineHeight를 그대로 쓰면 큰 글자에서 줄 높이가
+        // 폰트보다 작아져 텍스트가 잘린다. 동일한 텍스트 스타일 곡선으로 lineHeight도 함께 스케일한다.
+        let lineHeight = UIFontMetrics(forTextStyle: variant.uiTextStyle)
+            .scaledValue(for: variant.lineHeight)
 
         // http://blog.eppz.eu/uilabel-line-height-letter-spacing-and-more-uilabel-typography-extensions/
         let baselineOffset: CGFloat

--- a/documentation/utilities/ios-utility-components/typography.md
+++ b/documentation/utilities/ios-utility-components/typography.md
@@ -203,10 +203,27 @@ Text("Hello, World!")
 </details>
 <details>
 
+<summary>``var textStyle: Font.TextStyle``</summary>
+
+
+Dynamic Type 스케일의 기준이 되는 SwiftUI 텍스트 스타일.
+- **Discussion**
+
+  각 variant의 고정 크기는 그대로 두되, 사용자가 시스템 글자 크기를 키우면 여기에 매핑된 텍스트 스타일의 스케일 곡선을 따라 커진다. 큰 글자(display/title)는 완만하게, 작은 글자(caption)는 더 적극적으로 커지도록 역할·크기가 가장 가까운 스타일에 연결한다.
+</details>
+<details>
+
 <summary>``var tracking: CGFloat``</summary>
 
 
 각 변형에 대한 자간 (letter spacing)
+</details>
+<details>
+
+<summary>``var uiTextStyle: UIFont.TextStyle``</summary>
+
+
+Dynamic Type 스케일의 기준이 되는 UIKit 텍스트 스타일. 과 동일한 논리이며 UIKit 케이스 이름(`.title1`, `.caption1`)만 다르다.
 </details>
 
 </details>
@@ -298,7 +315,7 @@ Montage 디자인 시스템의 폰트를 생성합니다.
 - **Discussion**
   >  **Note**
   >
-  > 반환 폰트는 variant별 텍스트 스타일(`Typography/Variant/uiTextStyle`) 기준 Dynamic Type 스케일이 적용된다. 실행 중 글자 크기 변경에 반응하려면 사용하는 뷰에서 `adjustsFontForContentSizeCategory = true`를 설정해야 한다.
+  > 반환 폰트는 variant별 텍스트 스타일([uiTextStyle](/documentation/montage/typography/variant/uitextstyle.md)) 기준 Dynamic Type 스케일이 적용된다. 실행 중 글자 크기 변경에 반응하려면 사용하는 뷰에서 `adjustsFontForContentSizeCategory = true`를 설정해야 한다.
 
 </details>
 

--- a/documentation/utilities/ios-utility-components/typography.md
+++ b/documentation/utilities/ios-utility-components/typography.md
@@ -273,6 +273,11 @@ Montage 디자인 시스템의 폰트를 생성합니다.
 - **Return Value**
 
   생성된 UIFont 인스턴스. 폰트를 찾을 수 없는 경우 nil 반환
+- **Discussion**
+  >  **Note**
+  >
+  > 반환 폰트는 `.body` 기준 Dynamic Type 스케일이 적용된다. 실행 중 글자 크기 변경에 반응하려면 사용하는 뷰에서 `adjustsFontForContentSizeCategory = true`를 설정해야 한다.
+
 </details>
 
 <details>
@@ -290,6 +295,11 @@ Montage 디자인 시스템의 폰트를 생성합니다.
 - **Return Value**
 
   생성된 UIFont 인스턴스. 폰트를 찾을 수 없는 경우 시스템 폰트로 대체
+- **Discussion**
+  >  **Note**
+  >
+  > 반환 폰트는 variant별 텍스트 스타일(`Typography/Variant/uiTextStyle`) 기준 Dynamic Type 스케일이 적용된다. 실행 중 글자 크기 변경에 반응하려면 사용하는 뷰에서 `adjustsFontForContentSizeCategory = true`를 설정해야 한다.
+
 </details>
 
 


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-1333

Montage 디자인 시스템의 Dynamic Type 대응을 4.0.0에서 보완합니다. SwiftUI `Text`는 이미 `.custom(_:size:)`로 스케일되지만, UIKit 폰트 경로와 줄 높이(lineHeight) 계산이 고정값이라 큰 글자 크기에서 어긋나던 문제를 수정합니다. (WRP-1247 TextArea 작업 중 발견되어 디자인 시스템 전반 작업으로 분리)

기본 글자 크기에서는 동작 변화가 없으며, public API 시그니처 변경은 없습니다(`textStyle`/`uiTextStyle`만 additive 노출).

# 수정사항
- **Typography UIKit 폰트** (`UIFont.font(variant:)`/`font(size:)`)를 `UIFontMetrics` 스케일 폰트로 변경. variant별 텍스트 스타일 매핑(`textStyle`/`uiTextStyle`) 추가 (additive public)
- **SwiftUI `Font.font(variant:)`** 을 variant별 `relativeTo:`로 스케일 (기존 `.body` 통일 → variant별 곡선)
- **`NSAttributedString._montage`** lineHeight/baselineOffset 스케일 — UIKit Button/Label이 큰 글자에서 잘리지 않도록
- **SwiftUI `adjustLineHeight`** (`.paragraph()`)를 `@ScaledMetric`으로 스케일
- **TextArea** 입력 폰트 Dynamic Type 대응 (systemFont 고정 → 스케일 Pretendard + `adjustsFontForContentSizeCategory`). minHeight는 1줄 기준 유지하되 폰트 크기에 따라 스케일 — *2줄 기준 변경은 WRP-1247 범위*
- **Skeleton(text)** 줄 높이 `@ScaledMetric` 스케일
- **TypographyPreview** 진단 표시 보강 (drawn↔defined 스케일 비교)

# 미리보기
작업 전|작업 후
---|---
<img width="368" height="800" alt="image" src="https://github.com/user-attachments/assets/c2f38158-2e75-4c7e-a6be-d5bc7840b225" />|<img width="368" height="800" alt="image" src="https://github.com/user-attachments/assets/002fdf2b-f753-4b61-9be3-09fb8ba6cd7d" />
