### PR TITLE
fix: PushBadge 커스텀 사이즈 inset을 디자인 확정 수식으로 변경

### DIFF
--- a/Sources/Montage/1 Components/4 Contents/Avatar.swift
+++ b/Sources/Montage/1 Components/4 Contents/Avatar.swift
@@ -94,7 +94,9 @@ public struct Avatar: View {
         /// 커스텀 크기
         ///
         /// 커스텀 크기 사용 시 다음 규칙이 자동 적용됩니다:
-        /// - pushBadge size: 36pt 이하 `.xsmall`, 37~52pt `.small`, 53pt 이상 `.medium`
+        /// - pushBadge size: 36pt 이하 `.xsmall`, 37\~52pt `.small`, 53pt 이상 `.medium`
+        /// - pushBadge inset: person `round(0.293 × 크기 / 2)`,
+        ///   company/academy `round(0.293 × (크기 × 0.25 + 2))`
         /// - cornerRadius (company/academy): 크기의 25%에 +2 (짝수로 올림 보정)
         ///
         /// ``Avatar/cornerRadius(_:)``로 cornerRadius를 직접 지정하거나,
@@ -317,10 +319,15 @@ private extension Avatar {
 
     /// 뱃지를 아바타 바운딩 박스 코너에서 안쪽으로 들이는 여백(상단·우측 padding).
     ///
-    /// - person(원형): 원형 45° 접점 기준(≈ 0.29 × 반지름). 24/32/40/48/56 → 4/5/6/7/8.
-    /// - company·academy(둥근 사각): 24/32/40/48/56 → 2/3/4/4/5.
-    /// 커스텀 크기는 각 유형의 비율로 산정한다.
+    /// 뱃지 중심을 코너 반경의 45° 접점에 두기 위해 반경에 `1 - cos(45°)`(= 0.293)를 곱한 값을 사용한다.
+    /// - person(원형, 반경 = 크기 / 2): `round(0.293 × 크기 / 2)`. 24/32/40/48/56 → 4/5/6/7/8.
+    /// - company·academy(둥근 사각, 반경 = 크기 × 0.25 + 2): `round(0.293 × (크기 × 0.25 + 2))`.
+    ///   24/32/40/48/56 → 2/3/4/4/5.
+    ///
+    /// 고정 크기는 위 수식으로 산출된 디자인 확정값을 그대로 사용하고, 커스텀 크기는 수식으로 계산한다.
     var pushBadgeInset: CGSize {
+        // 45° 접점 보정 계수(1 - cos(45°)). 웹·Android와 동일한 디자인 확정값을 사용한다.
+        let tangentRatio: CGFloat = 0.293
         let inset: CGFloat
         switch variant {
         case .person:
@@ -330,7 +337,7 @@ private extension Avatar {
             case .medium: inset = 6
             case .large: inset = 7
             case .xlarge: inset = 8
-            case .custom(let value): inset = (value * 0.15).rounded()
+            case .custom(let value): inset = (tangentRatio * (value / 2)).rounded()
             }
         case .company, .academy:
             switch size {
@@ -339,7 +346,7 @@ private extension Avatar {
             case .medium: inset = 4
             case .large: inset = 4
             case .xlarge: inset = 5
-            case .custom(let value): inset = (value * 0.09).rounded()
+            case .custom(let value): inset = (tangentRatio * (value * 0.25 + 2)).rounded()
             }
         }
         return .init(width: inset, height: inset)

--- a/documentation/components/contents/avatar/ios.md
+++ b/documentation/components/contents/avatar/ios.md
@@ -160,6 +160,7 @@ URL 문자열로 아바타를 초기화합니다.
 
   커스텀 크기 사용 시 다음 규칙이 자동 적용됩니다:
   - pushBadge size: 36pt 이하 `.xsmall`, 37~52pt `.small`, 53pt 이상 `.medium`
+  - pushBadge inset: person `round(0.293 × 크기 / 2)`, company/academy `round(0.293 × (크기 × 0.25 + 2))`
   - cornerRadius (company/academy): 크기의 25%에 +2 (짝수로 올림 보정)
 
 


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2149

디자인에서 전달된 아바타 커스텀 사이즈용 PushBadge inset 수식을 반영한다. ([Slack 스레드](https://wantedx.slack.com/archives/C04TTGN5F1C/p1785311388981789))

- person: `inset = round(0.293 × (size / 2))`
- company·academy: `inset = round(0.293 × (size × 0.25 + 2))`

`0.293`은 `1 - cos(45°)`로, 뱃지 중심을 코너 반경의 45° 접점에 맞추는 계수다.

# 수정사항

`Avatar.pushBadgeInset`의 **커스텀 사이즈 계산식**을 기존 근사식에서 확정 수식으로 교체했다.

| variant | 기존 | 변경 |
|---|---|---|
| person | `(value * 0.15).rounded()` | `(0.293 * (value / 2)).rounded()` |
| company·academy | `(value * 0.09).rounded()` | `(0.293 * (value * 0.25 + 2)).rounded()` |

고정 사이즈(`xsmall` ~ `xlarge`)의 값은 **변경하지 않았다.** 아래처럼 확정 수식의 산출값과 이미 일치해서, 커스텀 값과 고정 값이 끊김 없이 이어진다.

| size | person 수식 | 기존 고정값 | company·academy 수식 | 기존 고정값 |
|---|---|---|---|---|
| 24 | 3.52 → 4 | 4 | 2.34 → 2 | 2 |
| 32 | 4.69 → 5 | 5 | 2.93 → 3 | 3 |
| 40 | 5.86 → 6 | 6 | 3.52 → 4 | 4 |
| 48 | 7.03 → 7 | 7 | 4.10 → 4 | 4 |
| 56 | 8.20 → 8 | 8 | 4.69 → 5 | 5 |

**영향 범위**: `16pt` ~ `120pt` 구간에서 person 28개 / company·academy 58개 크기의 inset이 1pt 조정된다. 특히 기존 `0.09` 계수는 큰 크기에서 편차가 컸다 (`120pt`: 11 → 9).

## 리뷰 시 확인 부탁드리는 지점

company·academy의 실제 `cornerRadius`는 커스텀 크기에서 짝수 보정이 붙어(`ceil(value * 0.25 / 2) * 2 + 2`) 디자인 수식의 기준값(`value * 0.25 + 2`)과 최대 2pt 벌어진다. 예를 들어 `50pt`는 실제 코너 반경이 16이고 수식 기준값은 14.5라서, 45° 접점에 정확히 맞추려면 inset이 5여야 하지만 수식대로면 4가 된다 (반올림 후 최대 1pt 오차).

웹·Android와 값을 일치시키는 편이 중요하다고 판단해 **전달받은 수식을 문자 그대로** 구현했다. 실제 코너 반경 기준으로 맞추려면 `variant.cornerRadius(size:)`를 곱하는 방식으로 한 줄만 바꾸면 된다.

# 미리보기

Blueprint > Avatar 에서 `custom size` 슬라이더(`16pt` ~ `120pt`)와 variant 전환으로 확인할 수 있다.

작업 전|작업 후
---|---
스크린샷 미첨부|스크린샷 미첨부
