### PR TITLE
fix: 플레이스홀더를 overlay로 변경하여 입력 필드 높이·폰트 깨짐 방지

### DIFF
--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -395,8 +395,11 @@ public struct TextArea: View {
                     .padding(.horizontal, -4.5)
                     .padding(.top, -4)
                     .padding(.bottom, -6)
-
-                if $text.wrappedValue.isEmpty, let placeholder {
+            }
+            // placeholder를 ZStack 자식으로 두면 여러 줄 placeholder가 TextArea 높이를 밀어 올리므로,
+            // 레이아웃에 참여하지 않는 overlay로 그려 입력 영역 크기 안에서 줄바꿈·말줄임만 한다.
+            .overlay(alignment: .topLeading) {
+                if text.isEmpty, let placeholder {
                     Text(placeholder)
                         .paragraph(
                             variant: size.inputVariant,

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -397,15 +397,14 @@ private extension TextField {
                     .padding(size.iconPadding)
             }
 
-            SwiftUI.TextField(
-                "",
-                text: $text,
-                prompt: promptText
-            )
+            SwiftUI.TextField("", text: $text)
             .autocorrectionDisabled(fixAutocorrection)
             .font(.font(variant: size.inputVariant, weight: .regular))
             .foregroundStyle(fieldTextColor)
             .focused($textFieldFocusState)
+            // placeholder를 prompt로 전달하면 폭이 부족할 때 시스템이 폰트를 자동 축소(shrink-to-fit)하므로,
+            // 레이아웃에 참여하지 않는 overlay로 직접 그려 폰트 크기를 유지한 채 말줄임 처리한다.
+            .overlay(alignment: .leading) { placeholderOverlay }
             .padding(.horizontal, .spacing4)
             // 실제 입력 텍스트가 보조 기술에 그대로 노출되도록 value는 덮어쓰지 않는다.
             // 필드의 용도는 placeholder로 라벨링하고, 상태 메시지(오류 등)는 hint로 전달한다.
@@ -436,14 +435,20 @@ private extension TextField {
         text = String(text.prefix(maxLength))
     }
 
-    var promptText: Text? {
-        guard let placeholder else { return nil }
-        return Text(placeholder)
-            .typography(
-                variant: size.inputVariant,
-                weight: .regular,
-                color: placeholderTextColor
-            )
+    @ViewBuilder
+    var placeholderOverlay: some View {
+        if text.isEmpty, let placeholder {
+            Text(placeholder)
+                .typography(
+                    variant: size.inputVariant,
+                    weight: .regular,
+                    color: placeholderTextColor
+                )
+                .lineLimit(1)
+                .allowsHitTesting(false)
+                // 필드의 accessibilityLabel이 이미 placeholder를 노출하므로 중복 낭독을 막는다.
+                .accessibilityHidden(true)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-1619

# 수정사항
- TextField: placeholder를 `prompt:` 파라미터에서 overlay로 변경하여 폭 부족 시 시스템 폰트 자동 축소(shrink-to-fit) 방지
- TextArea: placeholder를 ZStack 조건부 렌더링에서 overlay(.topLeading)로 변경하여 여러 줄 placeholder가 입력 영역 높이를 밀어올리지 않도록 수정

# 미리보기
작업 전|작업 후
---|---
스크린샷|스크린샷
