### PR TITLE
refactor: Select 메뉴를 LazyVStack으로 전환해 대량 항목 스크롤 hitch 해소

### DIFF
--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -487,7 +487,9 @@ public struct Select: View {
     }
 
     private var menu: some View {
-        VStack(spacing: 4) {
+        // BottomSheet가 스크롤 오프셋 변화마다 content를 재평가하므로,
+        // 항목이 많을 때 eager 렌더링(VStack)은 스크롤 hitch를 유발한다
+        LazyVStack(spacing: 4) {
             ForEach(items.indices, id: \.self) { index in
                 Group {
                     let cell = ListCell(title: items[index].text) {


### PR DESCRIPTION
# 개요
- 이슈 링크 : 없음 (Wanted 앱 WRP-1962 작업 중 발견)

# 수정사항
- `Select` 메뉴 목록 컨테이너를 `VStack` → `LazyVStack`으로 전환

## 증상
- 항목이 많은 `Select` 메뉴(전화번호 국가 선택, 240여 개)에서 바텀시트 스크롤 hitch 발생
- Instruments에서 "Potentially expensive app update(s)"로 검출

## 원인
1. `BottomSheet`는 스크롤 오프셋을 `@State scrollStatus`로 추적 (`ScrollView`의 `onPreferenceChange` → 디바운스 없이 오프셋마다 write) → 오프셋이 바뀔 때마다 BottomSheet body가 재평가되고 `content()`가 재호출됨
2. `Select.menu`는 eager한 `VStack + ForEach`라 재평가마다 전체 항목의 `ListCell`이 재구성됨 → 항목 N개 × 매 스크롤 틱 = 스크롤 내내 메인 스레드 점유

## 검증
- 실제 앱 국가 선택 화면(240개 항목)에서 hang 소멸, Instruments 재측정으로 확인
- items 바인딩을 `@Published` 저장 배열로 바꾸는 것만으로는 부족했고(접근당 재-map 제거 후에도 재현), LazyVStack 전환이 결정적이었음

## 영향 범위
- 시각/동작 변화 없음 예상. `.hug` resize의 높이 측정도 LazyVStack이 전체 콘텐츠 높이를 보고하므로 동일
- 소량 항목 화면(DesiredSalary 등)은 Blueprint 쇼케이스에서 확인 권장

## 후속 논의거리
- 근본적으로는 BottomSheet의 오프셋 추적이 sheet 전체 body를 매 틱 무효화하는 구조의 격리(오프셋 소비자를 하위 뷰로 분리, `scrolledToMax` Bool만 상위 전파). 본 PR로 증상은 해소되지만 content 재평가 자체는 남아 있음

# 미리보기
작업 전|작업 후
---|---
스크롤 hitch (Instruments hitch 검출)|hitch 없음