### PR TITLE
fix: iOS 26 BottomSheet 최대 높이 제한(-10.2 보정) 제거

### DIFF
--- a/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
+++ b/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
@@ -251,9 +251,15 @@ public struct BottomSheet: View {
     }
     
     private var maxDetentHeight: CGFloat {
-        // 최대 높이에 도달할 경우 자동으로 스택 형태로 변경되는 것을 막기 위한 보정값 10.2 추가
-        // https://wantedx.slack.com/archives/C04TTGN5F1C/p1761040362320469?thread_ts=1761035208.156399&cid=C04TTGN5F1C
-        (UIApplication.keyWindow?.safeAreaSize.height ?? 0) - 10.2
+        if #available(iOS 26, *) {
+            // iOS 26 부터는 stacked sheet로 자동 변경되지 않으므로 보정값 제거
+            // 단, 스크린 높이 - 10.2 보다 커지면 자동으로 불투명해지고 edge가 스크린 끝에 붙음
+            (UIApplication.keyWindow?.safeAreaSize.height ?? 0)
+        } else {
+            // 최대 높이에 도달할 경우 자동으로 stacked sheet로 변경되는 것을 막기 위한 보정값 10.2 추가
+            // https://wantedx.slack.com/archives/C04TTGN5F1C/p1761040362320469?thread_ts=1761035208.156399&cid=C04TTGN5F1C
+            (UIApplication.keyWindow?.safeAreaSize.height ?? 0) - 10.2
+        }
     }
     
     private var bottomSheetMaxHeight: CGFloat {


### PR DESCRIPTION
## 개요

iOS 26부터는 `BottomSheet`의 detent가 스크린 높이에 도달해도 stacked sheet로 자동 전환되지 않으므로, 이를 회피하기 위한 `-10.2` 보정값을 iOS 26 이상에서 제거한다.

## 배경

`BottomSheet.maxDetentHeight`는 detent가 `(스크린 safeArea 높이 - 10.2)` 이상이 되면 iOS가 자동으로 stacked sheet 형태로 전환하는 것을 막기 위해 최대 높이를 제한해 왔다.

- **iOS 18 이하**: 시트 높이가 `(스크린 높이 - 10.2)` 이상이면 stacked sheet로 자동 변경 → 제한으로 회피.
- **iOS 26 이상**: 높이가 `(스크린 높이 - 10.2)` 이상이 되어도 stacked sheet로 자동 전환되지 **않고**, 배경이 불투명해지며 엣지가 스크린을 꽉 채운다. 따라서 `-10.2` 제한은 시트가 화면 끝까지 도달하지 못하게 막는 불필요한 제약이 된다.

## 변경 사항

`maxDetentHeight`를 OS 버전별로 분기:

- **iOS 26 이상**: `-10.2` 보정 제거 → safeArea 높이 전체 사용 (특히 `resize: .fill`에서 화면 끝까지 확장).
- **iOS 18 이하**: 기존 `-10.2` 보정 유지 (stacked sheet 자동 전환 회피).

## 참고

- Jira: [WRP-1523](https://wantedlab.atlassian.net/browse/WRP-1523)
- Slack 스레드: https://wantedx.slack.com/archives/C04TTGN5F1C/p1782983199838499

## 테스트

- [x] iOS 26 시뮬레이터에서 `resize: .fill` 시 시트가 화면 끝까지 확장되는지 확인
- [x] iOS 18 이하에서 기존 동작(stacked sheet 회피) 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[WRP-1523]: https://wantedlab.atlassian.net/browse/WRP-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ