### PR TITLE
fix: TextField 트레일링 버튼에 접근성 버튼 특성 추가

### DIFF
--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -752,6 +752,7 @@ private extension TextField {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(title)
                 .accessibilityAddTraits(.isButton)
+                .accessibilityRespondsToUserInteraction(disable == false)
         }
 
         var textColor: Color.Semantic {

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -749,6 +749,9 @@ private extension TextField {
                 }
                 .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: disable ? nil : handler))
                 .allowsHitTesting(disable == false)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(title)
+                .accessibilityAddTraits(.isButton)
         }
 
         var textColor: Color.Semantic {


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-1928 (ios 레포 작업 중 발견)

# 수정사항

`TextField`의 트레일링 버튼이 접근성 트리에 **버튼이 아니라 텍스트로만** 노출되고 있었습니다.

```swift
// 기존 — TrailingButton.body
Text(title)
    .paragraph(...)
    ...
    .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: disable ? nil : handler))
    .allowsHitTesting(disable == false)
```

`PressActionDetectingModifier`는 iOS 18 이상에서 `onTapGesture` 기반이므로, 접근성 특성이 없으면 VoiceOver가 이 요소를 버튼으로 인식하지 못하고 이중 탭으로 활성화할 수 없습니다.

`Button`, `IconButton`, `Chip`, `FilterButton`, `ListCell`에 이미 적용된 것과 동일한 방식으로 특성을 지정했습니다.

```swift
    .accessibilityElement(children: .ignore)
    .accessibilityLabel(title)
    .accessibilityAddTraits(.isButton)
```

### 발견 경로

원티드 앱의 회원가입 휴대폰 인증 화면을 디자인 시스템으로 마이그레이션(ios#8653)하면서 확인했습니다. 기존 화면은 `SwiftUI.Button`으로 구현되어 있었기 때문에, 마이그레이션 후 `인증번호` / `재전송` / `인증` 버튼을 VoiceOver로 누를 수 없게 되는 회귀가 생깁니다. 시뮬레이터 접근성 트리에서도 해당 요소가 `text`로만 노출되는 것을 확인했습니다.

`TextField`에 트레일링 버튼을 쓰는 다른 화면들도 같은 영향을 받습니다.

### 참고: 남은 누락

`Accordion`도 헤더 탭이 `PressActionDetectingModifier`로만 처리되어 동일하게 버튼 특성이 없습니다. 다만 펼침/접힘 상태를 어떻게 낭독할지(`accessibilityValue` / `accessibilityHint` 설계)와 새 문구 로컬라이즈가 함께 필요해 성격이 달라, 이 PR에서는 제외했습니다.

### 검증

- `xcodebuild -scheme Montage -destination 'generic/platform=iOS Simulator' build` 성공
- public API 변경 없음 (`private extension`의 Inner View만 수정) → DocC 재생성 불필요

# 미리보기

시각적 변경은 없습니다. 접근성 트리에만 영향이 있어 스크린샷 비교는 생략합니다.

| | 접근성 트리 |
|---|---|
| 작업 전 | `text\|인증번호` — 버튼으로 노출되지 않아 VoiceOver 활성화 불가 |
| 작업 후 | `button\|인증번호` — 버튼 특성 부여, VoiceOver 이중 탭으로 활성화 |

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
