### PR TITLE
chore: MCP 색인에 중첩 타입 이니셜라이저·case 시그니처 반영

### DIFF
--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -441,11 +441,6 @@
             "assistive",
             "negative",
             "primary"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ]
         },
         {
@@ -457,11 +452,6 @@
             "medium",
             "small",
             "xsmall"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ]
         },
         {
@@ -471,11 +461,6 @@
           "cases": [
             "outlined",
             "solid"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ]
         }
       ]
@@ -813,11 +798,6 @@
             "medium",
             "small",
             "xsmall"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ]
         },
         {
@@ -1008,11 +988,6 @@
             "medium",
             "small",
             "xsmall"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ]
         },
         {
@@ -2606,11 +2581,6 @@
             "long",
             "short"
           ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
-          ],
           "instanceProperties": [
             {
               "name": "rawValue",
@@ -2936,11 +2906,6 @@
           "cases": [
             "assistive",
             "primary"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ]
         },
         {
@@ -2950,11 +2915,6 @@
           "cases": [
             "medium",
             "small"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ]
         }
       ]

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -121,12 +121,21 @@
           "cases": [
             "automatic",
             "manual"
+          ],
+          "caseSignatures": [
+            "automatic",
+            "manual(_:)"
           ]
         },
         {
           "name": "ActionArea.ButtonInfo",
           "kind": "struct",
           "summary": "ActionArea에 표시될 버튼 정보를 정의하는 구조체입니다.",
+          "initializers": [
+            {
+              "signature": "init(text:action:)"
+            }
+          ],
           "staticMethods": [
             {
               "name": "custom(_:)",
@@ -139,7 +148,15 @@
         {
           "name": "ActionArea.Model",
           "kind": "struct",
-          "summary": "ActionArea를 구성하기 위한 모델 구조체입니다."
+          "summary": "ActionArea를 구성하기 위한 모델 구조체입니다.",
+          "initializers": [
+            {
+              "signature": "init(variant:backgroundTransparencyControl:caption:)"
+            },
+            {
+              "signature": "init(variant:backgroundTransparencyControl:caption:extra:extraDivider:)"
+            }
+          ]
         },
         {
           "name": "ActionArea.Variant",
@@ -149,6 +166,11 @@
             "cancel",
             "neutral",
             "strong"
+          ],
+          "caseSignatures": [
+            "cancel(main:)",
+            "neutral(main:sub:alternative:)",
+            "strong(main:sub:alternative:)"
           ]
         }
       ]
@@ -202,6 +224,14 @@
           "summary": "아바타의 크기를 정의하는 열거형입니다.",
           "cases": [
             "custom",
+            "large",
+            "medium",
+            "small",
+            "xlarge",
+            "xsmall"
+          ],
+          "caseSignatures": [
+            "custom(_:)",
             "large",
             "medium",
             "small",
@@ -319,6 +349,13 @@
             "fixedRatio",
             "flexible",
             "hug"
+          ],
+          "caseSignatures": [
+            "fill",
+            "fixedHeight(_:)",
+            "fixedRatio(_:)",
+            "flexible",
+            "hug"
           ]
         }
       ]
@@ -404,6 +441,11 @@
             "assistive",
             "negative",
             "primary"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ]
         },
         {
@@ -415,6 +457,11 @@
             "medium",
             "small",
             "xsmall"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ]
         },
         {
@@ -424,6 +471,11 @@
           "cases": [
             "outlined",
             "solid"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ]
         }
       ]
@@ -761,6 +813,11 @@
             "medium",
             "small",
             "xsmall"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ]
         },
         {
@@ -821,6 +878,10 @@
           "cases": [
             "accent",
             "neutral"
+          ],
+          "caseSignatures": [
+            "accent(_:background:)",
+            "neutral(_:)"
           ]
         },
         {
@@ -867,6 +928,21 @@
             "horizontal",
             "single",
             "vertical"
+          ],
+          "caseSignatures": [
+            "horizontal(main:alternative:)",
+            "single(_:)",
+            "vertical(main:alternative:)"
+          ]
+        },
+        {
+          "name": "FallbackView.ButtonActionArea.ButtonInfo",
+          "kind": "struct",
+          "summary": "버튼에 표시할 텍스트와 탭 시 실행할 액션을 정의하는 구조체입니다.",
+          "initializers": [
+            {
+              "signature": "init(text:action:)"
+            }
           ]
         }
       ]
@@ -932,6 +1008,11 @@
             "medium",
             "small",
             "xsmall"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ]
         },
         {
@@ -1214,6 +1295,13 @@
             "medium",
             "small",
             "xlarge"
+          ],
+          "caseSignatures": [
+            "custom(size:)",
+            "large",
+            "medium",
+            "small",
+            "xlarge"
           ]
         },
         {
@@ -1222,6 +1310,11 @@
           "summary": "버튼 사이즈를 결정하는 열거형입니다.",
           "cases": [
             "custom",
+            "medium",
+            "small"
+          ],
+          "caseSignatures": [
+            "custom(size:)",
             "medium",
             "small"
           ]
@@ -1235,6 +1328,12 @@
             "normal",
             "outlined",
             "solid"
+          ],
+          "caseSignatures": [
+            "background(size:isAlternative:)",
+            "normal(size:)",
+            "outlined(size:)",
+            "solid(size:)"
           ]
         }
       ]
@@ -1476,6 +1575,10 @@
           "summary": "로딩 애니메이션의 종류를 정의하는 열거형입니다.",
           "cases": [
             "circular",
+            "wanted"
+          ],
+          "caseSignatures": [
+            "circular(color:)",
             "wanted"
           ]
         }
@@ -1782,6 +1885,10 @@
           "cases": [
             "fixed",
             "hug"
+          ],
+          "caseSignatures": [
+            "fixed(_:)",
+            "hug"
           ]
         }
       ]
@@ -1824,12 +1931,21 @@
           "cases": [
             "horizontal",
             "vertical"
+          ],
+          "caseSignatures": [
+            "horizontal(labels:)",
+            "vertical(stepContents:)"
           ]
         },
         {
           "name": "ProgressTracker.VerticalStepContent",
           "kind": "struct",
-          "summary": "수직 진행 추적기에서 각 단계에 표시되는 콘텐츠를 표현하는 공개 타입입니다."
+          "summary": "수직 진행 추적기에서 각 단계에 표시되는 콘텐츠를 표현하는 공개 타입입니다.",
+          "initializers": [
+            {
+              "signature": "init(label:labelAccessoryView:contentView:)"
+            }
+          ]
         }
       ]
     },
@@ -1893,6 +2009,21 @@
             "bottom",
             "center",
             "top"
+          ],
+          "caseSignatures": [
+            "bottom(_:)",
+            "center(_:)",
+            "top(_:)"
+          ]
+        },
+        {
+          "name": "PushBadge.Position.HorizontalPosition",
+          "kind": "enum",
+          "summary": "수평 위치를 정의하는 열거형입니다.",
+          "cases": [
+            "center",
+            "leading",
+            "trailing"
           ]
         },
         {
@@ -1913,6 +2044,11 @@
             "dot",
             "maxCount",
             "text"
+          ],
+          "caseSignatures": [
+            "dot",
+            "maxCount(_:max:)",
+            "text(_:)"
           ]
         }
       ]
@@ -2012,6 +2148,11 @@
           "name": "ScrollView.ScrollStatus",
           "kind": "struct",
           "summary": "스크롤 뷰의 상태를 추적하는 구조체입니다.",
+          "initializers": [
+            {
+              "signature": "init(axis:scrollViewSize:contentSize:contentOffset:)"
+            }
+          ],
           "instanceProperties": [
             {
               "name": "axis",
@@ -2134,7 +2275,12 @@
         {
           "name": "SegmentedControl.Item",
           "kind": "struct",
-          "summary": "세그먼트 컨트롤의 항목을 나타내는 구조체입니다."
+          "summary": "세그먼트 컨트롤의 항목을 나타내는 구조체입니다.",
+          "initializers": [
+            {
+              "signature": "init(leadingIcon:title:)"
+            }
+          ]
         },
         {
           "name": "SegmentedControl.Size",
@@ -2204,6 +2350,11 @@
           "name": "Select.Item",
           "kind": "struct",
           "summary": "Select 컴포넌트에서 사용하는 항목 모델을 정의합니다.",
+          "initializers": [
+            {
+              "signature": "init(text:icon:isNegative:isSelected:)"
+            }
+          ],
           "instanceProperties": [
             {
               "name": "icon",
@@ -2239,6 +2390,11 @@
             "custom",
             "icon",
             "iconButton"
+          ],
+          "caseSignatures": [
+            "custom(_:)",
+            "icon(_:)",
+            "iconButton(_:)"
           ]
         },
         {
@@ -2275,6 +2431,10 @@
           "cases": [
             "multiple",
             "single"
+          ],
+          "caseSignatures": [
+            "multiple(render:overflow:menuPrimaryButtonTitle:)",
+            "single(selectionType:menuPrimaryButtonTitle:)"
           ]
         }
       ]
@@ -2351,6 +2511,11 @@
           "name": "Skeleton.SkeletonView",
           "kind": "struct",
           "summary": "스켈레톤 로딩 UI를 표시하는 뷰입니다.",
+          "initializers": [
+            {
+              "signature": "init(_:)"
+            }
+          ],
           "modifiers": [
             {
               "name": "color(_:)",
@@ -2441,6 +2606,11 @@
             "long",
             "short"
           ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
+          ],
           "instanceProperties": [
             {
               "name": "rawValue",
@@ -2457,12 +2627,24 @@
           "cases": [
             "bottom",
             "top"
+          ],
+          "caseSignatures": [
+            "bottom(offset:)",
+            "top(offset:)"
           ]
         },
         {
           "name": "SnackBar.Model",
           "kind": "struct",
-          "summary": "SnackBar의 데이터 모델을 정의하는 구조체입니다."
+          "summary": "SnackBar의 데이터 모델을 정의하는 구조체입니다.",
+          "initializers": [
+            {
+              "signature": "init(duration:heading:description:action:)"
+            },
+            {
+              "signature": "init(duration:heading:description:extraContents:action:)"
+            }
+          ]
         }
       ]
     },
@@ -2638,6 +2820,11 @@
             "fixed",
             "limit",
             "normal"
+          ],
+          "caseSignatures": [
+            "fixed(min:max:)",
+            "limit",
+            "normal"
           ]
         },
         {
@@ -2652,6 +2839,15 @@
             "primaryIconButton",
             "segmentedControl",
             "slotView"
+          ],
+          "caseSignatures": [
+            "button(color:title:handler:)",
+            "contentBadge(_:title:)",
+            "icon(_:tintColor:)",
+            "iconButton(icon:tintColor:handler:)",
+            "primaryIconButton(icon:handler:)",
+            "segmentedControl(selectedIndex:icons:accessibilityLabels:onSelect:)",
+            "slotView(_:)"
           ],
           "staticMethods": [
             {
@@ -2740,6 +2936,11 @@
           "cases": [
             "assistive",
             "primary"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ]
         },
         {
@@ -2749,6 +2950,11 @@
           "cases": [
             "medium",
             "small"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ]
         }
       ]
@@ -2833,6 +3039,11 @@
           "name": "TextField.AutoCompletionDataSource",
           "kind": "struct",
           "summary": "텍스트 필드의 자동완성 기능을 위한 데이터 소스를 정의합니다.",
+          "initializers": [
+            {
+              "signature": "init(numberOfSections:sectionTitleAt:numberOfItemsInSection:cellForItemAt:headerView:footerView:maxHeight:)"
+            }
+          ],
           "instanceProperties": [
             {
               "name": "totalNumberOfItems",
@@ -2864,7 +3075,12 @@
         {
           "name": "TextField.TrailingButtonInfo",
           "kind": "struct",
-          "summary": "텍스트 필드의 오른쪽에 표시할 버튼의 속성을 정의합니다."
+          "summary": "텍스트 필드의 오른쪽에 표시할 버튼의 속성을 정의합니다.",
+          "initializers": [
+            {
+              "signature": "init(title:disable:handler:)"
+            }
+          ]
         }
       ]
     },
@@ -2955,12 +3171,21 @@
           "cases": [
             "bottom",
             "top"
+          ],
+          "caseSignatures": [
+            "bottom(offset:)",
+            "top(offset:)"
           ]
         },
         {
           "name": "Toast.Model",
           "kind": "struct",
-          "summary": "토스트 메시지의 데이터 모델을 정의하는 구조체입니다."
+          "summary": "토스트 메시지의 데이터 모델을 정의하는 구조체입니다.",
+          "initializers": [
+            {
+              "signature": "init(_:message:)"
+            }
+          ]
         },
         {
           "name": "Toast.Variant",
@@ -2970,6 +3195,12 @@
             "cautionary",
             "negative",
             "normal",
+            "positive"
+          ],
+          "caseSignatures": [
+            "cautionary",
+            "negative",
+            "normal(_:tint:)",
             "positive"
           ]
         }
@@ -3004,6 +3235,12 @@
             "leading",
             "top",
             "trailing"
+          ],
+          "caseSignatures": [
+            "bottom(arrowPosition:)",
+            "leading(arrowPosition:)",
+            "top(arrowPosition:)",
+            "trailing(arrowPosition:)"
           ]
         },
         {
@@ -3079,6 +3316,11 @@
           "name": "TopNavigation.LeadingButton",
           "kind": "struct",
           "summary": "내비게이션 바의 왼쪽(leading) 영역에 위치하는 기본 버튼입니다.",
+          "initializers": [
+            {
+              "signature": "init(_:)"
+            }
+          ],
           "instanceProperties": [
             {
               "name": "body",
@@ -3094,9 +3336,50 @@
           "summary": "TopNavigation의 좌/우에 표시될 Resource들의 Namespace입니다."
         },
         {
+          "name": "TopNavigation.Resource.LeadingButtonInfo",
+          "kind": "enum",
+          "summary": "TopNavigation의 좌측에 표시될 내용들의 열거형입니다.",
+          "cases": [
+            "back",
+            "icon",
+            "text"
+          ],
+          "caseSignatures": [
+            "back(action:)",
+            "icon(_:action:)",
+            "text(_:action:)"
+          ]
+        },
+        {
+          "name": "TopNavigation.Resource.TrailingButtonInfo",
+          "kind": "enum",
+          "summary": "TopNavigation의 우측에 표시될 내용들의 열거형입니다.",
+          "cases": [
+            "icon",
+            "text"
+          ],
+          "caseSignatures": [
+            "icon(_:disable:showPushBadge:action:)",
+            "text(_:disable:action:)"
+          ],
+          "modifiers": [
+            {
+              "name": "hash(into:)",
+              "signature": "func hash(into: inout Hasher)",
+              "summary": "해시 값을 생성합니다.",
+              "kind": "method"
+            }
+          ]
+        },
+        {
           "name": "TopNavigation.TrailingIconButton",
           "kind": "struct",
           "summary": "내비게이션 바의 오른쪽(trailing)에 위치하는 아이콘 버튼입니다.",
+          "initializers": [
+            {
+              "signature": "init(icon:disable:showPushBadge:action:)"
+            }
+          ],
           "instanceProperties": [
             {
               "name": "body",
@@ -3110,6 +3393,11 @@
           "name": "TopNavigation.TrailingTextButton",
           "kind": "struct",
           "summary": "내비게이션 바의 오른쪽(trailing)에 위치하는 텍스트 버튼입니다.",
+          "initializers": [
+            {
+              "signature": "init(text:disable:action:)"
+            }
+          ],
           "instanceProperties": [
             {
               "name": "body",

--- a/packages/montage-mcp/data/tokens.json
+++ b/packages/montage-mcp/data/tokens.json
@@ -214,6 +214,11 @@
             "violet95",
             "violet99"
           ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
+          ],
           "modifiers": [
             {
               "name": "resolve(_:)",
@@ -303,6 +308,11 @@
             "surfaceNeutralStrong",
             "surfaceNeutralTertiary",
             "surfacePositivePrimary"
+          ],
+          "initializers": [
+            {
+              "signature": "init(rawValue:)"
+            }
           ],
           "modifiers": [
             {

--- a/packages/montage-mcp/data/tokens.json
+++ b/packages/montage-mcp/data/tokens.json
@@ -214,11 +214,6 @@
             "violet95",
             "violet99"
           ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
-          ],
           "modifiers": [
             {
               "name": "resolve(_:)",
@@ -308,11 +303,6 @@
             "surfaceNeutralStrong",
             "surfaceNeutralTertiary",
             "surfacePositivePrimary"
-          ],
-          "initializers": [
-            {
-              "signature": "init(rawValue:)"
-            }
           ],
           "modifiers": [
             {

--- a/packages/montage-mcp/src/core/data/index.ts
+++ b/packages/montage-mcp/src/core/data/index.ts
@@ -21,7 +21,15 @@ export interface NestedTypeRecord {
   name: string;
   kind: string;
   summary?: string;
+  /** Case names without parameter labels (e.g. `bottom`). Always present for enums. */
   cases?: string[];
+  /**
+   * Full case signatures including parameter labels (e.g. `bottom(offset:)`).
+   * Only emitted when at least one case carries associated values, since the
+   * bare name alone is not enough to write the call.
+   */
+  caseSignatures?: string[];
+  initializers?: InitializerRecord[];
   modifiers?: MemberRecord[];
   staticMethods?: MemberRecord[];
   staticProperties?: MemberRecord[];

--- a/packages/montage-mcp/src/core/tools/get-component.ts
+++ b/packages/montage-mcp/src/core/tools/get-component.ts
@@ -45,7 +45,9 @@ function renderComponent(c: ComponentRecord): string {
   if (enums.length > 0) {
     lines.push("", "## Enums (variants / sizes / colors)", "");
     for (const e of enums) {
-      const cases = (e.cases ?? []).map((s) => `\`.${s}\``).join(", ");
+      // associated value가 있는 enum은 이름만으로 호출을 쓸 수 없으므로
+      // 파라미터 라벨이 남은 시그니처를 우선 출력한다 (예: `.bottom(offset:)`).
+      const cases = (e.caseSignatures ?? e.cases ?? []).map((s) => `\`.${s}\``).join(", ");
       const summary = e.summary ? ` — ${e.summary}` : "";
       lines.push(`- **${e.name}**${summary}`);
       if (cases) lines.push(`  - cases: ${cases}`);
@@ -57,6 +59,13 @@ function renderComponent(c: ComponentRecord): string {
     for (const t of others) {
       const summary = t.summary ? ` — ${t.summary}` : "";
       lines.push(`- **${t.name}** (\`${t.kind}\`)${summary}`);
+      // 중첩 타입을 만드는 유일한 계약이므로 이니셜라이저를 함께 노출한다
+      // (예: `ActionArea.ButtonInfo.init(text:action:)`).
+      if (t.initializers && t.initializers.length > 0) {
+        for (const init of t.initializers) {
+          lines.push(`  - init \`${t.name}.${init.signature}\``);
+        }
+      }
       if (t.staticMethods && t.staticMethods.length > 0) {
         for (const sm of t.staticMethods) {
           lines.push(`  - static \`${sm.signature}\``);

--- a/packages/montage-mcp/src/core/tools/get-component.ts
+++ b/packages/montage-mcp/src/core/tools/get-component.ts
@@ -51,6 +51,14 @@ function renderComponent(c: ComponentRecord): string {
       const summary = e.summary ? ` — ${e.summary}` : "";
       lines.push(`- **${e.name}**${summary}`);
       if (cases) lines.push(`  - cases: ${cases}`);
+      // enum도 직접 만들어야 하는 이니셜라이저가 있으면 노출한다. 합성된
+      // `init(rawValue:)`는 생성기(`scripts/build_mcp_data.js`)에서 이미 걸러지므로
+      // 여기 남는 것은 실제로 알아야 하는 API뿐이다.
+      if (e.initializers && e.initializers.length > 0) {
+        for (const init of e.initializers) {
+          lines.push(`  - init \`${e.name}.${init.signature}\``);
+        }
+      }
     }
   }
 

--- a/packages/montage-mcp/tests/tools.test.ts
+++ b/packages/montage-mcp/tests/tools.test.ts
@@ -105,6 +105,16 @@ describe("get_component", () => {
     expect(text).toMatch(/ActionArea\.ButtonInfo\.init\(text:action:\)/);
   });
 
+  it("omits the synthesized init(rawValue:) of raw-value enums", async () => {
+    // `Button.Variant`·`Button.Size` 등은 String raw value를 가지므로 컴파일러가
+    // `init(rawValue:)`를 합성한다. 소비자가 알아야 할 API가 아니라 노이즈이므로
+    // 생성기 단계에서 제외되고, 따라서 응답에도 나타나지 않아야 한다.
+    for (const componentName of ["Button", "Chip", "TextButton"]) {
+      const r = await get("get_component").handler({ componentName });
+      expect(r.content[0]!.text).not.toMatch(/init\(rawValue:\)/);
+    }
+  });
+
   it("returns error for unknown component", async () => {
     const r = await get("get_component").handler({ componentName: "Nope" });
     expect(r.isError).toBe(true);

--- a/packages/montage-mcp/tests/tools.test.ts
+++ b/packages/montage-mcp/tests/tools.test.ts
@@ -80,6 +80,31 @@ describe("get_component", () => {
     expect(r.content[0]!.text).toMatch(/^# Button/);
   });
 
+  it("renders enum cases with their associated value labels", async () => {
+    // `.bottom`만 노출하면 offset을 넘길 수 있다는 사실을 알 수 없다.
+    const snackBar = await get("get_component").handler({ componentName: "SnackBar" });
+    expect(snackBar.content[0]!.text).toMatch(/`\.bottom\(offset:\)`/);
+    expect(snackBar.content[0]!.text).toMatch(/`\.top\(offset:\)`/);
+
+    const popup = await get("get_component").handler({ componentName: "Popup" });
+    expect(popup.content[0]!.text).toMatch(/`\.fixed\(_:\)`/);
+    // associated value가 없는 case는 이름 그대로 유지된다.
+    expect(popup.content[0]!.text).toMatch(/`\.hug`/);
+  });
+
+  it("keeps bare case names for enums without associated values", async () => {
+    const r = await get("get_component").handler({ componentName: "Button" });
+    const text = r.content[0]!.text;
+    expect(text).toMatch(/`\.solid`/);
+    expect(text).not.toMatch(/`\.solid\(/);
+  });
+
+  it("renders initializers of nested types", async () => {
+    const r = await get("get_component").handler({ componentName: "ActionArea" });
+    const text = r.content[0]!.text;
+    expect(text).toMatch(/ActionArea\.ButtonInfo\.init\(text:action:\)/);
+  });
+
   it("returns error for unknown component", async () => {
     const r = await get("get_component").handler({ componentName: "Nope" });
     expect(r.isError).toBe(true);

--- a/scripts/build_mcp_data.js
+++ b/scripts/build_mcp_data.js
@@ -166,6 +166,15 @@ function extractMembers(json, componentDir, sectionTitle) {
   return out;
 }
 
+/**
+ * 중첩 타입으로 수집할 심볼 종류.
+ *
+ * DocC는 자식을 가진 심볼에만 디렉토리를 만들기 때문에 대부분은 타입이지만,
+ * associated value를 가진 enum case처럼 자식이 생기는 멤버도 있을 수 있다.
+ * 타입이 아닌 멤버가 `nestedTypes`에 섞이지 않도록 종류로 걸러낸다.
+ */
+const NESTED_TYPE_KINDS = new Set(['struct', 'enum', 'class', 'protocol', 'actor', 'typealias']);
+
 function extractNestedTypes(componentDir, componentName) {
   if (!fs.existsSync(componentDir)) return [];
   const entries = fs.readdirSync(componentDir, { withFileTypes: true });
@@ -183,6 +192,13 @@ function extractNestedTypes(componentDir, componentName) {
     }
     const symbolKind = typeJson?.metadata?.symbolKind;
     if (!symbolKind) continue;
+    const nestedDir = path.join(componentDir, slug);
+    // 타입이 아닌 심볼(enum case 등)은 nestedTypes에 넣지 않되, 그 하위에 있는
+    // 실제 타입은 놓치지 않도록 재귀는 그대로 수행한다.
+    if (!NESTED_TYPE_KINDS.has(symbolKind)) {
+      types.push(...extractNestedTypes(nestedDir, componentName));
+      continue;
+    }
     const title = typeJson?.metadata?.title || slug;
     const record = {
       name: title,
@@ -192,15 +208,22 @@ function extractNestedTypes(componentDir, componentName) {
     if (symbolKind === 'enum') {
       const casesSec = findSection(typeJson, (t) => t === 'Enumeration Cases' || t === 'Cases');
       if (casesSec) {
-        record.cases = (casesSec.identifiers || []).map((id) => {
-          const t = tail(id);
-          return t.replace(/\(.*\)$/, '');
-        });
+        const caseTails = (casesSec.identifiers || []).map((id) => tail(id));
+        record.cases = caseTails.map((t) => t.replace(/\(.*\)$/, ''));
+        // associated value가 있는 case는 이름만으로는 호출 형태를 알 수 없으므로
+        // 파라미터 라벨이 남은 전체 시그니처를 함께 노출한다.
+        // (`cases`는 기존 소비자 호환을 위해 이름만 유지)
+        if (caseTails.some((t) => t.includes('('))) {
+          record.caseSignatures = caseTails;
+        }
       }
     }
+    // 중첩 타입의 이니셜라이저는 그 타입을 만드는 유일한 계약이므로 함께 노출한다.
+    // (예: `FallbackView.ButtonActionArea.ButtonInfo.init(text:action:)`)
+    const inits = extractInitializers(typeJson);
+    if (inits.length > 0) record.initializers = inits;
     // Static factories like `TopNavigation.LeadingButton.back(action:)` live as
     // "Type Methods" / "Type Properties" inside the nested-type subdir.
-    const nestedDir = path.join(componentDir, slug);
     if (fs.existsSync(nestedDir)) {
       const staticMethods = extractMembers(typeJson, nestedDir, 'Type Methods');
       const staticProps = extractMembers(typeJson, nestedDir, 'Type Properties');
@@ -212,6 +235,8 @@ function extractNestedTypes(componentDir, componentName) {
       if (instanceProps.length > 0) record.instanceProperties = instanceProps;
     }
     types.push(record);
+    // 2단 이상 중첩된 타입(예: `ButtonActionArea` 안의 `ButtonInfo`)도 수집한다.
+    types.push(...extractNestedTypes(nestedDir, componentName));
   }
   return types;
 }

--- a/scripts/build_mcp_data.js
+++ b/scripts/build_mcp_data.js
@@ -220,7 +220,13 @@ function extractNestedTypes(componentDir, componentName) {
     }
     // 중첩 타입의 이니셜라이저는 그 타입을 만드는 유일한 계약이므로 함께 노출한다.
     // (예: `FallbackView.ButtonActionArea.ButtonInfo.init(text:action:)`)
-    const inits = extractInitializers(typeJson);
+    //
+    // 단, raw value를 가진 enum에 컴파일러가 합성하는 `init(rawValue:)`는 제외한다.
+    // 소비자가 알아야 할 API가 아니면서 색인 전반에 반복돼 노이즈만 늘리고,
+    // enum이 `String` 기반이라는 사실은 case 목록으로 이미 드러난다.
+    const inits = extractInitializers(typeJson).filter(
+      (i) => !(symbolKind === 'enum' && i.signature === 'init(rawValue:)'),
+    );
     if (inits.length > 0) record.initializers = inits;
     // Static factories like `TopNavigation.LeadingButton.back(action:)` live as
     // "Type Methods" / "Type Properties" inside the nested-type subdir.


### PR DESCRIPTION
# 개요
- 이슈 링크 :

`scripts/build_mcp_data.js`가 생성하는 MCP 색인(`packages/montage-mcp/data/`)에서 중첩 타입 정보가 누락되는 문제를 고칩니다.

[#555](https://github.com/wanteddev/montage-ios/pull/555) 리뷰 중 `FallbackView.ButtonActionArea.ButtonInfo`가 색인에 안 나온다는 지적에서 출발했는데, 확인해보니 **FallbackView만의 문제가 아니라 생성기의 기존 한계**였습니다. `ActionArea`도 지금 같은 영향을 받고 있습니다.

문서(`documentation/**/*.md`)는 `scripts/docc_to_md.js`가 생성하며 **원래부터 정상**이었습니다. 이번 변경은 MCP 색인 생성기만 손댑니다.

# 수정사항

`extractNestedTypes()` 세 곳을 고쳤습니다. 모두 **추가 방향**이라 기존 색인 항목이 사라지지 않습니다 (제거 0건 확인).

### 1. 2단 이상 중첩 타입 미수집
`componentDir`의 직속 하위 디렉토리만 순회하고 재귀하지 않아, 중첩 타입 안의 타입이 통째로 빠졌습니다.

→ 각 중첩 타입 디렉토리로 재귀 후 병합. 이번에 실제로 3개가 새로 잡혔습니다:

- `PushBadge.Position.HorizontalPosition`
- `TopNavigation.Resource.LeadingButtonInfo`
- `TopNavigation.Resource.TrailingButtonInfo`

타입 종류 필터(`NESTED_TYPE_KINDS`)를 함께 뒀습니다. DocC는 자식을 가진 심볼에만 디렉토리를 만드는데 associated value가 있는 enum case도 디렉토리가 생길 수 있어, 필터 없이 재귀하면 case가 타입으로 섞입니다. 단, 타입이 아닌 심볼 **하위의** 실제 타입은 놓치지 않도록 재귀 자체는 계속합니다.

### 2. 중첩 타입의 이니셜라이저 미출력
`staticMethods` / `staticProperties` / `modifiers` / `instanceProperties`만 추출하고 `Initializers` 섹션을 읽지 않았습니다. `extractInitializers()`는 이미 있었지만 최상위 컴포넌트에만 쓰였습니다.

→ 중첩 타입에도 호출. 중첩 타입 **22개**에 이니셜라이저가 붙었습니다.

```
ActionArea.ButtonInfo  → init(text:action:)
ActionArea.Model       → init(variant:backgroundTransparencyControl:caption:)
                          init(variant:backgroundTransparencyControl:caption:extra:extraDivider:)
```

### 3. enum case의 associated value 제거
case 이름에서 파라미터 목록을 정규식으로 지워, `.strong`이 무엇을 받는지 알 수 없었습니다.

→ `cases`는 **기존 소비자 호환을 위해 이름만 유지**하고, 파라미터가 있는 case가 하나라도 있을 때만 `caseSignatures`를 추가합니다. enum **23개**에 붙었습니다.

```json
"cases": ["cancel", "neutral", "strong"],
"caseSignatures": [
  "cancel(main:)",
  "neutral(main:sub:alternative:)",
  "strong(main:sub:alternative:)"
]
```

# 미리보기
작업 전|작업 후
---|---
`ActionArea.ButtonInfo`에 이니셜라이저 없음 · `Variant`는 case 이름만 · 2단 중첩 타입 누락|이니셜라이저 22개 · caseSignatures 23개 · 신규 중첩 타입 3개

## 검증
- `make` 통과. `documentation/`은 변경 없음(md 생성기 미수정) — MCP 데이터만 갱신
- `components.json` 중첩 타입 **제거 0건**, 추가 3건
- `tokens.json`은 String 기반 enum 2개에 `init(rawValue:)`가 붙은 10줄 추가

## 참고
`FallbackView.ButtonActionArea.ButtonInfo`는 [#555](https://github.com/wanteddev/montage-ios/pull/555)가 머지된 뒤 `make`를 다시 돌리면 색인에 반영됩니다. 이 브랜치는 `release/4.0.0` 기준이라 아직 해당 타입이 없습니다.
