### PR TITLE
feat: montage-mcp Streamable HTTP 엔드포인트 추가

### DIFF
--- a/packages/montage-mcp/README.ko.md
+++ b/packages/montage-mcp/README.ko.md
@@ -25,8 +25,10 @@ Wanted Lab의 [Montage iOS 디자인 시스템](https://github.com/wanteddev/mon
 ### A. 원격 MCP로 사용
 
 ```bash
-claude mcp add --transport sse montage-ios https://<your-host>/sse
+claude mcp add --transport http montage-ios https://<your-host>/mcp
 ```
+
+레거시 HTTP+SSE 전송(`--transport sse`, `https://<your-host>/sse`)도 하위 호환을 위해 계속 제공되지만, MCP 스펙에서 폐기됐고 일부 클라이언트는 지원하지 않습니다. 새로 설정할 때는 Streamable HTTP를 사용하세요.
 
 Wanted Lab 구성원은 사내 Confluence/Slack에서 공식 엔드포인트 URL을 확인하세요. 외부 사용자는 아래 B 옵션으로 self-host 하세요.
 

--- a/packages/montage-mcp/README.md
+++ b/packages/montage-mcp/README.md
@@ -25,8 +25,10 @@ Provides AI coding assistants with access to Montage component documentation, de
 ### A. As a remote MCP
 
 ```bash
-claude mcp add --transport sse montage-ios https://<your-host>/sse
+claude mcp add --transport http montage-ios https://<your-host>/mcp
 ```
+
+The legacy HTTP+SSE transport (`--transport sse`, `https://<your-host>/sse`) is still served for backward compatibility, but it is deprecated in the MCP spec and unsupported by some clients — prefer Streamable HTTP for new setups.
 
 Wanted Lab employees: see the internal Confluence/Slack for the official endpoint URL. External users should self-host (option B below).
 

--- a/packages/montage-mcp/src/http-app.ts
+++ b/packages/montage-mcp/src/http-app.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+import express, { type Express, type Request, type Response } from "express";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { PACKAGE_NAME, PACKAGE_VERSION, type RuntimeConfig } from "./core/config.js";
+import { createServer } from "./core/server.js";
+import { logDebug, logError } from "./core/logger.js";
+import { renderIndexPage } from "./index-page.js";
+
+/**
+ * SSE heartbeat — sends an SSE comment line periodically so L7 idle timeouts
+ * (e.g. ingress 30s) don't sever quiet streams. The colon-prefixed line is a
+ * no-op for SSE clients per spec, but counts as bytes for proxies.
+ *
+ * Only the legacy `/sse` transport needs this; `StreamableHTTPServerTransport`
+ * ships its own keep-alive.
+ */
+const SSE_HEARTBEAT_MS = 25_000;
+
+/** JSON-RPC error body for transport-level failures (no request id available). */
+function jsonRpcError(code: number, message: string): Record<string, unknown> {
+  return { jsonrpc: "2.0", error: { code, message }, id: null };
+}
+
+function sessionIdOf(req: Request): string | undefined {
+  const raw = req.headers["mcp-session-id"];
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}
+
+export function createApp(config: RuntimeConfig): Express {
+  const app = express();
+
+  // Note: the legacy SSE transport requires raw POST body delivery via
+  // handlePostMessage. express.json() is therefore registered AFTER /messages,
+  // and /mcp opts into JSON parsing per-route.
+  const sseTransports = new Map<string, SSEServerTransport>();
+  const streamableTransports = new Map<string, StreamableHTTPServerTransport>();
+
+  app.get("/", (req: Request, res: Response) => {
+    const forwardedProto = req.headers["x-forwarded-proto"];
+    const proto =
+      typeof forwardedProto === "string" && forwardedProto.length > 0
+        ? (forwardedProto.split(",")[0] ?? "").trim() || req.protocol
+        : req.protocol;
+    const host = req.get("host") ?? `localhost:${config.port}`;
+    const origin = `${proto}://${host}`;
+    res.type("html").send(renderIndexPage(origin));
+  });
+
+  app.get("/healthz", (_req: Request, res: Response) => {
+    res.json({
+      status: "ok",
+      name: PACKAGE_NAME,
+      version: PACKAGE_VERSION,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  // --- Streamable HTTP (current MCP spec) -----------------------------------
+
+  app.post("/mcp", express.json(), async (req: Request, res: Response) => {
+    const sessionId = sessionIdOf(req);
+    try {
+      let transport = sessionId ? streamableTransports.get(sessionId) : undefined;
+
+      if (!transport) {
+        if (sessionId) {
+          logDebug("/mcp POST rejected — session not found", { sessionId });
+          res.status(404).json(jsonRpcError(-32001, "session not found"));
+          return;
+        }
+        if (!isInitializeRequest(req.body)) {
+          logDebug("/mcp POST rejected — no session id and not an initialize request");
+          res
+            .status(400)
+            .json(jsonRpcError(-32000, "mcp-session-id header required for non-initialize requests"));
+          return;
+        }
+
+        const created = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (sid) => {
+            streamableTransports.set(sid, created);
+            logDebug("mcp session opened", { sessionId: sid });
+          },
+          onsessionclosed: (sid) => {
+            streamableTransports.delete(sid);
+            logDebug("mcp session closed by client", { sessionId: sid });
+          },
+        });
+        created.onclose = () => {
+          const sid = created.sessionId;
+          if (sid) {
+            streamableTransports.delete(sid);
+            logDebug("mcp session closed", { sessionId: sid });
+          }
+        };
+
+        const server = createServer({ config, transport: "http" });
+        // SDK typing quirk: StreamableHTTPServerTransport exposes `onclose`/`onerror`
+        // as accessors returning `T | undefined`, which `exactOptionalPropertyTypes`
+        // rejects against Transport's optional members. Runtime shape is compatible.
+        await server.connect(created as Transport);
+        transport = created;
+      }
+
+      logDebug("/mcp POST received", { sessionId: sessionId ?? "(initialize)" });
+      await transport.handleRequest(req, res, req.body);
+    } catch (err) {
+      logError("/mcp POST failed", err, { sessionId: sessionId ?? null });
+      if (!res.headersSent) {
+        res.status(500).json(jsonRpcError(-32603, "internal server error"));
+      }
+    }
+  });
+
+  // GET opens the server→client notification stream, DELETE terminates the session.
+  const handleStreamableSessionRequest = async (req: Request, res: Response): Promise<void> => {
+    const sessionId = sessionIdOf(req);
+    if (!sessionId) {
+      logDebug(`/mcp ${req.method} rejected — missing session id`);
+      res.status(400).json(jsonRpcError(-32000, "mcp-session-id header required"));
+      return;
+    }
+    const transport = streamableTransports.get(sessionId);
+    if (!transport) {
+      logDebug(`/mcp ${req.method} rejected — session not found`, { sessionId });
+      res.status(404).json(jsonRpcError(-32001, "session not found"));
+      return;
+    }
+    try {
+      logDebug(`/mcp ${req.method} received`, { sessionId });
+      await transport.handleRequest(req, res);
+    } catch (err) {
+      logError(`/mcp ${req.method} failed`, err, { sessionId });
+      if (!res.headersSent) {
+        res.status(500).json(jsonRpcError(-32603, "internal server error"));
+      }
+    }
+  };
+
+  app.get("/mcp", handleStreamableSessionRequest);
+  app.delete("/mcp", handleStreamableSessionRequest);
+
+  // --- Legacy HTTP+SSE (deprecated, kept for backward compatibility) --------
+
+  app.get("/sse", async (_req: Request, res: Response) => {
+    const transport = new SSEServerTransport("/messages", res);
+    sseTransports.set(transport.sessionId, transport);
+    const heartbeat = setInterval(() => {
+      try {
+        res.write(": ping\n\n");
+      } catch {
+        // socket already gone — close handler will clean up
+      }
+    }, SSE_HEARTBEAT_MS);
+    if (typeof heartbeat.unref === "function") heartbeat.unref();
+    logDebug("sse session opened", {
+      sessionId: transport.sessionId,
+      heartbeatMs: SSE_HEARTBEAT_MS,
+    });
+    res.on("close", () => {
+      clearInterval(heartbeat);
+      sseTransports.delete(transport.sessionId);
+      logDebug("sse session closed", { sessionId: transport.sessionId });
+    });
+
+    try {
+      const server = createServer({ config, transport: "http" });
+      await server.connect(transport);
+    } catch (err) {
+      clearInterval(heartbeat);
+      sseTransports.delete(transport.sessionId);
+      if (!res.headersSent) {
+        res.status(500).json({ error: "failed to initialize sse session" });
+      }
+      logError("sse init failed", err, { sessionId: transport.sessionId });
+    }
+  });
+
+  app.post("/messages", async (req: Request, res: Response) => {
+    const sessionId = req.query.sessionId;
+    if (typeof sessionId !== "string") {
+      logDebug("/messages rejected — missing sessionId");
+      res.status(400).json({ error: "sessionId query parameter required" });
+      return;
+    }
+    const transport = sseTransports.get(sessionId);
+    if (!transport) {
+      logDebug("/messages rejected — session not found", { sessionId });
+      res.status(404).json({ error: "session not found" });
+      return;
+    }
+    logDebug("/messages received", { sessionId });
+    await transport.handlePostMessage(req, res);
+  });
+
+  // JSON middleware for any other routes added later (must come AFTER /messages).
+  app.use(express.json());
+
+  return app;
+}

--- a/packages/montage-mcp/src/http-app.ts
+++ b/packages/montage-mcp/src/http-app.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import express, { type Express, type Request, type Response } from "express";
+import express, {
+  type Express,
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
@@ -143,6 +148,18 @@ export function createApp(config: RuntimeConfig): Express {
 
   app.get("/mcp", handleStreamableSessionRequest);
   app.delete("/mcp", handleStreamableSessionRequest);
+
+  // express.json() rejects a malformed body before the route handlers run, so their
+  // try/catch never sees it and Express would answer with its default HTML error page.
+  // Translate it into a JSON-RPC parse error instead.
+  app.use("/mcp", (err: unknown, _req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof SyntaxError && "body" in err) {
+      logDebug("/mcp rejected — malformed JSON body");
+      res.status(400).json(jsonRpcError(-32700, "parse error: request body is not valid JSON"));
+      return;
+    }
+    next(err);
+  });
 
   // --- Legacy HTTP+SSE (deprecated, kept for backward compatibility) --------
 

--- a/packages/montage-mcp/src/http.ts
+++ b/packages/montage-mcp/src/http.ts
@@ -1,10 +1,7 @@
-import express, { type Request, type Response } from "express";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { loadConfig, PACKAGE_NAME, PACKAGE_VERSION } from "./core/config.js";
-import { createServer } from "./core/server.js";
-import { configureLogger, logDebug, logError } from "./core/logger.js";
+import { configureLogger, logDebug } from "./core/logger.js";
 import { sanitizeUrl } from "./core/redact.js";
-import { renderIndexPage } from "./index-page.js";
+import { createApp } from "./http-app.js";
 
 const config = loadConfig();
 configureLogger({ debug: config.debug });
@@ -16,91 +13,8 @@ logDebug("config resolved", {
   queuePath: config.queuePath,
   port: config.port,
 });
-const app = express();
 
-// Note: SSE transport requires raw POST body delivery via handlePostMessage.
-// We register express.json() AFTER the SSE message endpoint so the SDK reads the stream itself.
-
-const transports = new Map<string, SSEServerTransport>();
-
-app.get("/", (req: Request, res: Response) => {
-  const forwardedProto = req.headers["x-forwarded-proto"];
-  const proto =
-    typeof forwardedProto === "string" && forwardedProto.length > 0
-      ? (forwardedProto.split(",")[0] ?? "").trim() || req.protocol
-      : req.protocol;
-  const host = req.get("host") ?? `localhost:${config.port}`;
-  const origin = `${proto}://${host}`;
-  res.type("html").send(renderIndexPage(origin));
-});
-
-app.get("/healthz", (_req: Request, res: Response) => {
-  res.json({
-    status: "ok",
-    name: PACKAGE_NAME,
-    version: PACKAGE_VERSION,
-    timestamp: new Date().toISOString(),
-  });
-});
-
-// SSE heartbeat — sends an SSE comment line periodically so L7 idle timeouts
-// (e.g. ingress 30s) don't sever quiet streams. The colon-prefixed line is a
-// no-op for SSE clients per spec, but counts as bytes for proxies.
-const SSE_HEARTBEAT_MS = 25_000;
-
-app.get("/sse", async (_req: Request, res: Response) => {
-  const transport = new SSEServerTransport("/messages", res);
-  transports.set(transport.sessionId, transport);
-  const heartbeat = setInterval(() => {
-    try {
-      res.write(": ping\n\n");
-    } catch {
-      // socket already gone — close handler will clean up
-    }
-  }, SSE_HEARTBEAT_MS);
-  if (typeof heartbeat.unref === "function") heartbeat.unref();
-  logDebug("sse session opened", {
-    sessionId: transport.sessionId,
-    heartbeatMs: SSE_HEARTBEAT_MS,
-  });
-  res.on("close", () => {
-    clearInterval(heartbeat);
-    transports.delete(transport.sessionId);
-    logDebug("sse session closed", { sessionId: transport.sessionId });
-  });
-
-  try {
-    const server = createServer({ config, transport: "http" });
-    await server.connect(transport);
-  } catch (err) {
-    clearInterval(heartbeat);
-    transports.delete(transport.sessionId);
-    if (!res.headersSent) {
-      res.status(500).json({ error: "failed to initialize sse session" });
-    }
-    logError("sse init failed", err, { sessionId: transport.sessionId });
-  }
-});
-
-app.post("/messages", async (req: Request, res: Response) => {
-  const sessionId = req.query.sessionId;
-  if (typeof sessionId !== "string") {
-    logDebug("/messages rejected — missing sessionId");
-    res.status(400).json({ error: "sessionId query parameter required" });
-    return;
-  }
-  const transport = transports.get(sessionId);
-  if (!transport) {
-    logDebug("/messages rejected — session not found", { sessionId });
-    res.status(404).json({ error: "session not found" });
-    return;
-  }
-  logDebug("/messages received", { sessionId });
-  await transport.handlePostMessage(req, res);
-});
-
-// JSON middleware for any other routes added later (must come AFTER /messages).
-app.use(express.json());
+const app = createApp(config);
 
 app.listen(config.port, () => {
   logDebug(`HTTP listening on :${config.port}`, {

--- a/packages/montage-mcp/src/index-page.ts
+++ b/packages/montage-mcp/src/index-page.ts
@@ -14,11 +14,21 @@ function escapeHtml(value: string): string {
 
 export function renderIndexPage(_origin: string): string {
   const safeOrigin = escapeHtml(PUBLIC_ORIGIN);
+  const mcpUrl = `${safeOrigin}/mcp`;
   const sseUrl = `${safeOrigin}/sse`;
-  const remoteAddCmd = `claude mcp add --transport sse montage-ios ${sseUrl}`;
+  const remoteAddCmd = `claude mcp add --transport http montage-ios ${mcpUrl}`;
   const cursorJson = `{
   "mcpServers": {
     "montage-ios": {
+      "type": "http",
+      "url": "${mcpUrl}"
+    }
+  }
+}`;
+  const legacySseJson = `{
+  "mcpServers": {
+    "montage-ios": {
+      "type": "sse",
       "url": "${sseUrl}"
     }
   }
@@ -107,18 +117,25 @@ export function renderIndexPage(_origin: string): string {
 
   <p>이 서버는 AI 코딩 어시스턴트(Claude Code, Cursor 등)에 Montage 컴포넌트 문서·디자인 토큰·아이콘·Figma 매핑 도구를 제공합니다. 아래 안내를 따라 클라이언트에 등록하면 바로 사용할 수 있습니다.</p>
 
-  <h2>1. Claude Code (원격 SSE)</h2>
-  <p>가장 권장되는 방식. 항상 최신 데이터를 사용합니다.</p>
+  <h2>1. Claude Code (원격 Streamable HTTP)</h2>
+  <p>가장 권장되는 방식. 항상 최신 데이터를 사용하며, 터미널·데스크탑 앱 모두 지원합니다.</p>
   <div class="block">
     <pre id="cmd-remote">${escapeHtml(remoteAddCmd)}</pre>
     <button class="copy" data-target="cmd-remote">복사</button>
   </div>
 
   <h2>2. Cursor / 기타 MCP 클라이언트</h2>
-  <p>설정 파일에 SSE 엔드포인트를 추가합니다.</p>
+  <p>설정 파일에 Streamable HTTP 엔드포인트를 추가합니다.</p>
   <div class="block">
     <pre id="cmd-cursor">${escapeHtml(cursorJson)}</pre>
     <button class="copy" data-target="cmd-cursor">복사</button>
+  </div>
+
+  <h2>3. 레거시 SSE (하위 호환)</h2>
+  <p>Streamable HTTP를 지원하지 않는 구버전 클라이언트만 사용하세요. MCP 스펙에서 폐기된 방식이며, 새 설정에는 권장하지 않습니다.</p>
+  <div class="block">
+    <pre id="cmd-sse">${escapeHtml(legacySseJson)}</pre>
+    <button class="copy" data-target="cmd-sse">복사</button>
   </div>
 
   <h2>제공 도구</h2>
@@ -142,8 +159,11 @@ export function renderIndexPage(_origin: string): string {
   <h2>엔드포인트</h2>
   <ul>
     <li><code>GET /</code> — 이 안내 페이지</li>
-    <li><code>GET /sse</code> — MCP SSE 스트림</li>
-    <li><code>POST /messages?sessionId=...</code> — MCP 메시지 수신</li>
+    <li><code>POST /mcp</code> — MCP Streamable HTTP 요청</li>
+    <li><code>GET /mcp</code> — MCP Streamable HTTP 알림 스트림</li>
+    <li><code>DELETE /mcp</code> — MCP 세션 종료</li>
+    <li><code>GET /sse</code> — MCP SSE 스트림 (레거시)</li>
+    <li><code>POST /messages?sessionId=...</code> — MCP 메시지 수신 (레거시)</li>
     <li><code>GET /healthz</code> — 헬스체크 JSON</li>
   </ul>
 </main>

--- a/packages/montage-mcp/tests/http-transport.test.ts
+++ b/packages/montage-mcp/tests/http-transport.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { createApp } from "../src/http-app.js";
+import { loadConfig, PACKAGE_NAME } from "../src/core/config.js";
+
+const PROTOCOL_VERSION = "2025-06-18";
+const JSON_AND_SSE = "application/json, text/event-stream";
+
+let server: Server;
+let baseUrl: string;
+
+/**
+ * A Streamable HTTP POST answers with either a plain JSON body or a short-lived
+ * SSE stream (the SDK prefers SSE). Normalize both into the JSON-RPC payload.
+ */
+async function readJsonRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text();
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream")) {
+    const dataLine = text
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.startsWith("data:"));
+    expect(dataLine, `no SSE data frame in response: ${text}`).toBeDefined();
+    return JSON.parse(dataLine!.slice("data:".length).trim());
+  }
+  return JSON.parse(text);
+}
+
+function post(body: unknown, sessionId?: string): Promise<Response> {
+  return fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: JSON_AND_SSE,
+      ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  const config = loadConfig({ MONTAGE_MCP_TRACK_DISABLE: "1" } as NodeJS.ProcessEnv);
+  const app = createApp(config);
+  server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("Streamable HTTP transport (POST/GET/DELETE /mcp)", () => {
+  it("completes initialize → tools/list → tools/call and terminates the session", async () => {
+    // initialize
+    const initRes = await post({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "vitest", version: "0.0.0" },
+      },
+    });
+    expect(initRes.status).toBe(200);
+    const sessionId = initRes.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    const initBody = await readJsonRpc(initRes);
+    expect((initBody.result as Record<string, any>).serverInfo.name).toBe(PACKAGE_NAME);
+
+    // notifications/initialized — required before regular requests
+    const notifyRes = await post(
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      sessionId!,
+    );
+    expect(notifyRes.status).toBe(202);
+    await notifyRes.text();
+
+    // tools/list
+    const listRes = await post({ jsonrpc: "2.0", id: 2, method: "tools/list" }, sessionId!);
+    expect(listRes.status).toBe(200);
+    const listBody = await readJsonRpc(listRes);
+    const toolNames = (listBody.result as Record<string, any>).tools.map(
+      (t: { name: string }) => t.name,
+    );
+    expect(toolNames).toContain("health_check");
+    expect(toolNames).toContain("list_components");
+
+    // tools/call
+    const callRes = await post(
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "health_check", arguments: {} },
+      },
+      sessionId!,
+    );
+    expect(callRes.status).toBe(200);
+    const callBody = await readJsonRpc(callRes);
+    const result = callBody.result as Record<string, any>;
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(result.content[0].text).status).toBe("ok");
+
+    // DELETE terminates the session, and the id stops resolving afterwards
+    const deleteRes = await fetch(`${baseUrl}/mcp`, {
+      method: "DELETE",
+      headers: { "mcp-session-id": sessionId! },
+    });
+    expect(deleteRes.status).toBeLessThan(300);
+    await deleteRes.text();
+
+    const afterDelete = await post({ jsonrpc: "2.0", id: 4, method: "tools/list" }, sessionId!);
+    expect(afterDelete.status).toBe(404);
+    await afterDelete.text();
+  });
+
+  it("rejects a non-initialize POST without a session id", async () => {
+    const res = await post({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+    expect(res.status).toBe(400);
+    const body = await readJsonRpc(res);
+    expect(body.error).toBeDefined();
+  });
+
+  it("rejects a POST carrying an unknown session id", async () => {
+    const res = await post({ jsonrpc: "2.0", id: 1, method: "tools/list" }, "does-not-exist");
+    expect(res.status).toBe(404);
+    await res.text();
+  });
+
+  it("rejects GET /mcp without a session id", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "GET",
+      headers: { accept: "text/event-stream" },
+    });
+    expect(res.status).toBe(400);
+    await res.text();
+  });
+});
+
+describe("legacy SSE transport (regression)", () => {
+  it("serves the endpoint handshake on GET /sse", async () => {
+    const controller = new AbortController();
+    const res = await fetch(`${baseUrl}/sse`, {
+      headers: { accept: "text/event-stream" },
+      signal: controller.signal,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const chunk = new TextDecoder().decode(value);
+    expect(chunk).toContain("event: endpoint");
+    expect(chunk).toContain("/messages?sessionId=");
+
+    await reader.cancel();
+    controller.abort();
+  });
+
+  it("rejects POST /messages without a sessionId", async () => {
+    const res = await fetch(`${baseUrl}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(res.status).toBe(400);
+    await res.text();
+  });
+});
+
+describe("service endpoints", () => {
+  it("serves /healthz", async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ok");
+    expect(body.name).toBe(PACKAGE_NAME);
+  });
+
+  it("advertises the Streamable HTTP endpoint on the index page", async () => {
+    const res = await fetch(`${baseUrl}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("/mcp");
+    expect(html).toContain("--transport http");
+  });
+});

--- a/packages/montage-mcp/tests/http-transport.test.ts
+++ b/packages/montage-mcp/tests/http-transport.test.ts
@@ -132,6 +132,17 @@ describe("Streamable HTTP transport (POST/GET/DELETE /mcp)", () => {
     await res.text();
   });
 
+  it("answers a malformed JSON body with a JSON-RPC parse error", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: JSON_AND_SSE },
+      body: '{"jsonrpc":"2.0",',
+    });
+    expect(res.status).toBe(400);
+    const body = await readJsonRpc(res);
+    expect((body.error as Record<string, unknown>).code).toBe(-32700);
+  });
+
   it("rejects GET /mcp without a session id", async () => {
     const res = await fetch(`${baseUrl}/mcp`, {
       method: "GET",


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2130

montage-mcp가 레거시 HTTP+SSE 트랜스포트(`GET /sse` + `POST /messages`)만 제공해서, SSE를 지원하지 않는 클라이언트(Claude Code 데스크탑 앱)에서 연결되지 않았습니다. MCP 스펙이 SSE를 대체·폐기하고 채택한 **Streamable HTTP** 엔드포인트를 추가하고, 기존 SSE 경로는 하위 호환용으로 그대로 유지합니다.

Swift 패키지(`Sources/`) 변경은 없고 `packages/montage-mcp`만 수정합니다.

# 수정사항

**Streamable HTTP 엔드포인트 추가**
- `POST /mcp`(요청) · `GET /mcp`(서버→클라이언트 알림 스트림) · `DELETE /mcp`(세션 종료)
- SDK의 `StreamableHTTPServerTransport` 사용 (현재 의존성 `@modelcontextprotocol/sdk` 1.30.0에 포함 — SDK 업그레이드 불필요)
- 세션은 기존 `/messages` 방식과 동일하게 세션별 transport 맵으로 관리하고, `onsessionclosed`/`onclose`에서 정리
- 세션 없는 비-initialize 요청 400, 알 수 없는 세션 404, 그 외 실패 500을 JSON-RPC 에러 형태로 응답

**레거시 경로 유지**
- `GET /sse` + `POST /messages`는 하트비트 포함 기존 동작 그대로 유지 (터미널 CLI·기존 사용자 설정 무영향)
- SSE 트랜스포트가 raw body를 직접 읽어야 하므로 `express.json()`은 계속 `/messages` 뒤에 등록하고, `/mcp`만 라우트 단위로 JSON 파싱을 켬

**리팩터링**
- 앱 구성을 `src/http-app.ts`의 `createApp(config)`로 분리하고 `src/http.ts`는 부팅 엔트리포인트로 축소 — 테스트에서 임의 포트로 앱을 띄울 수 있게 함

**안내 페이지·문서 갱신**
- `GET /` 안내 페이지: Streamable HTTP(`--transport http`, `{"type":"http","url":".../mcp"}`)를 기본으로 안내하고 SSE는 "레거시" 섹션으로 이동, 엔드포인트 목록에 `/mcp` 3종 추가
- `README.md` / `README.ko.md`: 원격 등록 명령을 `--transport http .../mcp`로 변경하고 SSE는 deprecated 안내

**테스트 추가** (`tests/http-transport.test.ts`, 8케이스)
- Streamable HTTP `initialize` → `notifications/initialized` → `tools/list` → `tools/call` → `DELETE` 왕복
- 세션 누락/미존재 요청의 400·404 처리
- 레거시 `/sse` 핸드셰이크 회귀 검증, `/healthz`, 안내 페이지 노출 확인

# 미리보기

로컬(`PORT=3123`) 실측 검증 결과 — 스크린샷 대신 응답 로그로 대체합니다.

작업 전|작업 후
---|---
`POST /mcp` → 404 (라우트 없음)|`POST /mcp` initialize → 200 + `mcp-session-id`, `tools/list` 11개 도구, `tools/call health_check` → `status: ok`, `DELETE /mcp` → 200 (이후 동일 세션 404)
`GET /sse` → 200 (유일한 경로)|`GET /sse` → 200 `event: endpoint` 유지, `/messages` 왕복(initialize·tools/call) 정상 — 회귀 없음

```
$ npm run typecheck   # 통과
$ npm test            # 5 files / 46 tests passed (신규 8건 포함)
$ npm run build       # dist/ 생성
```

DoD 중 **데스크탑 앱/터미널 실연결 확인**은 main 머지 후 `deploy-montage-mcp.yml` 배포가 끝나야 가능하므로, 배포 후 `https://montage-ios.lab.wntd.co/mcp`로 확인 예정입니다.
