### PR TITLE
feat: List Cell 4.0.0 업데이트

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/IconPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/IconPreview.swift
@@ -19,7 +19,7 @@ struct IconPreview: View {
             // 바깥 ScrollView 하나로 전체를 스크롤하도록 LazyVStack을 쓴다.
             LazyVStack(spacing: 0) {
                 ForEach(iconList, id: \.rawValue) { icon in
-                    ListCell(title: icon.rawValue)
+                    ListCell(label: icon.rawValue)
                         .leadingContent {
                             Image.icon(
                                 icon,

--- a/Sources/Blueprint/Sources/Scene/Previews/IconPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/IconPreview.swift
@@ -20,13 +20,15 @@ struct IconPreview: View {
             LazyVStack(spacing: 0) {
                 ForEach(iconList, id: \.rawValue) { icon in
                     ListCell(label: icon.rawValue)
-                        .leadingContent {
-                            Image.icon(
-                                icon,
-                                renderingMode: .original,
-                                color: color == .clear ? nil : color
-                            )
-                        }
+                        .leadingResources([
+                            .slot {
+                                Image.icon(
+                                    icon,
+                                    renderingMode: .original,
+                                    color: color == .clear ? nil : color
+                                )
+                            }
+                        ])
                 }
             }
         } options: {

--- a/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
@@ -117,6 +117,9 @@ struct ListCellPreview: View {
             }
             HStack {
                 ToggleOption("Label Trailing", isOn: $labelTrailingContent)
+                ToggleOption("+ 다중", isOn: $multipleLabelTrailingContent)
+            }
+            HStack {
                 ToggleOption("Extra Content", isOn: $extraContent)
             }
             HStack {

--- a/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
@@ -49,6 +49,32 @@ struct ListCellPreview: View {
         longText ? "이것은 두 줄 이상으로 표현될 수 있는 긴 설명입니다. 충분히 길어야 줄 바꿈이 됩니다." : "설명"
     }
 
+    var leadingResourceList: [ListCell.Resource.Leading] {
+        guard leadingContent else { return [] }
+        return multipleLeadingContent
+            ? [.checkbox(checked: selected), .avatar("", variant: .person)]
+            : [.checkbox(checked: selected)]
+    }
+
+    var labelTrailingResourceList: [ListCell.Resource.LabelTrailing] {
+        guard labelTrailingContent else { return [] }
+        return multipleLabelTrailingContent
+            ? [.contentBadge(title: "배지"), .icon(.check, tintColor: .semantic(.surfaceBrandPrimary))]
+            : [.contentBadge(title: "배지")]
+    }
+
+    var trailingResourceList: [ListCell.Resource.Trailing] {
+        guard trailingContent else { return [] }
+        return multipleTrailingContent
+            ? [.value("값"), .iconButton(.chevronRight)]
+            : [.iconButton(.chevronRight)]
+    }
+
+    var extraResourceList: [ListCell.Resource.Extra] {
+        guard extraContent else { return [] }
+        return [.contentBadge(.outlined, title: "서울"), .contentBadge(.outlined, title: "5년차")]
+    }
+
     var body: some View {
         PreviewLayout {
             ListCell(label: labelText, onTap: {
@@ -58,43 +84,10 @@ struct ListCellPreview: View {
             .verticalPadding(verticalPaddings[verticalPaddingIndex])
             .verticalAlign(verticalAlignments[verticalAlignmentIndex])
             .chevron(chevron)
-            .leadingContent {
-                if leadingContent {
-                    Checkmark(checked: selected)
-
-                    if multipleLeadingContent {
-                        Avatar("", variant: .person, size: .xsmall)
-                    }
-                }
-            }
-            .labelTrailingContent {
-                if labelTrailingContent {
-                    ContentBadge(text: "배지")
-
-                    if multipleLabelTrailingContent {
-                        Image.icon(.check)
-                            .resizable()
-                            .renderingMode(.template)
-                            .foregroundStyle(SwiftUI.Color.semantic(.surfaceBrandPrimary))
-                            .frame(width: 16, height: 16)
-                    }
-                }
-            }
-            .trailingContent { selected in
-                if trailingContent {
-                    if multipleTrailingContent {
-                        Text("값")
-                    }
-
-                    Checkmark(checked: selected)
-                }
-            }
-            .extraContent {
-                if extraContent {
-                    ContentBadge(variant: .outlined, text: "서울")
-                    ContentBadge(variant: .outlined, text: "5년차")
-                }
-            }
+            .leadingResources(leadingResourceList)
+            .labelTrailingResources(labelTrailingResourceList)
+            .trailingResources(trailingResourceList)
+            .extraResources(extraResourceList)
             .textEllipsis(textEllipsis)
             .divider(divider)
             .disable(disable)

--- a/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
@@ -10,90 +10,143 @@ import Montage
 
 struct ListCellPreview: View {
     @State private var isOn: Bool = true
-    @State private var caption = false
+    @State private var description = false
     @State private var verticalPaddingIndex = 1
-    @State private var fillWidth = false
+    @State private var customVerticalPadding: CGFloat = 24
     @State private var chevron = false
     @State private var leadingContent = false
+    @State private var multipleLeadingContent = false
+    @State private var labelTrailingContent = false
+    @State private var multipleLabelTrailingContent = false
     @State private var trailingContent = false
+    @State private var multipleTrailingContent = false
+    @State private var extraContent = false
     @State private var verticalAlignmentIndex = 0
     @State private var textEllipsis = false
     @State private var divider = false
     @State private var disable = false
     @State private var longText = false
-    @State private var interactionPadding: CGFloat = 12
+    @State private var interactionOutset: CGFloat = 12
+    @State private var interactionRadius: CGFloat = 16
     @State private var selected = false
     @State private var highlightText: String = ""
 
-    let verticalPaddings: [ListCell.VerticalPadding] = [.none, .small, .medium, .large]
-    let verticalAlignments: [VerticalAlignment] = [.top, .center, .bottom]
+    var verticalPaddings: [ListCell.VerticalPadding] {
+        [.none, .small, .medium, .large, .custom(customVerticalPadding)]
+    }
+
+    var isCustomVerticalPadding: Bool {
+        if case .custom = verticalPaddings[verticalPaddingIndex] { true } else { false }
+    }
+
+    let verticalAlignments: [ListCell.VerticalAlign] = [.top, .center]
+
+    var labelText: String {
+        longText ? "이것은 세 줄 이상으로 표현될 수 있는 긴 문장입니다. 충분히 길어야 줄 바꿈이 됩니다. 더욱 더 많이 길어야 합니다." : "텍스트"
+    }
+
+    var descriptionText: String {
+        longText ? "이것은 두 줄 이상으로 표현될 수 있는 긴 설명입니다. 충분히 길어야 줄 바꿈이 됩니다." : "설명"
+    }
 
     var body: some View {
         PreviewLayout {
-            ListCell(title: longText ? "이것은 세 줄 이상으로 표현될 수 있는 긴 문장입니다. 충분히 길어야 줄 바꿈이 됩니다. 더욱 더 많이 길어야 합니다." : "텍스트", onTap: {
+            ListCell(label: labelText, onTap: {
                 print("helloworld")
             })
-            .caption(caption ? "캡션" : nil)
+            .description(description ? descriptionText : nil)
             .verticalPadding(verticalPaddings[verticalPaddingIndex])
             .verticalAlign(verticalAlignments[verticalAlignmentIndex])
-            .fillWidth(fillWidth)
             .chevron(chevron)
             .leadingContent {
                 if leadingContent {
-                    Image.icon(.star)
-                        .resizable()
-                        .frame(width: 56, height: 56)
-                        .scaledToFit()
+                    Checkmark(checked: selected)
+
+                    if multipleLeadingContent {
+                        Image.icon(.star)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .scaledToFit()
+                    }
+                }
+            }
+            .labelTrailingContent {
+                if labelTrailingContent {
+                    ContentBadge(text: "배지")
+
+                    if multipleLabelTrailingContent {
+                        Image.icon(.check)
+                            .resizable()
+                            .renderingMode(.template)
+                            .foregroundStyle(SwiftUI.Color.semantic(.surfaceBrandPrimary))
+                            .frame(width: 16, height: 16)
+                    }
                 }
             }
             .trailingContent { selected in
                 if trailingContent {
+                    if multipleTrailingContent {
+                        Text("값")
+                    }
+
                     Checkmark(checked: selected)
+                }
+            }
+            .extraContent {
+                if extraContent {
+                    ContentBadge(variant: .outlined, text: "서울")
+                    ContentBadge(variant: .outlined, text: "5년차")
                 }
             }
             .textEllipsis(textEllipsis)
             .divider(divider)
             .disable(disable)
-            .interactionPadding(interactionPadding)
+            .interactionOutset(interactionOutset)
+            .interactionRadius(interactionRadius)
             .selected(selected)
             .if(!highlightText.isEmpty) {
                 $0.highlight(highlightText)
             }
         } options: {
             SegmentedIndexRow("Vertical Padding", index: $verticalPaddingIndex, labels: verticalPaddings.map(\.description))
+            if isCustomVerticalPadding {
+                SliderOptionRow("Custom Vertical Padding", value: $customVerticalPadding, in: 0...40, step: 1, format: { "\(Int(Double($0)))pt" })
+            }
             HStack {
-                ToggleOption("Caption", isOn: $caption)
-                ToggleOption("Fill Width", isOn: $fillWidth)
+                ToggleOption("Description", isOn: $description)
                 ToggleOption("Chevron", isOn: $chevron)
-            }
-            HStack {
-                ToggleOption("Leading Content", isOn: $leadingContent)
-                ToggleOption("Trailing Content", isOn: $trailingContent)
-            }
-            HStack {
-                ToggleOption("Text Ellipsis", isOn: $textEllipsis)
                 ToggleOption("Divider", isOn: $divider)
             }
             HStack {
-                ToggleOption("Disable", isOn: $disable)
+                ToggleOption("Leading Content", isOn: $leadingContent)
+                ToggleOption("+ 다중", isOn: $multipleLeadingContent)
+            }
+            HStack {
+                ToggleOption("Trailing Content", isOn: $trailingContent)
+                ToggleOption("+ 다중", isOn: $multipleTrailingContent)
+            }
+            HStack {
+                ToggleOption("Label Trailing", isOn: $labelTrailingContent)
+                ToggleOption("Extra Content", isOn: $extraContent)
+            }
+            HStack {
+                ToggleOption("Text Ellipsis", isOn: $textEllipsis)
                 ToggleOption("Long Text", isOn: $longText)
+            }
+            HStack {
+                ToggleOption("Disable", isOn: $disable)
                 ToggleOption("Selected", isOn: $selected)
             }
-            SegmentedIndexRow("Vertical Alignment", index: $verticalAlignmentIndex, labels: verticalAlignments.map { alignment in
-                switch alignment {
-                case .top: "top"
-                case .center: "center"
-                case .bottom: "bottom"
-                default: "unknown"
-                }
-            })
-            SliderOptionRow("Interaction Padding", value: $interactionPadding, in: 0...20, step: 1, format: { "\(Int(Double($0)))pt" })
+            SegmentedIndexRow("Vertical Alignment", index: $verticalAlignmentIndex, labels: verticalAlignments.map(\.description))
+            SliderOptionRow("Interaction Outset", value: $interactionOutset, in: 0...20, step: 1, format: { "\(Int(Double($0)))pt" })
+            SliderOptionRow("Interaction Radius", value: $interactionRadius, in: 0...20, step: 1, format: { "\(Int(Double($0)))pt" })
             TextFieldOptionRow("Highlight Text", text: $highlightText)
         }
     }
 }
 
 extension ListCell.VerticalPadding: CaseDescribable {}
+extension ListCell.VerticalAlign: CaseDescribable {}
 
 #Preview {
     ListCellPreview()

--- a/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
@@ -63,10 +63,7 @@ struct ListCellPreview: View {
                     Checkmark(checked: selected)
 
                     if multipleLeadingContent {
-                        Image.icon(.star)
-                            .resizable()
-                            .frame(width: 24, height: 24)
-                            .scaledToFit()
+                        Avatar("", variant: .person, size: .xsmall)
                     }
                 }
             }

--- a/Sources/Blueprint/Sources/Scene/Previews/SelectPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SelectPreview.swift
@@ -104,10 +104,8 @@ struct SelectPreview: View {
                                 break
                             }
                         }
+                        // selected 상태의 체크 아이콘은 ListCell이 직접 그린다.
                         .selected(items[index].isSelected)
-                        .trailingContent { active in
-                            Checkmark(checked: active)
-                        }
                     }
                 }
             }

--- a/Sources/Blueprint/Sources/Scene/Previews/SelectPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SelectPreview.swift
@@ -89,7 +89,7 @@ struct SelectPreview: View {
             .bottomSheet(isPresented: $showSheet) {
                 VStack {
                     ForEach(items.indices, id: \.self) { index in
-                        ListCell(title: items[index].text) {
+                        ListCell(label: items[index].text) {
                             switch variants[variantIndex] {
                             case .single:
                                 items = items.map {

--- a/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
@@ -140,7 +140,7 @@ struct TextFieldPreview: View {
                 suggestions.count
             },
             cellForItemAt: { indexPath in
-                ListCell(title: suggestions[indexPath.row]) {
+                ListCell(label: suggestions[indexPath.row]) {
                     self.text = suggestions[indexPath.row]
                     Task {
                         self.autoCompletionDataSource = nil
@@ -158,17 +158,17 @@ struct TextFieldPreview: View {
                     }
                 }
                 .if(indexPath.section == 1) {
-                    $0.caption("캡션")
+                    $0.description("설명")
                 }
             },
             headerView: {
-                ListCell(title: "'\(trimmed)' 사용하기") {
+                ListCell(label: "'\(trimmed)' 사용하기") {
                     autoCompletionDataSource = nil
                 }
                 .highlight(trimmed)
             },
             footerView: {
-                ListCell(title: "'\(trimmed)' 사용하기") {
+                ListCell(label: "'\(trimmed)' 사용하기") {
                     autoCompletionDataSource = nil
                 }
                 .highlight(trimmed)

--- a/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
@@ -147,16 +147,11 @@ struct TextFieldPreview: View {
                     }
                 }
                 .highlight(trimmed)
-                .leadingContent {
-                    Group {
-                        if indexPath.section == 0 {
-                            Image.icon(.search)
-                                .foregroundStyle(SwiftUI.Color.semantic(.foregroundNeutralTertiary))
-                        } else {
-                            Avatar("", variant: .company, size: .medium)
-                        }
-                    }
-                }
+                .leadingResources([
+                    indexPath.section == 0
+                        ? .icon(.search, tintColor: .semantic(.foregroundNeutralTertiary))
+                        : .avatar("", variant: .company)
+                ])
                 .if(indexPath.section == 1) {
                     $0.description("설명")
                 }

--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -429,7 +429,7 @@ public struct Select: View {
         LazyVStack(spacing: 4) {
             ForEach(items.indices, id: \.self) { index in
                 Group {
-                    let cell = ListCell(title: items[index].text) {
+                    let cell = ListCell(label: items[index].text) {
                         switch variant {
                         case .single(_, let primaryButtonTitle):
                             deselectAll()

--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -450,14 +450,10 @@ public struct Select: View {
                             // 체크 아이콘은 ListCell이 selected 상태에서 직접 그린다.
                             cell.selected(items[index].isSelected)
                         case .radio:
-                            cell.leadingContent {
-                                Radio(checked: items[index].isSelected)
-                            }
+                            cell.leadingResources([.radio(checked: items[index].isSelected)])
                         }
                     case .multiple:
-                        cell.leadingContent {
-                            Checkbox(checked: items[index].isSelected)
-                        }
+                        cell.leadingResources([.checkbox(checked: items[index].isSelected)])
                     }
                 }
             }

--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -447,19 +447,8 @@ public struct Select: View {
                     case .single(let selectionType, _):
                         switch selectionType {
                         case .checkmark:
+                            // 체크 아이콘은 ListCell이 selected 상태에서 직접 그린다.
                             cell.selected(items[index].isSelected)
-                                .trailingContent { active in
-                                    Group {
-                                        if active {
-                                            Image.icon(.check)
-                                                .resizable()
-                                                .foregroundStyle(
-                                                    SwiftUI.Color.semantic(.surfaceBrandPrimary)
-                                                )
-                                                .frame(width: 24, height: 24)
-                                        }
-                                    }
-                                }
                         case .radio:
                             cell.leadingContent {
                                 Radio(checked: items[index].isSelected)

--- a/Sources/Montage/1 Components/4 Contents/Accordion.swift
+++ b/Sources/Montage/1 Components/4 Contents/Accordion.swift
@@ -278,8 +278,8 @@ public struct Accordion: View {
                 .padding(.horizontal, fillWidth ? 20 : 0)
                 .modifier(ListCellInteractionModifier(
                     pressed: $isPressed,
-                    fillWidth: fillWidth,
-                    interactionPadding: 12
+                    outset: fillWidth ? 0 : 12,
+                    radius: fillWidth ? 0 : 12
                 ))
                 .modifier(PressActionDetectingModifier(isPressed: $isPressed) {
                     withAnimation(.timingCurve(0.25, 0.1, 0.25, 1, duration: 0.3)) {

--- a/Sources/Montage/1 Components/4 Contents/Avatar.swift
+++ b/Sources/Montage/1 Components/4 Contents/Avatar.swift
@@ -160,6 +160,11 @@ public struct Avatar: View {
     // MARK: - Body
     
     @State private var isPressed = false
+
+    /// 상위 컨테이너가 `disabled(_:)`로 비활성화되면 이미지도 흐리게 표시한다.
+    ///
+    /// 이미지 계열은 색 토큰으로 비활성을 표현할 수 없어 불투명도를 낮춘다.
+    @Environment(\.isEnabled) private var isEnabled
     
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
@@ -193,6 +198,7 @@ public struct Avatar: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(variant.accessibilityDescription)
             .if(onTap != nil) { $0.accessibilityAddTraits(.isButton) }
+            .opacity(isEnabled ? 1 : Double(CGFloat.opacity43))
     }
 
     private var pushBadge = false

--- a/Sources/Montage/1 Components/4 Contents/ListCell.swift
+++ b/Sources/Montage/1 Components/4 Contents/ListCell.swift
@@ -10,8 +10,8 @@ import SwiftUI
 /// 텍스트와 콘텐츠를 포함하는 리스트 아이템 컴포넌트입니다.
 ///
 /// `ListCell`은 앱 내에서 리스트 형태로 정보를 표시할 때 사용되는 기본 컴포넌트입니다.
-/// 라벨, 부가 설명과 함께 네 종류의 콘텐츠 슬롯(``leadingContent(_:)``, ``labelTrailingContent(_:)``,
-/// ``trailingContent(_:)``, ``extraContent(_:)``)을 제공하며 다양한 스타일로 커스터마이징할 수 있습니다.
+/// 라벨, 부가 설명과 함께 네 종류의 콘텐츠 슬롯(``leadingResources(_:)``, ``labelTrailingResources(_:)``,
+/// ``trailingResources(_:)``, ``extraResources(_:)``)을 제공하며 다양한 스타일로 커스터마이징할 수 있습니다.
 ///
 /// ```swift
 /// // 기본 셀
@@ -21,14 +21,11 @@ import SwiftUI
 /// ListCell(label: "설명이 있는 셀")
 ///     .description("부가 설명 텍스트")
 ///
-/// // 리딩 콘텐츠와 선택 상태의 셀
+/// // 리딩 요소와 선택 상태의 셀
 /// ListCell(label: "커스텀 셀", onTap: {
 ///     print("셀이 탭되었습니다")
 /// })
-/// .leadingContent {
-///     Image.icon(.person)
-///         .frame(width: 24, height: 24)
-/// }
+/// .leadingResources([.icon(.person)])
 /// .selected(true)
 /// .chevron(true)
 /// ```
@@ -36,24 +33,26 @@ import SwiftUI
 /// ## 콘텐츠 슬롯
 ///
 /// 네 슬롯은 셀 안에서 각각 다음 위치를 차지하며, 슬롯마다 여러 요소를 나열할 수 있습니다.
+/// 슬롯에 넣을 수 있는 요소는 ``Resource``에 슬롯별로 정의되어 있어, 다른 슬롯 전용 요소를 넘기면 컴파일되지 않습니다.
 ///
-/// - ``leadingContent(_:)``: 라벨 앞, 항목 간 간격 8
-/// - ``labelTrailingContent(_:)``: 라벨 바로 뒤, 항목 간 간격 4
-/// - ``trailingContent(_:)``: 셀 오른쪽 끝, 항목 간 간격 8
-/// - ``extraContent(_:)``: 설명 아래, 항목 간 간격 6
+/// - ``leadingResources(_:)``: 라벨 앞, 항목 간 간격 8
+/// - ``labelTrailingResources(_:)``: 라벨 바로 뒤, 항목 간 간격 4
+/// - ``trailingResources(_:)``: 셀 오른쪽 끝, 항목 간 간격 8
+/// - ``extraResources(_:)``: 설명 아래, 항목 간 간격 6
 ///
 /// ```swift
 /// ListCell(label: "김티드")
 ///     .description("iOS 개발자")
-///     .labelTrailingContent {
-///         ContentBadge(text: "신규")
-///     }
-///     .extraContent {
-///         ContentBadge(variant: .outlined, text: "서울")
-///     }
-///     .trailingContent { _ in
-///         Text("값")
-///     }
+///     .labelTrailingResources([.contentBadge(title: "신규")])
+///     .extraResources([.contentBadge(.outlined, title: "서울")])
+///     .trailingResources([.value("값")])
+/// ```
+///
+/// 목록에 없는 구성이 필요하면 각 슬롯 타입의 `slot(_:)` 팩토리로 임의 뷰를 넣을 수 있습니다.
+///
+/// ```swift
+/// ListCell(label: "커스텀")
+///     .trailingResources([.slot { MyCustomView() }])
 /// ```
 public struct ListCell: View {
     // MARK: - Types
@@ -138,9 +137,6 @@ public struct ListCell: View {
 
     // MARK: - Body
     @State private var isPressed = false
-    @State private var leadingContentEmpty = false
-    @State private var trailingContentEmpty = false
-    @State private var labelTrailingContentEmpty = true
 
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
@@ -180,10 +176,10 @@ public struct ListCell: View {
     private var selected = false
     private var divider = false
     private var chevron = false
-    private var leadingContent: (() -> AnyView)? = nil
-    private var labelTrailingContent: (() -> AnyView)? = nil
-    private var trailingContent: ((Bool) -> AnyView)? = nil
-    private var extraContent: (() -> AnyView)? = nil
+    private var leadingResources: [Resource.Leading] = []
+    private var labelTrailingResources: [Resource.LabelTrailing] = []
+    private var trailingResources: [Resource.Trailing] = []
+    private var extraResources: [Resource.Extra] = []
     private var interactionOutset: CGFloat = 12
     private var interactionRadius: CGFloat? = nil
     private var verticalAlignment: VerticalAlign = .top
@@ -337,8 +333,8 @@ public struct ListCell: View {
     ///   - selected: 선택 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 ListCell 인스턴스
     ///
-    /// - Important: 체크 아이콘은 ``trailingContent(_:)`` 자리를 대신 차지하므로 둘을 함께 표시할 수 없습니다.
-    ///   선택 상태와 별개의 우측 콘텐츠가 필요하면 ``labelTrailingContent(_:)`` 또는 ``extraContent(_:)``를 사용하세요.
+    /// - Important: 체크 아이콘은 ``trailingResources(_:)`` 자리를 대신 차지하므로 둘을 함께 표시할 수 없습니다.
+    ///   선택 상태와 별개의 우측 콘텐츠가 필요하면 ``labelTrailingResources(_:)`` 또는 ``extraResources(_:)``를 사용하세요.
     public func selected(_ selected: Bool = true) -> Self {
         var zelf = self
         zelf.selected = selected
@@ -369,87 +365,89 @@ public struct ListCell: View {
         return zelf
     }
 
-    /// 셀 좌측에 추가 콘텐츠를 표시합니다.
+    /// 셀 좌측에 표시할 요소를 지정합니다.
     ///
     /// 아이콘, 체크박스, 아바타, 썸네일 등을 셀 라벨 앞에 배치할 수 있습니다.
-    /// 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다.
+    /// 여러 개를 넘기면 8포인트 간격으로 가로 배치됩니다.
     ///
     /// ```swift
     /// ListCell(label: "김티드")
-    ///     .leadingContent {
-    ///         Checkbox(checked: isChecked)
-    ///         Avatar(image: profileImage)
-    ///     }
+    ///     .leadingResources([
+    ///         .checkbox(checked: isChecked),
+    ///         .avatar(profileImageURL, variant: .person)
+    ///     ])
     /// ```
     ///
     /// - Parameters:
-    ///   - contents: 표시할 콘텐츠를 생성하는 클로저
+    ///   - resources: 표시할 요소 목록
     /// - Returns: 수정된 ListCell 인스턴스
-    public func leadingContent<V: View>(@ViewBuilder _ contents: @escaping () -> V) -> Self {
+    public func leadingResources(_ resources: [Resource.Leading]) -> Self {
         var zelf = self
-        zelf.leadingContent = { AnyView(contents()) }
+        zelf.leadingResources = resources
         return zelf
     }
 
-    /// 라벨 행의 오른쪽 끝에 콘텐츠를 표시합니다.
+    /// 라벨 행의 오른쪽 끝에 표시할 요소를 지정합니다.
     ///
     /// 배지나 인증 아이콘처럼 라벨에 딸린 요소를 배치할 때 사용합니다.
-    /// 여러 요소를 나열하면 4포인트 간격으로 가로 배치되며, 높이가 22포인트로 고정되어 행 높이를 늘리지 않습니다.
+    /// 여러 개를 넘기면 4포인트 간격으로 가로 배치되며, 높이가 22포인트로 고정되어 행 높이를 늘리지 않습니다.
     ///
     /// ```swift
     /// ListCell(label: "김티드")
-    ///     .labelTrailingContent {
-    ///         ContentBadge(text: "신규")
-    ///     }
+    ///     .labelTrailingResources([.contentBadge(title: "신규")])
     /// ```
     ///
     /// - Parameters:
-    ///   - contents: 표시할 콘텐츠를 생성하는 클로저
+    ///   - resources: 표시할 요소 목록
     /// - Returns: 수정된 ListCell 인스턴스
     ///
     /// - Note: 라벨이 2줄 이상일 때 표시 위치는 ``verticalAlign(_:)``을 따릅니다.
-    public func labelTrailingContent<V: View>(@ViewBuilder _ contents: @escaping () -> V) -> Self {
+    public func labelTrailingResources(_ resources: [Resource.LabelTrailing]) -> Self {
         var zelf = self
-        zelf.labelTrailingContent = { AnyView(contents()) }
+        zelf.labelTrailingResources = resources
         return zelf
     }
 
-    /// 셀 우측에 추가 콘텐츠를 표시합니다.
+    /// 셀 우측에 표시할 요소를 지정합니다.
     ///
-    /// 값 텍스트, 배지, 버튼, 스위치 등 추가 UI 요소를 셀 오른쪽 끝에 배치할 수 있습니다.
-    /// 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다.
-    /// 클로저 파라미터를 통해 셀의 선택된 상태를 전달받을 수 있습니다.
+    /// 값 텍스트, 배지, 버튼, 스위치 등을 셀 오른쪽 끝에 배치할 수 있습니다.
+    /// 여러 개를 넘기면 8포인트 간격으로 가로 배치됩니다.
+    ///
+    /// ```swift
+    /// ListCell(label: "알림 받기")
+    ///     .trailingResources([.switch(checked: isOn, onSelect: { isOn = $0 })])
+    /// ```
     ///
     /// - Parameters:
-    ///   - contents: 표시할 콘텐츠를 생성하는 클로저 (선택된 상태를 파라미터로 받음)
+    ///   - resources: 표시할 요소 목록
     /// - Returns: 수정된 ListCell 인스턴스
-    public func trailingContent<V: View>(@ViewBuilder _ contents: @escaping (Bool) -> V) -> Self {
+    ///
+    /// - Important: ``selected(_:)``가 `true`인 셀은 체크 아이콘이 이 자리를 대신 차지해 요소가 표시되지 않습니다.
+    public func trailingResources(_ resources: [Resource.Trailing]) -> Self {
         var zelf = self
-        zelf.trailingContent = { AnyView(contents($0)) }
+        zelf.trailingResources = resources
         return zelf
     }
 
-    /// 설명 아래에 자유 콘텐츠를 표시합니다.
+    /// 설명 아래에 표시할 요소를 지정합니다.
     ///
-    /// 셀 폭을 모두 사용하는 자유 슬롯으로, 여러 요소를 나열하면 6포인트 간격으로 가로 배치됩니다.
+    /// 셀 폭을 모두 사용하며, 여러 개를 넘기면 6포인트 간격으로 가로 배치됩니다.
     ///
     /// ```swift
     /// ListCell(label: "김티드")
     ///     .description("iOS 개발자")
-    ///     .extraContent {
-    ///         ContentBadge(variant: .outlined, text: "서울")
-    ///         ContentBadge(variant: .outlined, text: "5년차")
-    ///     }
+    ///     .extraResources([
+    ///         .contentBadge(.outlined, title: "서울"),
+    ///         .contentBadge(.outlined, title: "5년차")
+    ///     ])
     /// ```
     ///
     /// - Parameters:
-    ///   - contents: 표시할 콘텐츠를 생성하는 클로저
+    ///   - resources: 표시할 요소 목록
     /// - Returns: 수정된 ListCell 인스턴스
-    ///
-    /// - Note: 슬롯 내부 구성은 사용처가 정하며, 그 안의 타이포그래피와 색상은 컴포넌트가 보장하지 않습니다.
-    public func extraContent<V: View>(@ViewBuilder _ contents: @escaping () -> V) -> Self {
+    public func extraResources(_ resources: [Resource.Extra]) -> Self {
         var zelf = self
-        zelf.extraContent = { AnyView(contents()) }
+        zelf.extraResources = resources
         return zelf
     }
 
@@ -504,13 +502,14 @@ extension ListCell {
 
     private var row: some View {
         HStack(alignment: verticalAlignment.alignment, spacing: 0) {
-            if let leadingContent {
+            if leadingResources.isEmpty == false {
                 HStack(alignment: .center, spacing: 8) {
-                    leadingContent()
+                    ForEach(Array(leadingResources.enumerated()), id: \.offset) { _, resource in
+                        resource.view
+                    }
                 }
-                .ifEmptyView { leadingContentEmpty = $0 }
-                .frame(minHeight: leadingContentEmpty ? 0 : Self.rowMinHeight)
-                .padding(.trailing, leadingContentEmpty ? 0 : 8)
+                .frame(minHeight: Self.rowMinHeight)
+                .padding(.trailing, 8)
             }
 
             VStack(alignment: .leading, spacing: 0) {
@@ -529,9 +528,11 @@ extension ListCell {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                if let extraContent {
+                if extraResources.isEmpty == false {
                     HStack(alignment: .center, spacing: 6) {
-                        extraContent()
+                        ForEach(Array(extraResources.enumerated()), id: \.offset) { _, resource in
+                            resource.view
+                        }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -546,13 +547,14 @@ extension ListCell {
                     .frame(width: Self.selectedCheckSize, height: Self.selectedCheckSize)
                     .frame(minHeight: Self.rowMinHeight)
                     .padding(.leading, 8)
-            } else if let trailingContent {
+            } else if trailingResources.isEmpty == false {
                 HStack(alignment: .center, spacing: 8) {
-                    trailingContent(selected)
+                    ForEach(Array(trailingResources.enumerated()), id: \.offset) { _, resource in
+                        resource.view
+                    }
                 }
-                .ifEmptyView { trailingContentEmpty = $0 }
-                .frame(minHeight: trailingContentEmpty ? 0 : Self.rowMinHeight)
-                .padding(.leading, trailingContentEmpty ? 0 : 8)
+                .frame(minHeight: Self.rowMinHeight)
+                .padding(.leading, 8)
             }
 
             if chevron {
@@ -582,21 +584,22 @@ extension ListCell {
             }
             .fixedSize(horizontal: false, vertical: true)
             // labelTrailing이 없을 때만 라벨이 행을 채운다.
-            // 있을 때는 라벨이 hug해서 짧으면 콘텐츠가 바로 옆에 붙고, 길면 아래 Spacer가 0으로 줄며
-            // 콘텐츠 자리를 뺀 남은 폭에서 줄바꿈된다.
-            .if(labelTrailingContentEmpty) {
+            // 있을 때는 라벨이 hug해서 짧으면 요소가 바로 옆에 붙고, 길면 아래 Spacer가 0으로 줄며
+            // 요소 자리를 뺀 남은 폭에서 줄바꿈된다.
+            .if(labelTrailingResources.isEmpty) {
                 $0.frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            if let labelTrailingContent {
+            if labelTrailingResources.isEmpty == false {
                 HStack(alignment: .center, spacing: 4) {
-                    labelTrailingContent()
+                    ForEach(Array(labelTrailingResources.enumerated()), id: \.offset) { _, resource in
+                        resource.view
+                    }
                 }
-                .ifEmptyView { labelTrailingContentEmpty = $0 }
-                // 라벨이 길어져도 콘텐츠는 축소되지 않는다.
+                // 라벨이 길어져도 요소는 축소되지 않는다.
                 .fixedSize(horizontal: true, vertical: false)
-                .frame(height: labelTrailingContentEmpty ? 0 : Self.labelContentHeight)
-                .padding(.leading, labelTrailingContentEmpty ? 0 : 4)
+                .frame(height: Self.labelContentHeight)
+                .padding(.leading, 4)
 
                 Spacer(minLength: 0)
             }
@@ -631,6 +634,307 @@ extension ListCell {
                         semantic: resolvedLabelColor
                     )
             }
+        }
+    }
+}
+
+// MARK: - Resource
+extension ListCell {
+    /// ``ListCell``의 각 슬롯에 표시할 요소들의 Namespace입니다.
+    ///
+    /// 슬롯마다 쓸 수 있는 요소가 다르므로 슬롯별로 타입을 나눠 두었습니다.
+    /// 예를 들어 ``Trailing/switch(checked:onSelect:)``는 ``ListCell/trailingResources(_:)``에만 넘길 수 있고,
+    /// ``ListCell/leadingResources(_:)``에 넘기면 컴파일되지 않습니다.
+    ///
+    /// 각 요소의 크기와 정렬은 셀 스펙(행 최소 높이 24)에 맞춰 고정됩니다.
+    /// 목록에 없는 구성이 필요하면 각 타입의 `slot(_:)` 팩토리를 사용합니다.
+    public enum Resource {
+        /// 셀 좌측(``ListCell/leadingResources(_:)``)에 표시할 요소입니다.
+        public enum Leading {
+            /// 아이콘 (22×22)
+            /// - Parameters:
+            ///   - icon: 표시할 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralPrimary)` 적용
+            case icon(
+                _ icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralPrimary)
+            )
+
+            /// 배경이 있는 큰 아이콘 (컨테이너 36×36 / 아이콘 20×20)
+            /// - Parameters:
+            ///   - icon: 표시할 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralPrimary)` 적용
+            case largeIcon(
+                _ icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralPrimary)
+            )
+
+            /// 체크박스
+            /// - Parameters:
+            ///   - checked: 선택 여부
+            ///   - onSelect: 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용
+            case checkbox(checked: Bool, onSelect: ((Bool) -> Void)? = nil)
+
+            /// 라디오
+            /// - Parameters:
+            ///   - checked: 선택 여부
+            ///   - onSelect: 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용
+            case radio(checked: Bool, onSelect: ((Bool) -> Void)? = nil)
+
+            /// 아바타 (40×40)
+            /// - Parameters:
+            ///   - imageUrl: 표시할 이미지의 URL 문자열
+            ///   - variant: 아바타 유형
+            case avatar(_ imageUrl: String, variant: Avatar.Variant)
+
+            /// 썸네일 (56×56 정사각, 둥근 모서리·테두리 적용)
+            /// - Parameter imageUrl: 표시할 이미지의 URL 문자열
+            case thumbnail(_ imageUrl: String)
+
+            /// 임의 뷰. ``slot(_:)`` 팩토리로 생성합니다.
+            case slotView(() -> AnyView)
+
+            /// 목록에 없는 구성을 직접 배치합니다.
+            ///
+            /// - Parameter content: 표시할 뷰를 생성하는 클로저
+            /// - Returns: 구성된 요소
+            public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Leading {
+                .slotView { AnyView(content()) }
+            }
+        }
+
+        /// 셀 우측(``ListCell/trailingResources(_:)``)에 표시할 요소입니다.
+        public enum Trailing {
+            /// 값 텍스트
+            /// - Parameter text: 표시할 텍스트
+            case value(_ text: String)
+
+            /// 아이콘 (22×22)
+            /// - Parameters:
+            ///   - icon: 표시할 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralQuaternary)` 적용
+            case icon(
+                _ icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralQuaternary)
+            )
+
+            /// 아이콘 버튼 (배경 없음)
+            /// - Parameters:
+            ///   - icon: 버튼 아이콘
+            ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
+            case iconButton(_ icon: Icon, handler: (() -> Void)? = nil)
+
+            /// 텍스트 버튼
+            /// - Parameters:
+            ///   - title: 버튼 텍스트
+            ///   - color: 버튼 색상, 생략하면 기본값으로 `.assistive` 적용
+            ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
+            case textButton(
+                title: String,
+                color: TextButton.Color = .assistive,
+                handler: (() -> Void)? = nil
+            )
+
+            /// 버튼
+            /// - Parameters:
+            ///   - title: 버튼 텍스트
+            ///   - color: 버튼 색상, 생략하면 기본값으로 `.assistive` 적용
+            ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
+            case button(
+                title: String,
+                color: Button.Color = .assistive,
+                handler: (() -> Void)? = nil
+            )
+
+            /// 콘텐츠 배지
+            /// - Parameters:
+            ///   - variant: 배지 변형 스타일, 생략하면 기본값으로 `.solid` 적용
+            ///   - title: 배지 텍스트
+            case contentBadge(_ variant: ContentBadge.Variant = .solid, title: String)
+
+            /// 스위치
+            /// - Parameters:
+            ///   - checked: 켜짐 여부
+            ///   - onSelect: 값 변경 핸들러, 생략하면 기본값으로 `nil` 적용
+            case `switch`(checked: Bool, onSelect: ((Bool) -> Void)? = nil)
+
+            /// 임의 뷰. ``slot(_:)`` 팩토리로 생성합니다.
+            case slotView(() -> AnyView)
+
+            /// 목록에 없는 구성을 직접 배치합니다.
+            ///
+            /// - Parameter content: 표시할 뷰를 생성하는 클로저
+            /// - Returns: 구성된 요소
+            public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Trailing {
+                .slotView { AnyView(content()) }
+            }
+        }
+
+        /// 라벨 행 오른쪽 끝(``ListCell/labelTrailingResources(_:)``)에 표시할 요소입니다.
+        public enum LabelTrailing {
+            /// 콘텐츠 배지
+            /// - Parameters:
+            ///   - variant: 배지 변형 스타일, 생략하면 기본값으로 `.solid` 적용
+            ///   - title: 배지 텍스트
+            case contentBadge(_ variant: ContentBadge.Variant = .solid, title: String)
+
+            /// 아이콘 (22×22)
+            /// - Parameters:
+            ///   - icon: 표시할 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralPrimary)` 적용
+            case icon(
+                _ icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralPrimary)
+            )
+
+            /// 임의 뷰. ``slot(_:)`` 팩토리로 생성합니다.
+            case slotView(() -> AnyView)
+
+            /// 목록에 없는 구성을 직접 배치합니다.
+            ///
+            /// - Parameter content: 표시할 뷰를 생성하는 클로저
+            /// - Returns: 구성된 요소
+            public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> LabelTrailing {
+                .slotView { AnyView(content()) }
+            }
+        }
+
+        /// 설명 아래(``ListCell/extraResources(_:)``)에 표시할 요소입니다.
+        public enum Extra {
+            /// 텍스트
+            /// - Parameter text: 표시할 텍스트
+            case text(_ text: String)
+
+            /// 콘텐츠 배지
+            /// - Parameters:
+            ///   - variant: 배지 변형 스타일, 생략하면 기본값으로 `.solid` 적용
+            ///   - title: 배지 텍스트
+            case contentBadge(_ variant: ContentBadge.Variant = .solid, title: String)
+
+            /// 임의 뷰. ``slot(_:)`` 팩토리로 생성합니다.
+            case slotView(() -> AnyView)
+
+            /// 목록에 없는 구성을 직접 배치합니다.
+            ///
+            /// - Parameter content: 표시할 뷰를 생성하는 클로저
+            /// - Returns: 구성된 요소
+            public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Extra {
+                .slotView { AnyView(content()) }
+            }
+        }
+    }
+}
+
+// MARK: - Resource Rendering
+extension ListCell.Resource {
+    /// 슬롯 아이콘의 한 변 크기.
+    fileprivate static var iconSize: CGFloat { 22 }
+    /// ``Leading/largeIcon(_:tintColor:)`` 컨테이너의 한 변 크기.
+    fileprivate static var largeIconContainerSize: CGFloat { 36 }
+    /// ``Leading/largeIcon(_:tintColor:)`` 안쪽 아이콘의 한 변 크기.
+    fileprivate static var largeIconSize: CGFloat { 20 }
+    /// ``Leading/largeIcon(_:tintColor:)`` 컨테이너의 모서리 반경.
+    fileprivate static var largeIconCornerRadius: CGFloat { 12 }
+    /// ``Leading/thumbnail(_:)``의 한 변 크기.
+    fileprivate static var thumbnailSize: CGFloat { 56 }
+
+    /// 지정한 크기의 템플릿 아이콘을 만든다.
+    fileprivate static func iconView(
+        _ icon: Icon,
+        tintColor: SwiftUI.Color,
+        size: CGFloat
+    ) -> some View {
+        Image.icon(icon)
+            .resizable()
+            .renderingMode(.template)
+            .foregroundStyle(tintColor)
+            .frame(width: size, height: size)
+    }
+}
+
+extension ListCell.Resource.Leading {
+    @ViewBuilder
+    var view: some View {
+        switch self {
+        case let .icon(icon, tintColor):
+            ListCell.Resource.iconView(icon, tintColor: tintColor, size: ListCell.Resource.iconSize)
+        case let .largeIcon(icon, tintColor):
+            ListCell.Resource.iconView(icon, tintColor: tintColor, size: ListCell.Resource.largeIconSize)
+                .frame(
+                    width: ListCell.Resource.largeIconContainerSize,
+                    height: ListCell.Resource.largeIconContainerSize
+                )
+                .background(
+                    RoundedRectangle(cornerRadius: ListCell.Resource.largeIconCornerRadius)
+                        .fill(SwiftUI.Color.semantic(.surfaceNeutralSecondary))
+                )
+        case let .checkbox(checked, onSelect):
+            Checkbox(checked: checked, onSelect: onSelect)
+        case let .radio(checked, onSelect):
+            Radio(checked: checked, onSelect: onSelect)
+        case let .avatar(imageUrl, variant):
+            Avatar(imageUrl, variant: variant, size: .medium)
+        case let .thumbnail(imageUrl):
+            Thumbnail(urlString: imageUrl, ratio: .r1x1)
+                .width(ListCell.Resource.thumbnailSize)
+                .radius()
+                .border()
+        case let .slotView(content):
+            content()
+        }
+    }
+}
+
+extension ListCell.Resource.Trailing {
+    @ViewBuilder
+    var view: some View {
+        switch self {
+        case let .value(text):
+            Text(text)
+                .paragraph(variant: .body2, semantic: .foregroundNeutralTertiary)
+        case let .icon(icon, tintColor):
+            ListCell.Resource.iconView(icon, tintColor: tintColor, size: ListCell.Resource.iconSize)
+        case let .iconButton(icon, handler):
+            IconButton(variant: .normal(size: .small), icon: icon, handler: handler)
+        case let .textButton(title, color, handler):
+            TextButton(color: color, size: .small, text: title, handler: handler)
+        case let .button(title, color, handler):
+            Button(variant: .outlined, color: color, size: .xsmall, text: title, handler: handler)
+        case let .contentBadge(variant, title):
+            ContentBadge(variant: variant, text: title)
+        case let .switch(checked, onSelect):
+            Switch(checked: checked, onSelect: onSelect)
+        case let .slotView(content):
+            content()
+        }
+    }
+}
+
+extension ListCell.Resource.LabelTrailing {
+    @ViewBuilder
+    var view: some View {
+        switch self {
+        case let .contentBadge(variant, title):
+            ContentBadge(variant: variant, text: title)
+        case let .icon(icon, tintColor):
+            ListCell.Resource.iconView(icon, tintColor: tintColor, size: ListCell.Resource.iconSize)
+        case let .slotView(content):
+            content()
+        }
+    }
+}
+
+extension ListCell.Resource.Extra {
+    @ViewBuilder
+    var view: some View {
+        switch self {
+        case let .text(text):
+            Text(text)
+                .paragraph(variant: .label2, semantic: .foregroundNeutralTertiary)
+        case let .contentBadge(variant, title):
+            ContentBadge(variant: variant, text: title)
+        case let .slotView(content):
+            content()
         }
     }
 }

--- a/Sources/Montage/1 Components/4 Contents/ListCell.swift
+++ b/Sources/Montage/1 Components/4 Contents/ListCell.swift
@@ -115,6 +115,9 @@ public struct ListCell: View {
     /// 라벨 행에 들어가는 콘텐츠의 고정 높이입니다.
     private static let labelContentHeight: CGFloat = 22
 
+    /// 선택 상태를 나타내는 체크 아이콘의 크기입니다.
+    private static let selectedCheckSize: CGFloat = 22
+
     // MARK: - Initializer
 
     private let label: String
@@ -327,12 +330,15 @@ public struct ListCell: View {
 
     /// 셀을 선택된 상태로 설정합니다.
     ///
-    /// 선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정됩니다.
-    /// `trailingContent` 클로저의 파라미터로 선택된 상태 여부가 전달됩니다.
+    /// 선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정되며,
+    /// 셀 오른쪽 끝에 체크 아이콘이 표시됩니다.
     ///
     /// - Parameters:
     ///   - selected: 선택 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 ListCell 인스턴스
+    ///
+    /// - Important: 체크 아이콘은 ``trailingContent(_:)`` 자리를 대신 차지하므로 둘을 함께 표시할 수 없습니다.
+    ///   선택 상태와 별개의 우측 콘텐츠가 필요하면 ``labelTrailingContent(_:)`` 또는 ``extraContent(_:)``를 사용하세요.
     public func selected(_ selected: Bool = true) -> Self {
         var zelf = self
         zelf.selected = selected
@@ -492,6 +498,10 @@ extension ListCell {
         disable ? .foregroundDisablePrimary : .foregroundNeutralQuaternary
     }
 
+    private var selectedCheckColor: Color.Semantic {
+        disable ? .foregroundDisablePrimary : .surfaceBrandPrimary
+    }
+
     private var row: some View {
         HStack(alignment: verticalAlignment.alignment, spacing: 0) {
             if let leadingContent {
@@ -527,7 +537,16 @@ extension ListCell {
                 }
             }
 
-            if let trailingContent {
+            // 선택된 셀은 체크 아이콘이 trailing 자리를 대신 차지한다.
+            if selected {
+                Image.icon(.check)
+                    .resizable()
+                    .renderingMode(.template)
+                    .foregroundStyle(SwiftUI.Color.semantic(selectedCheckColor))
+                    .frame(width: Self.selectedCheckSize, height: Self.selectedCheckSize)
+                    .frame(minHeight: Self.rowMinHeight)
+                    .padding(.leading, 8)
+            } else if let trailingContent {
                 HStack(alignment: .center, spacing: 8) {
                     trailingContent(selected)
                 }

--- a/Sources/Montage/1 Components/4 Contents/ListCell.swift
+++ b/Sources/Montage/1 Components/4 Contents/ListCell.swift
@@ -161,6 +161,9 @@ public struct ListCell: View {
         .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: onTap))
         .accessibilityElement(children: .combine)
         .if(onTap != nil) { $0.accessibilityAddTraits(.isButton) }
+        // 선택 상태는 체크 아이콘으로만 표현되는데 children을 combine하므로
+        // 트레이트로 따로 전달하지 않으면 보조 기술이 선택 여부를 알 수 없다.
+        .if(selected) { $0.accessibilityAddTraits(.isSelected) }
         // allowsHitTesting은 포인터 입력만 막아 보조 기술에 비활성 상태가 전달되지 않는다.
         // disabled를 써야 VoiceOver가 "사용 안 함"으로 읽고 포커스 이동도 함께 차단된다.
         .disabled(disable)
@@ -327,7 +330,8 @@ public struct ListCell: View {
     /// 셀을 선택된 상태로 설정합니다.
     ///
     /// 선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정되며,
-    /// 셀 오른쪽 끝에 체크 아이콘이 표시됩니다.
+    /// trailing 영역에 체크 아이콘이 표시됩니다.
+    /// ``chevron(_:)``을 켠 셀에서는 화살표가 체크 아이콘 오른쪽에 그대로 남습니다.
     ///
     /// - Parameters:
     ///   - selected: 선택 여부, 생략하면 기본값으로 `true` 적용
@@ -646,8 +650,11 @@ extension ListCell {
     /// 예를 들어 ``Trailing/switch(checked:onSelect:)``는 ``ListCell/trailingResources(_:)``에만 넘길 수 있고,
     /// ``ListCell/leadingResources(_:)``에 넘기면 컴파일되지 않습니다.
     ///
-    /// 각 요소의 크기와 정렬은 셀 스펙(행 최소 높이 24)에 맞춰 고정됩니다.
+    /// 미리 정의된 요소는 크기와 정렬이 셀 스펙(행 최소 높이 24)에 맞춰 고정됩니다.
     /// 목록에 없는 구성이 필요하면 각 타입의 `slot(_:)` 팩토리를 사용합니다.
+    ///
+    /// - Important: `slot(_:)`으로 넣은 뷰에는 이 크기 제약이 적용되지 않습니다.
+    ///   행 높이가 밀리지 않게 하려면 사용처에서 `frame(...)`이나 `fixedSize(...)`로 크기를 직접 정해야 합니다.
     public enum Resource {
         /// 셀 좌측(``ListCell/leadingResources(_:)``)에 표시할 요소입니다.
         public enum Leading {

--- a/Sources/Montage/1 Components/4 Contents/ListCell.swift
+++ b/Sources/Montage/1 Components/4 Contents/ListCell.swift
@@ -10,18 +10,19 @@ import SwiftUI
 /// 텍스트와 콘텐츠를 포함하는 리스트 아이템 컴포넌트입니다.
 ///
 /// `ListCell`은 앱 내에서 리스트 형태로 정보를 표시할 때 사용되는 기본 컴포넌트입니다.
-/// 타이틀, 부가 설명, 좌측 콘텐츠, 우측 콘텐츠 등을 포함할 수 있으며 다양한 스타일로 커스터마이징할 수 있습니다.
+/// 라벨, 부가 설명과 함께 네 종류의 콘텐츠 슬롯(``leadingContent(_:)``, ``labelTrailingContent(_:)``,
+/// ``trailingContent(_:)``, ``extraContent(_:)``)을 제공하며 다양한 스타일로 커스터마이징할 수 있습니다.
 ///
 /// ```swift
 /// // 기본 셀
-/// ListCell(title: "기본 셀")
+/// ListCell(label: "기본 셀")
 ///
 /// // 추가 설명이 있는 셀
-/// ListCell(title: "설명이 있는 셀")
-///     .caption("부가 설명 텍스트")
+/// ListCell(label: "설명이 있는 셀")
+///     .description("부가 설명 텍스트")
 ///
 /// // 리딩 콘텐츠와 선택 상태의 셀
-/// ListCell(title: "커스텀 셀", onTap: {
+/// ListCell(label: "커스텀 셀", onTap: {
 ///     print("셀이 탭되었습니다")
 /// })
 /// .leadingContent {
@@ -31,236 +32,293 @@ import SwiftUI
 /// .selected(true)
 /// .chevron(true)
 /// ```
+///
+/// ## 콘텐츠 슬롯
+///
+/// 네 슬롯은 셀 안에서 각각 다음 위치를 차지하며, 슬롯마다 여러 요소를 나열할 수 있습니다.
+///
+/// - ``leadingContent(_:)``: 라벨 앞, 항목 간 간격 8
+/// - ``labelTrailingContent(_:)``: 라벨 바로 뒤, 항목 간 간격 4
+/// - ``trailingContent(_:)``: 셀 오른쪽 끝, 항목 간 간격 8
+/// - ``extraContent(_:)``: 설명 아래, 항목 간 간격 6
+///
+/// ```swift
+/// ListCell(label: "김티드")
+///     .description("iOS 개발자")
+///     .labelTrailingContent {
+///         ContentBadge(text: "신규")
+///     }
+///     .extraContent {
+///         ContentBadge(variant: .outlined, text: "서울")
+///     }
+///     .trailingContent { _ in
+///         Text("값")
+///     }
+/// ```
 public struct ListCell: View {
     // MARK: - Types
     /// 상하 여백을 나타내는 열거형입니다.
     ///
     /// 셀 컴포넌트의 상하 여백을 조정할 때 사용되며, 각 케이스는 다양한 크기의 여백을 제공합니다.
-    public enum VerticalPadding {
+    public enum VerticalPadding: Equatable {
         /// 여백 없음
         case none
-        /// 작은 여백
+        /// 작은 여백 (8)
         case small
-        /// 중간 여백
+        /// 중간 여백 (12)
         case medium
-        /// 큰 여백
+        /// 큰 여백 (16)
         case large
-        
+        /// 직접 지정한 여백
+        ///
+        /// 정해진 네 단계로 표현할 수 없는 간격이 필요할 때만 사용합니다.
+        case custom(CGFloat)
+
         var length: CGFloat {
             switch self {
             case .none: 0
             case .small: 8
             case .medium: 12
             case .large: 16
+            case .custom(let length): length
             }
         }
     }
-    
+
+    /// 셀 내 콘텐츠의 수직 정렬을 나타내는 열거형입니다.
+    public enum VerticalAlign: Equatable {
+        /// 첫 행에 맞춰 정렬
+        case top
+        /// 셀 높이의 중앙에 정렬
+        case center
+
+        var alignment: VerticalAlignment {
+            switch self {
+            case .top: .top
+            case .center: .center
+            }
+        }
+    }
+
+    // MARK: - Constants
+
+    /// 행 콘텐츠(leading·라벨·trailing)의 최소 높이입니다.
+    private static let rowMinHeight: CGFloat = 24
+
+    /// 라벨 행의 상하 패딩입니다.
+    ///
+    /// leading·trailing 콘텐츠(22)가 24 컨테이너 안에서 중앙정렬되며 생기는 1pt 오프셋과 맞추기 위한 값으로,
+    /// 이 패딩이 없으면 라벨이 2줄 이상일 때 첫 줄과 아이콘이 1pt 어긋납니다.
+    /// Spacing 토큰 스케일(전부 짝수)에 없는 값이라 토큰이 아닌 고정값을 사용합니다.
+    private static let labelRowPadding: CGFloat = 1
+
+    /// 라벨 행에 들어가는 콘텐츠의 고정 높이입니다.
+    private static let labelContentHeight: CGFloat = 22
+
     // MARK: - Initializer
-    
-    private let title: String
+
+    private let label: String
     private let onTap: (() -> Void)?
-    
+
     /// 셀 컴포넌트를 초기화합니다.
     ///
     /// - Parameters:
-    ///   - title: 셀에 표시할 제목 텍스트
+    ///   - label: 셀에 표시할 제목 텍스트
     ///   - onTap: 셀을 탭했을 때 실행할 클로저, 생략하면 기본값으로 `nil` 적용
     public init(
-        title: String,
+        label: String,
         onTap: (() -> Void)? = nil
     ) {
-        self.title = title
+        self.label = label
         self.onTap = onTap
     }
-    
+
     // MARK: - Body
     @State private var isPressed = false
-    
+    @State private var leadingContentEmpty = false
+    @State private var trailingContentEmpty = false
+    @State private var labelTrailingContentEmpty = true
+
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
         ZStack(alignment: .bottom) {
-            ZStack {
-                HStack(alignment: verticalAlignment, spacing: 8) {
-                    leadingContent()
-                    
-                    VStack(alignment: .leading, spacing: 4) {
-                        Group {
-                            titleView
-                        }
-                        .frame(minHeight: 24)
-                        .if(textEllipsis) {
-                            $0.lineLimit(2)
-                        }
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        
-                        if let caption {
-                            Text(caption)
-                                .paragraph(
-                                    variant: .label2,
-                                    semantic: .foregroundNeutralTertiary
-                                )
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
-                    
-                    trailingContent(selected)
-                    
-                    VStack {
-                        Image.icon(.chevronRightTightSmall)
-                            .resizable()
-                            .renderingMode(.template)
-                            .foregroundStyle(SwiftUI.Color.semantic(.foregroundNeutralQuaternary))
-                            .frame(width: 8, height: 16)
-                            .padding(.vertical, 4)
-                    }
-                    .frame(maxHeight: .infinity)
-                    .if(chevron)
-                }
-            }
-            .padding(.vertical, verticalPadding.length)
-            
+            row
+                .padding(.vertical, verticalPadding.length)
+
             Rectangle()
                 .frame(height: 1)
-                .foregroundStyle(SwiftUI.Color.semantic(.lineNeutralTertiary))
+                .foregroundStyle(SwiftUI.Color.semantic(.lineNeutralPrimaryOpaque))
                 .background()
                 .if(divider)
         }
-        .padding(.horizontal, fillWidth ? 20 : 0)
-        .modifier(ListCellInteractionModifier(
-            pressed: $isPressed,
-            fillWidth: fillWidth,
-            interactionPadding: interactionPadding
-        ))
+        .if(interactionEnabled) {
+            $0.modifier(ListCellInteractionModifier(
+                pressed: $isPressed,
+                outset: interactionOutset,
+                radius: resolvedInteractionRadius
+            ))
+        }
         .contentShape(Rectangle())
-        .allowsHitTesting(disable == false)
-        .opacity(disable ? 0.43 : 1)
         .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: onTap))
         .accessibilityElement(children: .combine)
         .if(onTap != nil) { $0.accessibilityAddTraits(.isButton) }
+        // allowsHitTesting은 포인터 입력만 막아 보조 기술에 비활성 상태가 전달되지 않는다.
+        // disabled를 써야 VoiceOver가 "사용 안 함"으로 읽고 포커스 이동도 함께 차단된다.
+        .disabled(disable)
     }
-    
+
     // MARK: - Modifiers
-    
-    private var titleTypography: (variant: Typography.Variant, weight: Typography.Weight, color: Color.Semantic) = (.body1, .regular, .foregroundNeutralPrimary)
+
+    private var labelTypography: (variant: Typography.Variant, weight: Typography.Weight, color: Color.Semantic) = (.body2, .medium, .foregroundNeutralPrimary)
     private var verticalPadding: VerticalPadding = .medium
-    private var fillWidth = false
     private var textEllipsis = false
-    private var caption: String? = nil
+    private var descriptionText: String? = nil
     private var disable = false
     private var selected = false
     private var divider = false
     private var chevron = false
-    private var leadingContent: () -> AnyView = { AnyView(EmptyView()) }
-    private var trailingContent: (Bool) -> AnyView = { _ in AnyView(EmptyView()) }
-    private var interactionPadding: CGFloat = 12
-    private var verticalAlignment: VerticalAlignment = .top
+    private var leadingContent: (() -> AnyView)? = nil
+    private var labelTrailingContent: (() -> AnyView)? = nil
+    private var trailingContent: ((Bool) -> AnyView)? = nil
+    private var extraContent: (() -> AnyView)? = nil
+    private var interactionOutset: CGFloat = 12
+    private var interactionRadius: CGFloat? = nil
+    private var verticalAlignment: VerticalAlign = .top
     private var highlightText: String? = nil
-    
-    /// 타이틀 텍스트의 `variant` 속성을 조정합니다.
+
+    /// 라벨 텍스트의 `variant` 속성을 조정합니다.
     ///
     /// - Parameters:
     ///   - variant: 적용할 Typography 변형 스타일
     /// - Returns: 수정된 ListCell 인스턴스
-    public func titleVariant(_ variant: Typography.Variant) -> Self {
+    public func labelVariant(_ variant: Typography.Variant) -> Self {
         var zelf = self
-        zelf.titleTypography.variant = variant
+        zelf.labelTypography.variant = variant
         return zelf
     }
-    
-    /// 타이틀 텍스트의 `weight` 속성을 조정합니다.
+
+    /// 라벨 텍스트의 `weight` 속성을 조정합니다.
     ///
     /// - Parameters:
     ///   - weight: 적용할 텍스트 두께
     /// - Returns: 수정된 ListCell 인스턴스
-    public func titleWeight(_ weight: Typography.Weight) -> Self {
+    ///
+    /// - Note: `selected`가 `true`인 셀은 이 값과 무관하게 `bold`로 표시됩니다.
+    public func labelWeight(_ weight: Typography.Weight) -> Self {
         var zelf = self
-        zelf.titleTypography.weight = weight
+        zelf.labelTypography.weight = weight
         return zelf
     }
-    
-    /// 타이틀 텍스트의 `color` 속성을 조정합니다.
+
+    /// 라벨 텍스트의 `color` 속성을 조정합니다.
     ///
     /// - Parameters:
     ///   - color: 적용할 텍스트 색상
     /// - Returns: 수정된 ListCell 인스턴스
-    public func titleColor(_ color: Color.Semantic) -> Self {
+    public func labelColor(_ color: Color.Semantic) -> Self {
         var zelf = self
-        zelf.titleTypography.color = color
+        zelf.labelTypography.color = color
         return zelf
     }
-    
+
     /// 상하 여백의 크기를 조정합니다.
+    ///
+    /// 정해진 네 단계(`none`·`small`·`medium`·`large`)로 표현할 수 없는 간격은
+    /// ``VerticalPadding/custom(_:)``으로 직접 지정할 수 있습니다.
     ///
     /// - Parameters:
     ///   - verticalPadding: 적용할 상하 여백 크기
     /// - Returns: 수정된 ListCell 인스턴스
+    ///
+    /// - Note: 여백이 `0`인 셀은 인터랙션 효과를 표시하지 않습니다.
     public func verticalPadding(_ verticalPadding: VerticalPadding) -> Self {
         var zelf = self
         zelf.verticalPadding = verticalPadding
         return zelf
     }
-    
+
     /// 셀 내 콘텐츠의 수직 정렬을 조정합니다.
     ///
+    /// 라벨이 2줄 이상일 때 leading·labelTrailing·trailing 콘텐츠를 첫 행에 맞출지, 셀 중앙에 맞출지 정합니다.
+    ///
     /// - Parameters:
-    ///   - verticalAlignment: 적용할 수직 정렬 방식
+    ///   - verticalAlignment: 적용할 수직 정렬 방식, 생략하면 기본값으로 `.top` 적용
     /// - Returns: 수정된 ListCell 인스턴스
-    public func verticalAlign(_ verticalAlignment: VerticalAlignment) -> Self {
+    public func verticalAlign(_ verticalAlignment: VerticalAlign) -> Self {
         var zelf = self
         zelf.verticalAlignment = verticalAlignment
         return zelf
     }
-    
-    /// 셀의 좌우 여백 사용 여부를 설정합니다.
+
+    /// 인터랙션 효과(hover·pressed 배경)가 셀 경계 바깥으로 확장되는 정도를 설정합니다.
+    ///
+    /// 메뉴처럼 좌우 여백이 있는 컨테이너 안에서는 기본값 `12`를 그대로 사용해 여백까지 배경을 넓히고,
+    /// 셀이 화면 폭을 그대로 채우는 목록에서는 `0`을 지정합니다.
     ///
     /// - Parameters:
-    ///   - fillWidth: 좌우 여백 적용 여부, 생략하면 기본값으로 `true` 적용
+    ///   - outset: 좌우로 확장할 크기 (포인트 단위), 생략하면 기본값으로 `12` 적용
     /// - Returns: 수정된 ListCell 인스턴스
     ///
-    /// - Note: `true`로 설정하면 셀 내부에 좌우 20포인트의 여백이 적용되고 인터랙션 영역이 각진 모서리 사각형 모양의 셀 내부 영역으로 한정되며, `false`로 설정하면 셀 내부 여백이 없는 대신 인터랙션 영역이 둥근 모서리 사각형 모양으로 셀 영역 바깥까지 적용됩니다.
-    public func fillWidth(_ fillWidth: Bool = true) -> Self {
+    /// - Note: 모서리 둥글기는 ``interactionRadius(_:)``로 따로 정하며 `outset`과 독립적으로 동작합니다.
+    ///
+    /// - Note: 4.0.0에서 제거된 `fillWidth(_:)`·`interactionPadding(_:)`을 대체합니다.
+    ///   `fillWidth(true)`는 `interactionOutset(0)`, `fillWidth(false)`는 `interactionOutset(12)`에 대응하며,
+    ///   `fillWidth(true)`가 적용하던 셀 좌우 20포인트 여백은 더 이상 자동으로 붙지 않으므로 필요하면 사용처에서 직접 지정합니다.
+    public func interactionOutset(_ outset: CGFloat = 12) -> Self {
         var zelf = self
-        zelf.fillWidth = fillWidth
+        zelf.interactionOutset = outset
         return zelf
     }
-    
-    /// 타이틀 텍스트의 생략 처리 여부를 설정합니다.
+
+    /// 인터랙션 효과 영역의 모서리 둥글기를 설정합니다.
     ///
-    /// `true`로 설정하면 타이틀 텍스트가 2줄로 제한되고, 초과 텍스트는 생략됩니다.
+    /// 지정하지 않으면 ``interactionOutset(_:)``이 `0`보다 클 때 `16`, 그 외에는 `0`이 적용됩니다.
+    ///
+    /// - Parameters:
+    ///   - radius: 적용할 모서리 반경 (포인트 단위)
+    /// - Returns: 수정된 ListCell 인스턴스
+    public func interactionRadius(_ radius: CGFloat) -> Self {
+        var zelf = self
+        zelf.interactionRadius = radius
+        return zelf
+    }
+
+    /// 텍스트의 생략 처리 여부를 설정합니다.
+    ///
+    /// `true`로 설정하면 라벨과 설명이 각각 한 줄로 제한되고, 초과 텍스트는 말줄임 처리됩니다.
+    /// `false`인 경우 두 텍스트 모두 줄 수 제한 없이 줄바꿈됩니다.
     ///
     /// - Parameters:
     ///   - textEllipsis: 텍스트 생략 처리 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 ListCell 인스턴스
-    ///
-    /// - Note: `false`인 경우 좌우 콘텐츠는 상단 정렬됩니다.
     public func textEllipsis(_ textEllipsis: Bool = true) -> Self {
         var zelf = self
         zelf.textEllipsis = textEllipsis
         return zelf
     }
-    
-    /// 셀에 부가 설명(캡션)을 추가합니다.
+
+    /// 셀에 부가 설명을 추가합니다.
     ///
-    /// 캡션은 타이틀 아래에 작은 글씨로 표시되는 부가 설명 텍스트입니다.
+    /// 설명은 라벨 아래에 작은 글씨로 표시되는 부가 설명 텍스트입니다.
     ///
     /// - Parameters:
-    ///   - caption: 표시할 캡션 텍스트, 생략하면 기본값으로 `nil` 적용 (nil 설정 시 캡션 제거)
+    ///   - description: 표시할 설명 텍스트, 생략하면 기본값으로 `nil` 적용 (nil 설정 시 설명 제거)
     /// - Returns: 수정된 ListCell 인스턴스
-    public func caption(_ caption: String? = nil) -> Self {
+    public func description(_ description: String? = nil) -> Self {
         var zelf = self
-        zelf.caption = caption
+        zelf.descriptionText = description
         return zelf
     }
-    
+
     /// 셀의 비활성화 상태를 설정합니다.
     ///
-    /// 비활성화된 셀은 탭 이벤트를 받지 않으며, 시각적으로 흐리게 표시됩니다.
+    /// 비활성화된 셀은 탭 이벤트를 받지 않으며, 라벨·설명·콘텐츠 슬롯에 `foregroundDisablePrimary` 색상이 적용됩니다.
     ///
     /// - Parameters:
     ///   - disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 ListCell 인스턴스
+    ///
+    /// - Note: 콘텐츠 슬롯에는 전경색으로 전달되므로, 슬롯 안에서 색상을 직접 지정한 뷰에는 적용되지 않습니다.
     public func disable(_ disable: Bool = true) -> Self {
         var zelf = self
         zelf.disable = disable
@@ -269,7 +327,7 @@ public struct ListCell: View {
 
     /// 셀을 선택된 상태로 설정합니다.
     ///
-    /// 선택된 셀은 타이틀 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 medium으로 설정됩니다.
+    /// 선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정됩니다.
     /// `trailingContent` 클로저의 파라미터로 선택된 상태 여부가 전달됩니다.
     ///
     /// - Parameters:
@@ -280,7 +338,7 @@ public struct ListCell: View {
         zelf.selected = selected
         return zelf
     }
-    
+
     /// 셀 하단에 구분선을 추가합니다.
     ///
     /// - Parameters:
@@ -291,7 +349,7 @@ public struct ListCell: View {
         zelf.divider = divider
         return zelf
     }
-    
+
     /// 셀 우측에 화살표(chevron) 아이콘을 추가합니다.
     ///
     /// 주로 탭했을 때 다른 화면으로 이동하는 셀에 사용됩니다.
@@ -304,10 +362,19 @@ public struct ListCell: View {
         zelf.chevron = chevron
         return zelf
     }
-    
+
     /// 셀 좌측에 추가 콘텐츠를 표시합니다.
     ///
-    /// 아이콘, 이미지, 기타 커스텀 뷰 등을 셀 타이틀 앞에 배치할 수 있습니다.
+    /// 아이콘, 체크박스, 아바타, 썸네일 등을 셀 라벨 앞에 배치할 수 있습니다.
+    /// 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다.
+    ///
+    /// ```swift
+    /// ListCell(label: "김티드")
+    ///     .leadingContent {
+    ///         Checkbox(checked: isChecked)
+    ///         Avatar(image: profileImage)
+    ///     }
+    /// ```
     ///
     /// - Parameters:
     ///   - contents: 표시할 콘텐츠를 생성하는 클로저
@@ -317,10 +384,34 @@ public struct ListCell: View {
         zelf.leadingContent = { AnyView(contents()) }
         return zelf
     }
-    
+
+    /// 라벨 행의 오른쪽 끝에 콘텐츠를 표시합니다.
+    ///
+    /// 배지나 인증 아이콘처럼 라벨에 딸린 요소를 배치할 때 사용합니다.
+    /// 여러 요소를 나열하면 4포인트 간격으로 가로 배치되며, 높이가 22포인트로 고정되어 행 높이를 늘리지 않습니다.
+    ///
+    /// ```swift
+    /// ListCell(label: "김티드")
+    ///     .labelTrailingContent {
+    ///         ContentBadge(text: "신규")
+    ///     }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - contents: 표시할 콘텐츠를 생성하는 클로저
+    /// - Returns: 수정된 ListCell 인스턴스
+    ///
+    /// - Note: 라벨이 2줄 이상일 때 표시 위치는 ``verticalAlign(_:)``을 따릅니다.
+    public func labelTrailingContent<V: View>(@ViewBuilder _ contents: @escaping () -> V) -> Self {
+        var zelf = self
+        zelf.labelTrailingContent = { AnyView(contents()) }
+        return zelf
+    }
+
     /// 셀 우측에 추가 콘텐츠를 표시합니다.
     ///
-    /// 배지, 스위치, 토글 등 추가 UI 요소를 셀 타이틀 뒤에 배치할 수 있습니다.
+    /// 값 텍스트, 배지, 버튼, 스위치 등 추가 UI 요소를 셀 오른쪽 끝에 배치할 수 있습니다.
+    /// 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다.
     /// 클로저 파라미터를 통해 셀의 선택된 상태를 전달받을 수 있습니다.
     ///
     /// - Parameters:
@@ -331,19 +422,32 @@ public struct ListCell: View {
         zelf.trailingContent = { AnyView(contents($0)) }
         return zelf
     }
-    
-    /// 셀의 인터랙션 효과 영역의 좌우 패딩을 조정합니다.
+
+    /// 설명 아래에 자유 콘텐츠를 표시합니다.
+    ///
+    /// 셀 폭을 모두 사용하는 자유 슬롯으로, 여러 요소를 나열하면 6포인트 간격으로 가로 배치됩니다.
+    ///
+    /// ```swift
+    /// ListCell(label: "김티드")
+    ///     .description("iOS 개발자")
+    ///     .extraContent {
+    ///         ContentBadge(variant: .outlined, text: "서울")
+    ///         ContentBadge(variant: .outlined, text: "5년차")
+    ///     }
+    /// ```
     ///
     /// - Parameters:
-    ///   - padding: 적용할 패딩 값 (포인트 단위)
+    ///   - contents: 표시할 콘텐츠를 생성하는 클로저
     /// - Returns: 수정된 ListCell 인스턴스
-    public func interactionPadding(_ padding: CGFloat) -> Self {
+    ///
+    /// - Note: 슬롯 내부 구성은 사용처가 정하며, 그 안의 타이포그래피와 색상은 컴포넌트가 보장하지 않습니다.
+    public func extraContent<V: View>(@ViewBuilder _ contents: @escaping () -> V) -> Self {
         var zelf = self
-        zelf.interactionPadding = padding
+        zelf.extraContent = { AnyView(contents()) }
         return zelf
     }
-    
-    /// 타이틀의 특정 텍스트를 강조 표시합니다.
+
+    /// 라벨의 특정 텍스트를 강조 표시합니다.
     ///
     /// 지정한 문자열과 일치하는 부분을 굵은 글씨(bold)로 강조 표시합니다.
     /// 대소문자를 구분하지 않으며, 첫 번째로 일치하는 부분만 강조됩니다.
@@ -360,38 +464,152 @@ public struct ListCell: View {
 
 // MARK: - Private
 extension ListCell {
-    private var normalTitleColor: Color.Semantic {
+    /// 인터랙션 효과 적용 여부.
+    ///
+    /// 상하 여백이 없는 셀은 배경이 텍스트에 바짝 붙어 눌림 표현이 오히려 노이즈가 되므로 사용하지 않는다.
+    /// `custom(0)`도 `none`과 결과가 같으므로 케이스가 아닌 실제 여백 값으로 판단한다.
+    private var interactionEnabled: Bool {
+        verticalPadding.length > 0
+    }
+
+    private var resolvedInteractionRadius: CGFloat {
+        interactionRadius ?? (interactionOutset > 0 ? 16 : 0)
+    }
+
+    private var resolvedLabelColor: Color.Semantic {
         if disable {
-            .foregroundNeutralTertiary
+            .foregroundDisablePrimary
         } else {
-            selected ? .surfaceBrandPrimary : titleTypography.color
+            selected ? .surfaceBrandPrimary : labelTypography.color
         }
     }
-    
-    private var titleView: some View {
+
+    private var resolvedDescriptionColor: Color.Semantic {
+        disable ? .foregroundDisablePrimary : .foregroundNeutralTertiary
+    }
+
+    private var chevronColor: Color.Semantic {
+        disable ? .foregroundDisablePrimary : .foregroundNeutralQuaternary
+    }
+
+    private var row: some View {
+        HStack(alignment: verticalAlignment.alignment, spacing: 0) {
+            if let leadingContent {
+                HStack(alignment: .center, spacing: 8) {
+                    leadingContent()
+                }
+                .ifEmptyView { leadingContentEmpty = $0 }
+                .frame(minHeight: leadingContentEmpty ? 0 : Self.rowMinHeight)
+                .padding(.trailing, leadingContentEmpty ? 0 : 8)
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                labelRow
+
+                if let descriptionText {
+                    Text(descriptionText)
+                        .paragraph(
+                            variant: .label2,
+                            semantic: resolvedDescriptionColor
+                        )
+                        .if(textEllipsis) {
+                            $0.lineLimit(1)
+                        }
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if let extraContent {
+                    HStack(alignment: .center, spacing: 6) {
+                        extraContent()
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+
+            if let trailingContent {
+                HStack(alignment: .center, spacing: 8) {
+                    trailingContent(selected)
+                }
+                .ifEmptyView { trailingContentEmpty = $0 }
+                .frame(minHeight: trailingContentEmpty ? 0 : Self.rowMinHeight)
+                .padding(.leading, trailingContentEmpty ? 0 : 8)
+            }
+
+            if chevron {
+                Image.icon(.chevronRightTightSmall)
+                    .resizable()
+                    .renderingMode(.template)
+                    .foregroundStyle(SwiftUI.Color.semantic(chevronColor))
+                    .frame(width: 8, height: 16)
+                    .frame(minHeight: Self.rowMinHeight)
+                    .padding(.leading, 8)
+            }
+        }
+        // 슬롯 콘텐츠에는 비활성일 때만 색을 강제하고, 그 외에는 사용처가 지정한 색을 그대로 둔다.
+        // 자기 색을 직접 그리는 컴포넌트(ContentBadge·Switch 등)는 이 전경색을 따르지 않는다.
+        .if(disable) {
+            $0.foregroundStyle(SwiftUI.Color.semantic(.foregroundDisablePrimary))
+        }
+    }
+
+    private var labelRow: some View {
+        HStack(alignment: verticalAlignment.alignment, spacing: 0) {
+            Group {
+                labelView
+            }
+            .if(textEllipsis) {
+                $0.lineLimit(1)
+            }
+            .fixedSize(horizontal: false, vertical: true)
+            // labelTrailing이 없을 때만 라벨이 행을 채운다.
+            // 있을 때는 라벨이 hug해서 짧으면 콘텐츠가 바로 옆에 붙고, 길면 아래 Spacer가 0으로 줄며
+            // 콘텐츠 자리를 뺀 남은 폭에서 줄바꿈된다.
+            .if(labelTrailingContentEmpty) {
+                $0.frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if let labelTrailingContent {
+                HStack(alignment: .center, spacing: 4) {
+                    labelTrailingContent()
+                }
+                .ifEmptyView { labelTrailingContentEmpty = $0 }
+                // 라벨이 길어져도 콘텐츠는 축소되지 않는다.
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(height: labelTrailingContentEmpty ? 0 : Self.labelContentHeight)
+                .padding(.leading, labelTrailingContentEmpty ? 0 : 4)
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.vertical, Self.labelRowPadding)
+        .frame(minHeight: Self.rowMinHeight)
+    }
+
+    private var labelView: some View {
         Group {
             if let highlightText {
                 let attributedString: AttributedString = {
-                    var string = AttributedString(stringLiteral: title)
-                    string.font = .font(variant: titleTypography.variant, weight: selected ? .medium : titleTypography.weight)
-                    string.foregroundColor = .semantic(normalTitleColor)
+                    var string = AttributedString(stringLiteral: label)
+                    string.font = .font(variant: labelTypography.variant, weight: selected ? .bold : labelTypography.weight)
+                    string.foregroundColor = .semantic(resolvedLabelColor)
                     guard let range = string.range(of: highlightText, options: .caseInsensitive) else {
                         return string
                     }
-                    string[range].font = .font(variant: titleTypography.variant, weight: .bold)
-                    string[range].foregroundColor = .semantic(normalTitleColor)
+                    string[range].font = .font(variant: labelTypography.variant, weight: .bold)
+                    string[range].foregroundColor = .semantic(resolvedLabelColor)
                     return string
                 }()
-                
+
                 Text(attributedString)
-                    .tracking(titleTypography.variant.tracking)
-                    .adjustLineHeight(variant: titleTypography.variant)
+                    .tracking(labelTypography.variant.tracking)
+                    .adjustLineHeight(variant: labelTypography.variant)
             } else {
-                Text(title)
+                Text(label)
                     .paragraph(
-                        variant: titleTypography.variant,
-                        weight: selected ? .medium : titleTypography.weight,
-                        semantic: normalTitleColor
+                        variant: labelTypography.variant,
+                        weight: selected ? .bold : labelTypography.weight,
+                        semantic: resolvedLabelColor
                     )
             }
         }

--- a/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
+++ b/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
@@ -179,6 +179,11 @@ public struct Thumbnail: View {
 
     @State private var proposedWidth: CGFloat = .zero
 
+    /// 상위 컨테이너가 `disabled(_:)`로 비활성화되면 이미지도 흐리게 표시한다.
+    ///
+    /// 이미지 계열은 색 토큰으로 비활성을 표현할 수 없어 불투명도를 낮춘다.
+    @Environment(\.isEnabled) private var isEnabled
+
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
         ZStack {
@@ -204,6 +209,7 @@ public struct Thumbnail: View {
         .if (thumbnailWidth > 0) {
             $0.frame(width: thumbnailWidth, height: thumbnailWidth * ratio.rawValue)
         }
+        .opacity(isEnabled ? 1 : Double(CGFloat.opacity43))
     }
 
     private var thumbnailWidth: CGFloat {

--- a/Sources/Montage/1 Components/9 Utilities/Interaction.swift
+++ b/Sources/Montage/1 Components/9 Utilities/Interaction.swift
@@ -76,21 +76,23 @@ public struct Interaction: View {
 }
 
 extension Interaction.State {
+    /// 상태별 기본 불투명도. 값은 모두 Opacity 토큰과 일치한다.
     var alpha: CGFloat {
         switch self {
         case .normal:
-            0
+            .opacity0
         case .hovered:
-            0.05
+            .opacity5
         case .focused:
-            0.08
+            .opacity8
         case .pressed:
-            0.12
+            .opacity12
         }
     }
 }
 
 extension Interaction.Variant {
+    /// ``Interaction/State/alpha``에 곱해지는 강도 배율. 불투명도 자체가 아니므로 토큰을 쓰지 않는다.
     var weight: CGFloat {
         switch self {
         case .normal:

--- a/Sources/Montage/2 Utilities/Modifiers/ListCellInteractionModifier.swift
+++ b/Sources/Montage/2 Utilities/Modifiers/ListCellInteractionModifier.swift
@@ -9,12 +9,15 @@ import SwiftUI
 
 struct ListCellInteractionModifier: ViewModifier {
     @Binding private var pressed: Bool
-    private let fillWidth: Bool
-    private let interactionPadding: CGFloat
-    init(pressed: Binding<Bool>, fillWidth: Bool, interactionPadding: CGFloat) {
+    /// 인터랙션 배경이 콘텐츠 경계 바깥으로 확장되는 좌우 크기.
+    private let outset: CGFloat
+    /// 인터랙션 배경의 모서리 반경. `outset`과 독립적으로 지정한다.
+    private let radius: CGFloat
+
+    init(pressed: Binding<Bool>, outset: CGFloat, radius: CGFloat) {
         _pressed = pressed
-        self.fillWidth = fillWidth
-        self.interactionPadding = interactionPadding
+        self.outset = outset
+        self.radius = radius
     }
 
     @State private var labelSize: CGSize = .zero
@@ -29,10 +32,10 @@ struct ListCellInteractionModifier: ViewModifier {
                     color: .foregroundNeutralPrimary
                 )
                 .frame(
-                    width: labelSize.width + (fillWidth ? 0 : interactionPadding * 2),
+                    width: labelSize.width + outset * 2,
                     height: labelSize.height
                 )
-                .clipShape(RoundedRectangle(cornerRadius: fillWidth ? 0 : 12))
+                .clipShape(RoundedRectangle(cornerRadius: radius))
             )
     }
 }

--- a/documentation/components/contents/listcell/ios.md
+++ b/documentation/components/contents/listcell/ios.md
@@ -374,7 +374,11 @@ ListCell(label: "김티드")
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정됩니다. `trailingContent` 클로저의 파라미터로 선택된 상태 여부가 전달됩니다.
+  선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정되며, 셀 오른쪽 끝에 체크 아이콘이 표시됩니다.
+  >  **Important**
+  >
+  > 체크 아이콘은 [trailingContent(_:)](/documentation/montage/listcell/trailingcontent(_:).md) 자리를 대신 차지하므로 둘을 함께 표시할 수 없습니다. 선택 상태와 별개의 우측 콘텐츠가 필요하면 [labelTrailingContent(_:)](/documentation/montage/listcell/labeltrailingcontent(_:).md) 또는 [extraContent(_:)](/documentation/montage/listcell/extracontent(_:).md)를 사용하세요.
+
 </details>
 <details>
 

--- a/documentation/components/contents/listcell/ios.md
+++ b/documentation/components/contents/listcell/ios.md
@@ -9,7 +9,7 @@ description: 텍스트와 콘텐츠를 포함하는 리스트 아이템 컴포�
 
 ## Overview
 
-`ListCell`은 앱 내에서 리스트 형태로 정보를 표시할 때 사용되는 기본 컴포넌트입니다. 라벨, 부가 설명과 함께 네 종류의 콘텐츠 슬롯([leadingContent(_:)](/documentation/montage/listcell/leadingcontent(_:).md), [labelTrailingContent(_:)](/documentation/montage/listcell/labeltrailingcontent(_:).md), [trailingContent(_:)](/documentation/montage/listcell/trailingcontent(_:).md), [extraContent(_:)](/documentation/montage/listcell/extracontent(_:).md))을 제공하며 다양한 스타일로 커스터마이징할 수 있습니다.
+`ListCell`은 앱 내에서 리스트 형태로 정보를 표시할 때 사용되는 기본 컴포넌트입니다. 라벨, 부가 설명과 함께 네 종류의 콘텐츠 슬롯([leadingResources(_:)](/documentation/montage/listcell/leadingresources(_:).md), [labelTrailingResources(_:)](/documentation/montage/listcell/labeltrailingresources(_:).md), [trailingResources(_:)](/documentation/montage/listcell/trailingresources(_:).md), [extraResources(_:)](/documentation/montage/listcell/extraresources(_:).md))을 제공하며 다양한 스타일로 커스터마이징할 수 있습니다.
 
 ```swift
 // 기본 셀
@@ -19,39 +19,37 @@ ListCell(label: "기본 셀")
 ListCell(label: "설명이 있는 셀")
     .description("부가 설명 텍스트")
 
-// 리딩 콘텐츠와 선택 상태의 셀
+// 리딩 요소와 선택 상태의 셀
 ListCell(label: "커스텀 셀", onTap: {
     print("셀이 탭되었습니다")
 })
-.leadingContent {
-    Image.icon(.person)
-        .frame(width: 24, height: 24)
-}
+.leadingResources([.icon(.person)])
 .selected(true)
 .chevron(true)
 ```
 
 ## 콘텐츠 슬롯
 
-네 슬롯은 셀 안에서 각각 다음 위치를 차지하며, 슬롯마다 여러 요소를 나열할 수 있습니다.
+네 슬롯은 셀 안에서 각각 다음 위치를 차지하며, 슬롯마다 여러 요소를 나열할 수 있습니다. 슬롯에 넣을 수 있는 요소는 [ListCell.Resource](/documentation/montage/listcell/resource.md)에 슬롯별로 정의되어 있어, 다른 슬롯 전용 요소를 넘기면 컴파일되지 않습니다.
 
-- [leadingContent(_:)](/documentation/montage/listcell/leadingcontent(_:).md): 라벨 앞, 항목 간 간격 8
-- [labelTrailingContent(_:)](/documentation/montage/listcell/labeltrailingcontent(_:).md): 라벨 바로 뒤, 항목 간 간격 4
-- [trailingContent(_:)](/documentation/montage/listcell/trailingcontent(_:).md): 셀 오른쪽 끝, 항목 간 간격 8
-- [extraContent(_:)](/documentation/montage/listcell/extracontent(_:).md): 설명 아래, 항목 간 간격 6
+- [leadingResources(_:)](/documentation/montage/listcell/leadingresources(_:).md): 라벨 앞, 항목 간 간격 8
+- [labelTrailingResources(_:)](/documentation/montage/listcell/labeltrailingresources(_:).md): 라벨 바로 뒤, 항목 간 간격 4
+- [trailingResources(_:)](/documentation/montage/listcell/trailingresources(_:).md): 셀 오른쪽 끝, 항목 간 간격 8
+- [extraResources(_:)](/documentation/montage/listcell/extraresources(_:).md): 설명 아래, 항목 간 간격 6
 
 ```swift
 ListCell(label: "김티드")
     .description("iOS 개발자")
-    .labelTrailingContent {
-        ContentBadge(text: "신규")
-    }
-    .extraContent {
-        ContentBadge(variant: .outlined, text: "서울")
-    }
-    .trailingContent { _ in
-        Text("값")
-    }
+    .labelTrailingResources([.contentBadge(title: "신규")])
+    .extraResources([.contentBadge(.outlined, title: "서울")])
+    .trailingResources([.value("값")])
+```
+
+목록에 없는 구성이 필요하면 각 슬롯 타입의 `slot(_:)` 팩토리로 임의 뷰를 넣을 수 있습니다.
+
+```swift
+ListCell(label: "커스텀")
+    .trailingResources([.slot { MyCustomView() }])
 ```
 
 ## Topics
@@ -159,34 +157,30 @@ ListCell(label: "김티드")
 </details>
 <details>
 
-<summary>``func extraContent<V>(() -> V) -> ListCell``</summary>
+<summary>``func extraResources([Resource.Extra]) -> ListCell``</summary>
 
 
-설명 아래에 자유 콘텐츠를 표시합니다.
+설명 아래에 표시할 요소를 지정합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `contents` | 표시할 콘텐츠를 생성하는 클로저 |
+  | `resources` | 표시할 요소 목록 |
 - **Return Value**
 
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  셀 폭을 모두 사용하는 자유 슬롯으로, 여러 요소를 나열하면 6포인트 간격으로 가로 배치됩니다.
+  셀 폭을 모두 사용하며, 여러 개를 넘기면 6포인트 간격으로 가로 배치됩니다.
 
   ```swift
   ListCell(label: "김티드")
       .description("iOS 개발자")
-      .extraContent {
-          ContentBadge(variant: .outlined, text: "서울")
-          ContentBadge(variant: .outlined, text: "5년차")
-      }
+      .extraResources([
+          .contentBadge(.outlined, title: "서울"),
+          .contentBadge(.outlined, title: "5년차")
+      ])
   ```
-
-  >  **Note**
-  >
-  > 슬롯 내부 구성은 사용처가 정하며, 그 안의 타이포그래피와 색상은 컴포넌트가 보장하지 않습니다.
 
 </details>
 <details>
@@ -268,27 +262,25 @@ ListCell(label: "김티드")
 </details>
 <details>
 
-<summary>``func labelTrailingContent<V>(() -> V) -> ListCell``</summary>
+<summary>``func labelTrailingResources([Resource.LabelTrailing]) -> ListCell``</summary>
 
 
-라벨 행의 오른쪽 끝에 콘텐츠를 표시합니다.
+라벨 행의 오른쪽 끝에 표시할 요소를 지정합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `contents` | 표시할 콘텐츠를 생성하는 클로저 |
+  | `resources` | 표시할 요소 목록 |
 - **Return Value**
 
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  배지나 인증 아이콘처럼 라벨에 딸린 요소를 배치할 때 사용합니다. 여러 요소를 나열하면 4포인트 간격으로 가로 배치되며, 높이가 22포인트로 고정되어 행 높이를 늘리지 않습니다.
+  배지나 인증 아이콘처럼 라벨에 딸린 요소를 배치할 때 사용합니다. 여러 개를 넘기면 4포인트 간격으로 가로 배치되며, 높이가 22포인트로 고정되어 행 높이를 늘리지 않습니다.
 
   ```swift
   ListCell(label: "김티드")
-      .labelTrailingContent {
-          ContentBadge(text: "신규")
-      }
+      .labelTrailingResources([.contentBadge(title: "신규")])
   ```
 
   >  **Note**
@@ -333,28 +325,28 @@ ListCell(label: "김티드")
 </details>
 <details>
 
-<summary>``func leadingContent<V>(() -> V) -> ListCell``</summary>
+<summary>``func leadingResources([Resource.Leading]) -> ListCell``</summary>
 
 
-셀 좌측에 추가 콘텐츠를 표시합니다.
+셀 좌측에 표시할 요소를 지정합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `contents` | 표시할 콘텐츠를 생성하는 클로저 |
+  | `resources` | 표시할 요소 목록 |
 - **Return Value**
 
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  아이콘, 체크박스, 아바타, 썸네일 등을 셀 라벨 앞에 배치할 수 있습니다. 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다.
+  아이콘, 체크박스, 아바타, 썸네일 등을 셀 라벨 앞에 배치할 수 있습니다. 여러 개를 넘기면 8포인트 간격으로 가로 배치됩니다.
 
   ```swift
   ListCell(label: "김티드")
-      .leadingContent {
-          Checkbox(checked: isChecked)
-          Avatar(image: profileImage)
-      }
+      .leadingResources([
+          .checkbox(checked: isChecked),
+          .avatar(profileImageURL, variant: .person)
+      ])
   ```
 
 </details>
@@ -377,7 +369,7 @@ ListCell(label: "김티드")
   선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정되며, 셀 오른쪽 끝에 체크 아이콘이 표시됩니다.
   >  **Important**
   >
-  > 체크 아이콘은 [trailingContent(_:)](/documentation/montage/listcell/trailingcontent(_:).md) 자리를 대신 차지하므로 둘을 함께 표시할 수 없습니다. 선택 상태와 별개의 우측 콘텐츠가 필요하면 [labelTrailingContent(_:)](/documentation/montage/listcell/labeltrailingcontent(_:).md) 또는 [extraContent(_:)](/documentation/montage/listcell/extracontent(_:).md)를 사용하세요.
+  > 체크 아이콘은 [trailingResources(_:)](/documentation/montage/listcell/trailingresources(_:).md) 자리를 대신 차지하므로 둘을 함께 표시할 수 없습니다. 선택 상태와 별개의 우측 콘텐츠가 필요하면 [labelTrailingResources(_:)](/documentation/montage/listcell/labeltrailingresources(_:).md) 또는 [extraResources(_:)](/documentation/montage/listcell/extraresources(_:).md)를 사용하세요.
 
 </details>
 <details>
@@ -400,21 +392,31 @@ ListCell(label: "김티드")
 </details>
 <details>
 
-<summary>``func trailingContent<V>((Bool) -> V) -> ListCell``</summary>
+<summary>``func trailingResources([Resource.Trailing]) -> ListCell``</summary>
 
 
-셀 우측에 추가 콘텐츠를 표시합니다.
+셀 우측에 표시할 요소를 지정합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `contents` | 표시할 콘텐츠를 생성하는 클로저 (선택된 상태를 파라미터로 받음) |
+  | `resources` | 표시할 요소 목록 |
 - **Return Value**
 
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  값 텍스트, 배지, 버튼, 스위치 등 추가 UI 요소를 셀 오른쪽 끝에 배치할 수 있습니다. 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다. 클로저 파라미터를 통해 셀의 선택된 상태를 전달받을 수 있습니다.
+  값 텍스트, 배지, 버튼, 스위치 등을 셀 오른쪽 끝에 배치할 수 있습니다. 여러 개를 넘기면 8포인트 간격으로 가로 배치됩니다.
+
+  ```swift
+  ListCell(label: "알림 받기")
+      .trailingResources([.switch(checked: isOn, onSelect: { isOn = $0 })])
+  ```
+
+  >  **Important**
+  >
+  > [selected(_:)](/documentation/montage/listcell/selected(_:).md)가 `true`인 셀은 체크 아이콘이 이 자리를 대신 차지해 요소가 표시되지 않습니다.
+
 </details>
 <details>
 
@@ -459,6 +461,381 @@ ListCell(label: "김티드")
 
 ### Enumerations
 
+<details>
+
+<summary>``enum Resource``</summary>
+
+
+[ListCell](/documentation/montage/listcell.md)의 각 슬롯에 표시할 요소들의 Namespace입니다.
+- **Overview**
+
+  슬롯마다 쓸 수 있는 요소가 다르므로 슬롯별로 타입을 나눠 두었습니다. 예를 들어 [ListCell.Resource.Trailing.switch(checked:onSelect:)](/documentation/montage/listcell/resource/trailing/switch(checked:onselect:).md)는 [trailingResources(_:)](/documentation/montage/listcell/trailingresources(_:).md)에만 넘길 수 있고, [leadingResources(_:)](/documentation/montage/listcell/leadingresources(_:).md)에 넘기면 컴파일되지 않습니다.
+
+  각 요소의 크기와 정렬은 셀 스펙(행 최소 높이 24)에 맞춰 고정됩니다. 목록에 없는 구성이 필요하면 각 타입의 `slot(_:)` 팩토리를 사용합니다.
+#### Enumerations
+
+<details>
+
+<summary>``enum Extra``</summary>
+
+
+설명 아래([extraResources(_:)](/documentation/montage/listcell/extraresources(_:).md))에 표시할 요소입니다.
+##### Enumeration Cases
+
+<details>
+
+<summary>``case contentBadge(ContentBadge.Variant, title: String)``</summary>
+
+
+콘텐츠 배지
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `variant` | 배지 변형 스타일, 생략하면 기본값으로 `.solid` 적용 |
+  | `title` | 배지 텍스트 |
+</details>
+<details>
+
+<summary>``case slotView(() -> AnyView)``</summary>
+
+
+임의 뷰. [slot(_:)](/documentation/montage/listcell/resource/extra/slot(_:).md) 팩토리로 생성합니다.
+</details>
+<details>
+
+<summary>``case text(String)``</summary>
+
+
+텍스트
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `text` | 표시할 텍스트 |
+</details>
+
+##### Type Methods
+
+<details>
+
+<summary>``static func slot<V>(() -> V) -> Extra``</summary>
+
+
+목록에 없는 구성을 직접 배치합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `content` | 표시할 뷰를 생성하는 클로저 |
+- **Return Value**
+
+  구성된 요소
+</details>
+
+</details>
+<details>
+
+<summary>``enum LabelTrailing``</summary>
+
+
+라벨 행 오른쪽 끝([labelTrailingResources(_:)](/documentation/montage/listcell/labeltrailingresources(_:).md))에 표시할 요소입니다.
+##### Enumeration Cases
+
+<details>
+
+<summary>``case contentBadge(ContentBadge.Variant, title: String)``</summary>
+
+
+콘텐츠 배지
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `variant` | 배지 변형 스타일, 생략하면 기본값으로 `.solid` 적용 |
+  | `title` | 배지 텍스트 |
+</details>
+<details>
+
+<summary>``case icon(Icon, tintColor: SwiftUI.Color)``</summary>
+
+
+아이콘 (22×22)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `icon` | 표시할 아이콘 |
+  | `tintColor` | 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralPrimary)` 적용 |
+</details>
+<details>
+
+<summary>``case slotView(() -> AnyView)``</summary>
+
+
+임의 뷰. [slot(_:)](/documentation/montage/listcell/resource/labeltrailing/slot(_:).md) 팩토리로 생성합니다.
+</details>
+
+##### Type Methods
+
+<details>
+
+<summary>``static func slot<V>(() -> V) -> LabelTrailing``</summary>
+
+
+목록에 없는 구성을 직접 배치합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `content` | 표시할 뷰를 생성하는 클로저 |
+- **Return Value**
+
+  구성된 요소
+</details>
+
+</details>
+<details>
+
+<summary>``enum Leading``</summary>
+
+
+셀 좌측([leadingResources(_:)](/documentation/montage/listcell/leadingresources(_:).md))에 표시할 요소입니다.
+##### Enumeration Cases
+
+<details>
+
+<summary>``case avatar(String, variant: Avatar.Variant)``</summary>
+
+
+아바타 (40×40)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `imageUrl` | 표시할 이미지의 URL 문자열 |
+  | `variant` | 아바타 유형 |
+</details>
+<details>
+
+<summary>``case checkbox(checked: Bool, onSelect: ((Bool) -> Void)?)``</summary>
+
+
+체크박스
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `checked` | 선택 여부 |
+  | `onSelect` | 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용 |
+</details>
+<details>
+
+<summary>``case icon(Icon, tintColor: SwiftUI.Color)``</summary>
+
+
+아이콘 (22×22)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `icon` | 표시할 아이콘 |
+  | `tintColor` | 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralPrimary)` 적용 |
+</details>
+<details>
+
+<summary>``case largeIcon(Icon, tintColor: SwiftUI.Color)``</summary>
+
+
+배경이 있는 큰 아이콘 (컨테이너 36×36 / 아이콘 20×20)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `icon` | 표시할 아이콘 |
+  | `tintColor` | 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralPrimary)` 적용 |
+</details>
+<details>
+
+<summary>``case radio(checked: Bool, onSelect: ((Bool) -> Void)?)``</summary>
+
+
+라디오
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `checked` | 선택 여부 |
+  | `onSelect` | 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용 |
+</details>
+<details>
+
+<summary>``case slotView(() -> AnyView)``</summary>
+
+
+임의 뷰. [slot(_:)](/documentation/montage/listcell/resource/leading/slot(_:).md) 팩토리로 생성합니다.
+</details>
+<details>
+
+<summary>``case thumbnail(String)``</summary>
+
+
+썸네일 (56×56 정사각, 둥근 모서리·테두리 적용)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `imageUrl` | 표시할 이미지의 URL 문자열 |
+</details>
+
+##### Type Methods
+
+<details>
+
+<summary>``static func slot<V>(() -> V) -> Leading``</summary>
+
+
+목록에 없는 구성을 직접 배치합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `content` | 표시할 뷰를 생성하는 클로저 |
+- **Return Value**
+
+  구성된 요소
+</details>
+
+</details>
+<details>
+
+<summary>``enum Trailing``</summary>
+
+
+셀 우측([trailingResources(_:)](/documentation/montage/listcell/trailingresources(_:).md))에 표시할 요소입니다.
+##### Enumeration Cases
+
+<details>
+
+<summary>``case button(title: String, color: Button.Color, handler: (() -> Void)?)``</summary>
+
+
+버튼
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `title` | 버튼 텍스트 |
+  | `color` | 버튼 색상, 생략하면 기본값으로 `.assistive` 적용 |
+  | `handler` | 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용 |
+</details>
+<details>
+
+<summary>``case contentBadge(ContentBadge.Variant, title: String)``</summary>
+
+
+콘텐츠 배지
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `variant` | 배지 변형 스타일, 생략하면 기본값으로 `.solid` 적용 |
+  | `title` | 배지 텍스트 |
+</details>
+<details>
+
+<summary>``case icon(Icon, tintColor: SwiftUI.Color)``</summary>
+
+
+아이콘 (22×22)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `icon` | 표시할 아이콘 |
+  | `tintColor` | 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralQuaternary)` 적용 |
+</details>
+<details>
+
+<summary>``case iconButton(Icon, handler: (() -> Void)?)``</summary>
+
+
+아이콘 버튼 (배경 없음)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `icon` | 버튼 아이콘 |
+  | `handler` | 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용 |
+</details>
+<details>
+
+<summary>``case slotView(() -> AnyView)``</summary>
+
+
+임의 뷰. [slot(_:)](/documentation/montage/listcell/resource/trailing/slot(_:).md) 팩토리로 생성합니다.
+</details>
+<details>
+
+<summary>``case `switch`(checked: Bool, onSelect: ((Bool) -> Void)?)``</summary>
+
+
+스위치
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `checked` | 켜짐 여부 |
+  | `onSelect` | 값 변경 핸들러, 생략하면 기본값으로 `nil` 적용 |
+</details>
+<details>
+
+<summary>``case textButton(title: String, color: TextButton.Color, handler: (() -> Void)?)``</summary>
+
+
+텍스트 버튼
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `title` | 버튼 텍스트 |
+  | `color` | 버튼 색상, 생략하면 기본값으로 `.assistive` 적용 |
+  | `handler` | 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용 |
+</details>
+<details>
+
+<summary>``case value(String)``</summary>
+
+
+값 텍스트
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `text` | 표시할 텍스트 |
+</details>
+
+##### Type Methods
+
+<details>
+
+<summary>``static func slot<V>(() -> V) -> Trailing``</summary>
+
+
+목록에 없는 구성을 직접 배치합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `content` | 표시할 뷰를 생성하는 클로저 |
+- **Return Value**
+
+  구성된 요소
+</details>
+
+</details>
+
+</details>
 <details>
 
 <summary>``enum VerticalAlign``</summary>

--- a/documentation/components/contents/listcell/ios.md
+++ b/documentation/components/contents/listcell/ios.md
@@ -366,7 +366,7 @@ ListCell(label: "커스텀")
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정되며, 셀 오른쪽 끝에 체크 아이콘이 표시됩니다.
+  선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정되며, trailing 영역에 체크 아이콘이 표시됩니다. [chevron(_:)](/documentation/montage/listcell/chevron(_:).md)을 켠 셀에서는 화살표가 체크 아이콘 오른쪽에 그대로 남습니다.
   >  **Important**
   >
   > 체크 아이콘은 [trailingResources(_:)](/documentation/montage/listcell/trailingresources(_:).md) 자리를 대신 차지하므로 둘을 함께 표시할 수 없습니다. 선택 상태와 별개의 우측 콘텐츠가 필요하면 [labelTrailingResources(_:)](/documentation/montage/listcell/labeltrailingresources(_:).md) 또는 [extraResources(_:)](/documentation/montage/listcell/extraresources(_:).md)를 사용하세요.
@@ -471,7 +471,11 @@ ListCell(label: "커스텀")
 
   슬롯마다 쓸 수 있는 요소가 다르므로 슬롯별로 타입을 나눠 두었습니다. 예를 들어 [ListCell.Resource.Trailing.switch(checked:onSelect:)](/documentation/montage/listcell/resource/trailing/switch(checked:onselect:).md)는 [trailingResources(_:)](/documentation/montage/listcell/trailingresources(_:).md)에만 넘길 수 있고, [leadingResources(_:)](/documentation/montage/listcell/leadingresources(_:).md)에 넘기면 컴파일되지 않습니다.
 
-  각 요소의 크기와 정렬은 셀 스펙(행 최소 높이 24)에 맞춰 고정됩니다. 목록에 없는 구성이 필요하면 각 타입의 `slot(_:)` 팩토리를 사용합니다.
+  미리 정의된 요소는 크기와 정렬이 셀 스펙(행 최소 높이 24)에 맞춰 고정됩니다. 목록에 없는 구성이 필요하면 각 타입의 `slot(_:)` 팩토리를 사용합니다.
+  >  **Important**
+  >
+  > `slot(_:)`으로 넣은 뷰에는 이 크기 제약이 적용되지 않습니다. 행 높이가 밀리지 않게 하려면 사용처에서 `frame(...)`이나 `fixedSize(...)`로 크기를 직접 정해야 합니다.
+
 #### Enumerations
 
 <details>

--- a/documentation/components/contents/listcell/ios.md
+++ b/documentation/components/contents/listcell/ios.md
@@ -9,18 +9,18 @@ description: 텍스트와 콘텐츠를 포함하는 리스트 아이템 컴포�
 
 ## Overview
 
-`ListCell`은 앱 내에서 리스트 형태로 정보를 표시할 때 사용되는 기본 컴포넌트입니다. 타이틀, 부가 설명, 좌측 콘텐츠, 우측 콘텐츠 등을 포함할 수 있으며 다양한 스타일로 커스터마이징할 수 있습니다.
+`ListCell`은 앱 내에서 리스트 형태로 정보를 표시할 때 사용되는 기본 컴포넌트입니다. 라벨, 부가 설명과 함께 네 종류의 콘텐츠 슬롯([leadingContent(_:)](/documentation/montage/listcell/leadingcontent(_:).md), [labelTrailingContent(_:)](/documentation/montage/listcell/labeltrailingcontent(_:).md), [trailingContent(_:)](/documentation/montage/listcell/trailingcontent(_:).md), [extraContent(_:)](/documentation/montage/listcell/extracontent(_:).md))을 제공하며 다양한 스타일로 커스터마이징할 수 있습니다.
 
 ```swift
 // 기본 셀
-ListCell(title: "기본 셀")
+ListCell(label: "기본 셀")
 
 // 추가 설명이 있는 셀
-ListCell(title: "설명이 있는 셀")
-    .caption("부가 설명 텍스트")
+ListCell(label: "설명이 있는 셀")
+    .description("부가 설명 텍스트")
 
 // 리딩 콘텐츠와 선택 상태의 셀
-ListCell(title: "커스텀 셀", onTap: {
+ListCell(label: "커스텀 셀", onTap: {
     print("셀이 탭되었습니다")
 })
 .leadingContent {
@@ -31,13 +31,36 @@ ListCell(title: "커스텀 셀", onTap: {
 .chevron(true)
 ```
 
+## 콘텐츠 슬롯
+
+네 슬롯은 셀 안에서 각각 다음 위치를 차지하며, 슬롯마다 여러 요소를 나열할 수 있습니다.
+
+- [leadingContent(_:)](/documentation/montage/listcell/leadingcontent(_:).md): 라벨 앞, 항목 간 간격 8
+- [labelTrailingContent(_:)](/documentation/montage/listcell/labeltrailingcontent(_:).md): 라벨 바로 뒤, 항목 간 간격 4
+- [trailingContent(_:)](/documentation/montage/listcell/trailingcontent(_:).md): 셀 오른쪽 끝, 항목 간 간격 8
+- [extraContent(_:)](/documentation/montage/listcell/extracontent(_:).md): 설명 아래, 항목 간 간격 6
+
+```swift
+ListCell(label: "김티드")
+    .description("iOS 개발자")
+    .labelTrailingContent {
+        ContentBadge(text: "신규")
+    }
+    .extraContent {
+        ContentBadge(variant: .outlined, text: "서울")
+    }
+    .trailingContent { _ in
+        Text("값")
+    }
+```
+
 ## Topics
 
 ### Initializers
 
 <details>
 
-<summary>``init(title: String, onTap: (() -> Void)?)``</summary>
+<summary>``init(label: String, onTap: (() -> Void)?)``</summary>
 
 
 셀 컴포넌트를 초기화합니다.
@@ -45,7 +68,7 @@ ListCell(title: "커스텀 셀", onTap: {
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `title` | 셀에 표시할 제목 텍스트 |
+  | `label` | 셀에 표시할 제목 텍스트 |
   | `onTap` | 셀을 탭했을 때 실행할 클로저, 생략하면 기본값으로 `nil` 적용 |
 </details>
 
@@ -61,24 +84,6 @@ ListCell(title: "커스텀 셀", onTap: {
 
 ### Instance Methods
 
-<details>
-
-<summary>``func caption(String?) -> ListCell``</summary>
-
-
-셀에 부가 설명(캡션)을 추가합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `caption` | 표시할 캡션 텍스트, 생략하면 기본값으로 `nil` 적용 (nil 설정 시 캡션 제거) |
-- **Return Value**
-
-  수정된 ListCell 인스턴스
-- **Discussion**
-
-  캡션은 타이틀 아래에 작은 글씨로 표시되는 부가 설명 텍스트입니다.
-</details>
 <details>
 
 <summary>``func chevron(Bool) -> ListCell``</summary>
@@ -99,6 +104,24 @@ ListCell(title: "커스텀 셀", onTap: {
 </details>
 <details>
 
+<summary>``func description(String?) -> ListCell``</summary>
+
+
+셀에 부가 설명을 추가합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `description` | 표시할 설명 텍스트, 생략하면 기본값으로 `nil` 적용 (nil 설정 시 설명 제거) |
+- **Return Value**
+
+  수정된 ListCell 인스턴스
+- **Discussion**
+
+  설명은 라벨 아래에 작은 글씨로 표시되는 부가 설명 텍스트입니다.
+</details>
+<details>
+
 <summary>``func disable(Bool) -> ListCell``</summary>
 
 
@@ -113,7 +136,11 @@ ListCell(title: "커스텀 셀", onTap: {
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  비활성화된 셀은 탭 이벤트를 받지 않으며, 시각적으로 흐리게 표시됩니다.
+  비활성화된 셀은 탭 이벤트를 받지 않으며, 라벨·설명·콘텐츠 슬롯에 `foregroundDisablePrimary` 색상이 적용됩니다.
+  >  **Note**
+  >
+  > 콘텐츠 슬롯에는 전경색으로 전달되므로, 슬롯 안에서 색상을 직접 지정한 뷰에는 적용되지 않습니다.
+
 </details>
 <details>
 
@@ -132,22 +159,34 @@ ListCell(title: "커스텀 셀", onTap: {
 </details>
 <details>
 
-<summary>``func fillWidth(Bool) -> ListCell``</summary>
+<summary>``func extraContent<V>(() -> V) -> ListCell``</summary>
 
 
-셀의 좌우 여백 사용 여부를 설정합니다.
+설명 아래에 자유 콘텐츠를 표시합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `fillWidth` | 좌우 여백 적용 여부, 생략하면 기본값으로 `true` 적용 |
+  | `contents` | 표시할 콘텐츠를 생성하는 클로저 |
 - **Return Value**
 
   수정된 ListCell 인스턴스
 - **Discussion**
+
+  셀 폭을 모두 사용하는 자유 슬롯으로, 여러 요소를 나열하면 6포인트 간격으로 가로 배치됩니다.
+
+  ```swift
+  ListCell(label: "김티드")
+      .description("iOS 개발자")
+      .extraContent {
+          ContentBadge(variant: .outlined, text: "서울")
+          ContentBadge(variant: .outlined, text: "5년차")
+      }
+  ```
+
   >  **Note**
   >
-  > `true`로 설정하면 셀 내부에 좌우 20포인트의 여백이 적용되고 인터랙션 영역이 각진 모서리 사각형 모양의 셀 내부 영역으로 한정되며, `false`로 설정하면 셀 내부 여백이 없는 대신 인터랙션 영역이 둥근 모서리 사각형 모양으로 셀 영역 바깥까지 적용됩니다.
+  > 슬롯 내부 구성은 사용처가 정하며, 그 안의 타이포그래피와 색상은 컴포넌트가 보장하지 않습니다.
 
 </details>
 <details>
@@ -155,7 +194,7 @@ ListCell(title: "커스텀 셀", onTap: {
 <summary>``func highlight(String) -> ListCell``</summary>
 
 
-타이틀의 특정 텍스트를 강조 표시합니다.
+라벨의 특정 텍스트를 강조 표시합니다.
 
 - **Parameters**
   | Parameter | Description |
@@ -170,18 +209,127 @@ ListCell(title: "커스텀 셀", onTap: {
 </details>
 <details>
 
-<summary>``func interactionPadding(CGFloat) -> ListCell``</summary>
+<summary>``func interactionOutset(CGFloat) -> ListCell``</summary>
 
 
-셀의 인터랙션 효과 영역의 좌우 패딩을 조정합니다.
+인터랙션 효과(hover·pressed 배경)가 셀 경계 바깥으로 확장되는 정도를 설정합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `padding` | 적용할 패딩 값 (포인트 단위) |
+  | `outset` | 좌우로 확장할 크기 (포인트 단위), 생략하면 기본값으로 `12` 적용 |
 - **Return Value**
 
   수정된 ListCell 인스턴스
+- **Discussion**
+
+  메뉴처럼 좌우 여백이 있는 컨테이너 안에서는 기본값 `12`를 그대로 사용해 여백까지 배경을 넓히고, 셀이 화면 폭을 그대로 채우는 목록에서는 `0`을 지정합니다.
+  >  **Note**
+  >
+  > 모서리 둥글기는 [interactionRadius(_:)](/documentation/montage/listcell/interactionradius(_:).md)로 따로 정하며 `outset`과 독립적으로 동작합니다.
+
+  >  **Note**
+  >
+  > 4.0.0에서 제거된 `fillWidth(_:)`·`interactionPadding(_:)`을 대체합니다. `fillWidth(true)`는 `interactionOutset(0)`, `fillWidth(false)`는 `interactionOutset(12)`에 대응하며, `fillWidth(true)`가 적용하던 셀 좌우 20포인트 여백은 더 이상 자동으로 붙지 않으므로 필요하면 사용처에서 직접 지정합니다.
+
+</details>
+<details>
+
+<summary>``func interactionRadius(CGFloat) -> ListCell``</summary>
+
+
+인터랙션 효과 영역의 모서리 둥글기를 설정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `radius` | 적용할 모서리 반경 (포인트 단위) |
+- **Return Value**
+
+  수정된 ListCell 인스턴스
+- **Discussion**
+
+  지정하지 않으면 [interactionOutset(_:)](/documentation/montage/listcell/interactionoutset(_:).md)이 `0`보다 클 때 `16`, 그 외에는 `0`이 적용됩니다.
+</details>
+<details>
+
+<summary>``func labelColor(Color.Semantic) -> ListCell``</summary>
+
+
+라벨 텍스트의 `color` 속성을 조정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `color` | 적용할 텍스트 색상 |
+- **Return Value**
+
+  수정된 ListCell 인스턴스
+</details>
+<details>
+
+<summary>``func labelTrailingContent<V>(() -> V) -> ListCell``</summary>
+
+
+라벨 행의 오른쪽 끝에 콘텐츠를 표시합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `contents` | 표시할 콘텐츠를 생성하는 클로저 |
+- **Return Value**
+
+  수정된 ListCell 인스턴스
+- **Discussion**
+
+  배지나 인증 아이콘처럼 라벨에 딸린 요소를 배치할 때 사용합니다. 여러 요소를 나열하면 4포인트 간격으로 가로 배치되며, 높이가 22포인트로 고정되어 행 높이를 늘리지 않습니다.
+
+  ```swift
+  ListCell(label: "김티드")
+      .labelTrailingContent {
+          ContentBadge(text: "신규")
+      }
+  ```
+
+  >  **Note**
+  >
+  > 라벨이 2줄 이상일 때 표시 위치는 [verticalAlign(_:)](/documentation/montage/listcell/verticalalign(_:).md)을 따릅니다.
+
+</details>
+<details>
+
+<summary>``func labelVariant(Typography.Variant) -> ListCell``</summary>
+
+
+라벨 텍스트의 `variant` 속성을 조정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `variant` | 적용할 Typography 변형 스타일 |
+- **Return Value**
+
+  수정된 ListCell 인스턴스
+</details>
+<details>
+
+<summary>``func labelWeight(Typography.Weight) -> ListCell``</summary>
+
+
+라벨 텍스트의 `weight` 속성을 조정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `weight` | 적용할 텍스트 두께 |
+- **Return Value**
+
+  수정된 ListCell 인스턴스
+- **Discussion**
+  >  **Note**
+  >
+  > `selected`가 `true`인 셀은 이 값과 무관하게 `bold`로 표시됩니다.
+
 </details>
 <details>
 
@@ -199,7 +347,16 @@ ListCell(title: "커스텀 셀", onTap: {
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  아이콘, 이미지, 기타 커스텀 뷰 등을 셀 타이틀 앞에 배치할 수 있습니다.
+  아이콘, 체크박스, 아바타, 썸네일 등을 셀 라벨 앞에 배치할 수 있습니다. 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다.
+
+  ```swift
+  ListCell(label: "김티드")
+      .leadingContent {
+          Checkbox(checked: isChecked)
+          Avatar(image: profileImage)
+      }
+  ```
+
 </details>
 <details>
 
@@ -217,14 +374,14 @@ ListCell(title: "커스텀 셀", onTap: {
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  선택된 셀은 타이틀 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 medium으로 설정됩니다. `trailingContent` 클로저의 파라미터로 선택된 상태 여부가 전달됩니다.
+  선택된 셀은 라벨 텍스트의 색상이 `surfaceBrandPrimary`로 변경되고, 텍스트 두께가 bold로 설정됩니다. `trailingContent` 클로저의 파라미터로 선택된 상태 여부가 전달됩니다.
 </details>
 <details>
 
 <summary>``func textEllipsis(Bool) -> ListCell``</summary>
 
 
-타이틀 텍스트의 생략 처리 여부를 설정합니다.
+텍스트의 생략 처리 여부를 설정합니다.
 
 - **Parameters**
   | Parameter | Description |
@@ -235,56 +392,7 @@ ListCell(title: "커스텀 셀", onTap: {
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  `true`로 설정하면 타이틀 텍스트가 2줄로 제한되고, 초과 텍스트는 생략됩니다.
-  >  **Note**
-  >
-  > `false`인 경우 좌우 콘텐츠는 상단 정렬됩니다.
-
-</details>
-<details>
-
-<summary>``func titleColor(Color.Semantic) -> ListCell``</summary>
-
-
-타이틀 텍스트의 `color` 속성을 조정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `color` | 적용할 텍스트 색상 |
-- **Return Value**
-
-  수정된 ListCell 인스턴스
-</details>
-<details>
-
-<summary>``func titleVariant(Typography.Variant) -> ListCell``</summary>
-
-
-타이틀 텍스트의 `variant` 속성을 조정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `variant` | 적용할 Typography 변형 스타일 |
-- **Return Value**
-
-  수정된 ListCell 인스턴스
-</details>
-<details>
-
-<summary>``func titleWeight(Typography.Weight) -> ListCell``</summary>
-
-
-타이틀 텍스트의 `weight` 속성을 조정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `weight` | 적용할 텍스트 두께 |
-- **Return Value**
-
-  수정된 ListCell 인스턴스
+  `true`로 설정하면 라벨과 설명이 각각 한 줄로 제한되고, 초과 텍스트는 말줄임 처리됩니다. `false`인 경우 두 텍스트 모두 줄 수 제한 없이 줄바꿈됩니다.
 </details>
 <details>
 
@@ -302,11 +410,11 @@ ListCell(title: "커스텀 셀", onTap: {
   수정된 ListCell 인스턴스
 - **Discussion**
 
-  배지, 스위치, 토글 등 추가 UI 요소를 셀 타이틀 뒤에 배치할 수 있습니다. 클로저 파라미터를 통해 셀의 선택된 상태를 전달받을 수 있습니다.
+  값 텍스트, 배지, 버튼, 스위치 등 추가 UI 요소를 셀 오른쪽 끝에 배치할 수 있습니다. 여러 요소를 나열하면 8포인트 간격으로 가로 배치됩니다. 클로저 파라미터를 통해 셀의 선택된 상태를 전달받을 수 있습니다.
 </details>
 <details>
 
-<summary>``func verticalAlign(VerticalAlignment) -> ListCell``</summary>
+<summary>``func verticalAlign(VerticalAlign) -> ListCell``</summary>
 
 
 셀 내 콘텐츠의 수직 정렬을 조정합니다.
@@ -314,10 +422,13 @@ ListCell(title: "커스텀 셀", onTap: {
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `verticalAlignment` | 적용할 수직 정렬 방식 |
+  | `verticalAlignment` | 적용할 수직 정렬 방식, 생략하면 기본값으로 `.top` 적용 |
 - **Return Value**
 
   수정된 ListCell 인스턴스
+- **Discussion**
+
+  라벨이 2줄 이상일 때 leading·labelTrailing·trailing 콘텐츠를 첫 행에 맞출지, 셀 중앙에 맞출지 정합니다.
 </details>
 <details>
 
@@ -333,10 +444,41 @@ ListCell(title: "커스텀 셀", onTap: {
 - **Return Value**
 
   수정된 ListCell 인스턴스
+- **Discussion**
+
+  정해진 네 단계(`none`·`small`·`medium`·`large`)로 표현할 수 없는 간격은 [ListCell.VerticalPadding.custom(_:)](/documentation/montage/listcell/verticalpadding/custom(_:).md)으로 직접 지정할 수 있습니다.
+  >  **Note**
+  >
+  > 여백이 `0`인 셀은 인터랙션 효과를 표시하지 않습니다.
+
 </details>
 
 ### Enumerations
 
+<details>
+
+<summary>``enum VerticalAlign``</summary>
+
+
+셀 내 콘텐츠의 수직 정렬을 나타내는 열거형입니다.
+#### Enumeration Cases
+
+<details>
+
+<summary>``case center``</summary>
+
+
+셀 높이의 중앙에 정렬
+</details>
+<details>
+
+<summary>``case top``</summary>
+
+
+첫 행에 맞춰 정렬
+</details>
+
+</details>
 <details>
 
 <summary>``enum VerticalPadding``</summary>
@@ -350,17 +492,27 @@ ListCell(title: "커스텀 셀", onTap: {
 
 <details>
 
+<summary>``case custom(CGFloat)``</summary>
+
+
+직접 지정한 여백
+- **Discussion**
+
+  정해진 네 단계로 표현할 수 없는 간격이 필요할 때만 사용합니다.
+</details>
+<details>
+
 <summary>``case large``</summary>
 
 
-큰 여백
+큰 여백 (16)
 </details>
 <details>
 
 <summary>``case medium``</summary>
 
 
-중간 여백
+중간 여백 (12)
 </details>
 <details>
 
@@ -374,7 +526,7 @@ ListCell(title: "커스텀 셀", onTap: {
 <summary>``case small``</summary>
 
 
-작은 여백
+작은 여백 (8)
 </details>
 
 </details>

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -1435,20 +1435,20 @@
       "summary": "텍스트와 콘텐츠를 포함하는 리스트 아이템 컴포넌트입니다.",
       "initializers": [
         {
-          "signature": "init(title:onTap:)"
+          "signature": "init(label:onTap:)"
         }
       ],
       "modifiers": [
         {
-          "name": "caption(_:)",
-          "signature": "func caption(String?) -> ListCell",
-          "summary": "셀에 부가 설명(캡션)을 추가합니다.",
-          "kind": "method"
-        },
-        {
           "name": "chevron(_:)",
           "signature": "func chevron(Bool) -> ListCell",
           "summary": "셀 우측에 화살표(chevron) 아이콘을 추가합니다.",
+          "kind": "method"
+        },
+        {
+          "name": "description(_:)",
+          "signature": "func description(String?) -> ListCell",
+          "summary": "셀에 부가 설명을 추가합니다.",
           "kind": "method"
         },
         {
@@ -1464,21 +1464,51 @@
           "kind": "method"
         },
         {
-          "name": "fillWidth(_:)",
-          "signature": "func fillWidth(Bool) -> ListCell",
-          "summary": "셀의 좌우 여백 사용 여부를 설정합니다.",
+          "name": "extraContent(_:)",
+          "signature": "func extraContent<V>(() -> V) -> ListCell",
+          "summary": "설명 아래에 자유 콘텐츠를 표시합니다.",
           "kind": "method"
         },
         {
           "name": "highlight(_:)",
           "signature": "func highlight(String) -> ListCell",
-          "summary": "타이틀의 특정 텍스트를 강조 표시합니다.",
+          "summary": "라벨의 특정 텍스트를 강조 표시합니다.",
           "kind": "method"
         },
         {
-          "name": "interactionPadding(_:)",
-          "signature": "func interactionPadding(CGFloat) -> ListCell",
-          "summary": "셀의 인터랙션 효과 영역의 좌우 패딩을 조정합니다.",
+          "name": "interactionOutset(_:)",
+          "signature": "func interactionOutset(CGFloat) -> ListCell",
+          "summary": "인터랙션 효과(hover·pressed 배경)가 셀 경계 바깥으로 확장되는 정도를 설정합니다.",
+          "kind": "method"
+        },
+        {
+          "name": "interactionRadius(_:)",
+          "signature": "func interactionRadius(CGFloat) -> ListCell",
+          "summary": "인터랙션 효과 영역의 모서리 둥글기를 설정합니다.",
+          "kind": "method"
+        },
+        {
+          "name": "labelColor(_:)",
+          "signature": "func labelColor(Color.Semantic) -> ListCell",
+          "summary": "라벨 텍스트의 color 속성을 조정합니다.",
+          "kind": "method"
+        },
+        {
+          "name": "labelTrailingContent(_:)",
+          "signature": "func labelTrailingContent<V>(() -> V) -> ListCell",
+          "summary": "라벨 행의 오른쪽 끝에 콘텐츠를 표시합니다.",
+          "kind": "method"
+        },
+        {
+          "name": "labelVariant(_:)",
+          "signature": "func labelVariant(Typography.Variant) -> ListCell",
+          "summary": "라벨 텍스트의 variant 속성을 조정합니다.",
+          "kind": "method"
+        },
+        {
+          "name": "labelWeight(_:)",
+          "signature": "func labelWeight(Typography.Weight) -> ListCell",
+          "summary": "라벨 텍스트의 weight 속성을 조정합니다.",
           "kind": "method"
         },
         {
@@ -1496,25 +1526,7 @@
         {
           "name": "textEllipsis(_:)",
           "signature": "func textEllipsis(Bool) -> ListCell",
-          "summary": "타이틀 텍스트의 생략 처리 여부를 설정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "titleColor(_:)",
-          "signature": "func titleColor(Color.Semantic) -> ListCell",
-          "summary": "타이틀 텍스트의 color 속성을 조정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "titleVariant(_:)",
-          "signature": "func titleVariant(Typography.Variant) -> ListCell",
-          "summary": "타이틀 텍스트의 variant 속성을 조정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "titleWeight(_:)",
-          "signature": "func titleWeight(Typography.Weight) -> ListCell",
-          "summary": "타이틀 텍스트의 weight 속성을 조정합니다.",
+          "summary": "텍스트의 생략 처리 여부를 설정합니다.",
           "kind": "method"
         },
         {
@@ -1525,7 +1537,7 @@
         },
         {
           "name": "verticalAlign(_:)",
-          "signature": "func verticalAlign(VerticalAlignment) -> ListCell",
+          "signature": "func verticalAlign(VerticalAlign) -> ListCell",
           "summary": "셀 내 콘텐츠의 수직 정렬을 조정합니다.",
           "kind": "method"
         },
@@ -1539,10 +1551,27 @@
       "staticMembers": [],
       "nestedTypes": [
         {
+          "name": "ListCell.VerticalAlign",
+          "kind": "enum",
+          "summary": "셀 내 콘텐츠의 수직 정렬을 나타내는 열거형입니다.",
+          "cases": [
+            "center",
+            "top"
+          ]
+        },
+        {
           "name": "ListCell.VerticalPadding",
           "kind": "enum",
           "summary": "상하 여백을 나타내는 열거형입니다.",
           "cases": [
+            "custom",
+            "large",
+            "medium",
+            "none",
+            "small"
+          ],
+          "caseSignatures": [
+            "custom(_:)",
             "large",
             "medium",
             "none",

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -1464,9 +1464,9 @@
           "kind": "method"
         },
         {
-          "name": "extraContent(_:)",
-          "signature": "func extraContent<V>(() -> V) -> ListCell",
-          "summary": "설명 아래에 자유 콘텐츠를 표시합니다.",
+          "name": "extraResources(_:)",
+          "signature": "func extraResources([Resource.Extra]) -> ListCell",
+          "summary": "설명 아래에 표시할 요소를 지정합니다.",
           "kind": "method"
         },
         {
@@ -1494,9 +1494,9 @@
           "kind": "method"
         },
         {
-          "name": "labelTrailingContent(_:)",
-          "signature": "func labelTrailingContent<V>(() -> V) -> ListCell",
-          "summary": "라벨 행의 오른쪽 끝에 콘텐츠를 표시합니다.",
+          "name": "labelTrailingResources(_:)",
+          "signature": "func labelTrailingResources([Resource.LabelTrailing]) -> ListCell",
+          "summary": "라벨 행의 오른쪽 끝에 표시할 요소를 지정합니다.",
           "kind": "method"
         },
         {
@@ -1512,9 +1512,9 @@
           "kind": "method"
         },
         {
-          "name": "leadingContent(_:)",
-          "signature": "func leadingContent<V>(() -> V) -> ListCell",
-          "summary": "셀 좌측에 추가 콘텐츠를 표시합니다.",
+          "name": "leadingResources(_:)",
+          "signature": "func leadingResources([Resource.Leading]) -> ListCell",
+          "summary": "셀 좌측에 표시할 요소를 지정합니다.",
           "kind": "method"
         },
         {
@@ -1530,9 +1530,9 @@
           "kind": "method"
         },
         {
-          "name": "trailingContent(_:)",
-          "signature": "func trailingContent<V>((Bool) -> V) -> ListCell",
-          "summary": "셀 우측에 추가 콘텐츠를 표시합니다.",
+          "name": "trailingResources(_:)",
+          "signature": "func trailingResources([Resource.Trailing]) -> ListCell",
+          "summary": "셀 우측에 표시할 요소를 지정합니다.",
           "kind": "method"
         },
         {
@@ -1550,6 +1550,121 @@
       ],
       "staticMembers": [],
       "nestedTypes": [
+        {
+          "name": "ListCell.Resource",
+          "kind": "enum",
+          "summary": "ListCell의 각 슬롯에 표시할 요소들의 Namespace입니다."
+        },
+        {
+          "name": "ListCell.Resource.Extra",
+          "kind": "enum",
+          "summary": "설명 아래(extraResources(_:))에 표시할 요소입니다.",
+          "cases": [
+            "contentBadge",
+            "slotView",
+            "text"
+          ],
+          "caseSignatures": [
+            "contentBadge(_:title:)",
+            "slotView(_:)",
+            "text(_:)"
+          ],
+          "staticMethods": [
+            {
+              "name": "slot(_:)",
+              "signature": "static func slot<V>(() -> V) -> Extra",
+              "summary": "목록에 없는 구성을 직접 배치합니다.",
+              "kind": "method"
+            }
+          ]
+        },
+        {
+          "name": "ListCell.Resource.LabelTrailing",
+          "kind": "enum",
+          "summary": "라벨 행 오른쪽 끝(labelTrailingResources(_:))에 표시할 요소입니다.",
+          "cases": [
+            "contentBadge",
+            "icon",
+            "slotView"
+          ],
+          "caseSignatures": [
+            "contentBadge(_:title:)",
+            "icon(_:tintColor:)",
+            "slotView(_:)"
+          ],
+          "staticMethods": [
+            {
+              "name": "slot(_:)",
+              "signature": "static func slot<V>(() -> V) -> LabelTrailing",
+              "summary": "목록에 없는 구성을 직접 배치합니다.",
+              "kind": "method"
+            }
+          ]
+        },
+        {
+          "name": "ListCell.Resource.Leading",
+          "kind": "enum",
+          "summary": "셀 좌측(leadingResources(_:))에 표시할 요소입니다.",
+          "cases": [
+            "avatar",
+            "checkbox",
+            "icon",
+            "largeIcon",
+            "radio",
+            "slotView",
+            "thumbnail"
+          ],
+          "caseSignatures": [
+            "avatar(_:variant:)",
+            "checkbox(checked:onSelect:)",
+            "icon(_:tintColor:)",
+            "largeIcon(_:tintColor:)",
+            "radio(checked:onSelect:)",
+            "slotView(_:)",
+            "thumbnail(_:)"
+          ],
+          "staticMethods": [
+            {
+              "name": "slot(_:)",
+              "signature": "static func slot<V>(() -> V) -> Leading",
+              "summary": "목록에 없는 구성을 직접 배치합니다.",
+              "kind": "method"
+            }
+          ]
+        },
+        {
+          "name": "ListCell.Resource.Trailing",
+          "kind": "enum",
+          "summary": "셀 우측(trailingResources(_:))에 표시할 요소입니다.",
+          "cases": [
+            "button",
+            "contentBadge",
+            "icon",
+            "iconButton",
+            "slotView",
+            "switch",
+            "textButton",
+            "value"
+          ],
+          "caseSignatures": [
+            "button(title:color:handler:)",
+            "contentBadge(_:title:)",
+            "icon(_:tintColor:)",
+            "iconButton(_:handler:)",
+            "slotView(_:)",
+            "switch(checked:onSelect:)",
+            "textButton(title:color:handler:)",
+            "value(_:)"
+          ],
+          "staticMethods": [
+            {
+              "name": "slot(_:)",
+              "signature": "static func slot<V>(() -> V) -> Trailing",
+              "summary": "목록에 없는 구성을 직접 배치합니다.",
+              "kind": "method"
+            }
+          ]
+        },
         {
           "name": "ListCell.VerticalAlign",
           "kind": "enum",


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2178

List Cell을 4.0.0 스펙으로 업데이트합니다. Figma 상세 보드와 컴포넌트 프로퍼티 페이지, 그리고 Slack 스레드의 디자이너 답변을 모두 반영했습니다.

커밋 4개로 나눠 쌓았습니다.

# 수정사항

### 1. `feat: ListCell 4.0.0 스펙 반영 (콘텐츠 슬롯·인터랙션)`

| 항목 | 변경 |
|---|---|
| `fillWidth` → `interactionOutset` | 속성명이 실제 동작(인터랙션이 셀 경계 밖으로 나가는 정도)을 나타내도록 변경. 기본 12. 셀 좌우 20pt 우회 패딩 제거 |
| `interactionRadius` 신설 | outset과 독립. 미지정 시 `outset > 0 ? 16 : 0` 파생 |
| 타이포 | 라벨 `body1/regular` → `body2/medium`, selected는 `bold`. 라벨-설명 간격 4 → 0 |
| `textEllipsis` | `lineLimit(2)` → `lineLimit(1)`, 라벨·설명 모두 적용 |
| Disabled | 셀 전체 `opacity(0.43)` → `foregroundDisablePrimary` 토큰. `allowsHitTesting` → `disabled(_:)` |
| 콘텐츠 슬롯 | `labelTrailing`·`extraContent` 신설로 4종 구성. 슬롯당 다중 요소 배치 |
| 행 높이 | leading·라벨·trailing 최소 높이 24 + 중앙정렬, 라벨 행 상하 패딩 1 |
| `verticalPadding` | `custom(CGFloat)` 추가. 여백 0이면 인터랙션 미표시 |
| `verticalAlign` | `VerticalAlignment` → top/center만 갖는 전용 enum (bottom은 스펙에 없는 오버스펙) |
| 네이밍 | `title` → `label`, `caption` → `description` (Slack 확정) |
| divider | `lineNeutralTertiary` → `lineNeutralPrimaryOpaque` (3플랫폼 정합) |
| Interaction | alpha 리터럴을 Opacity 토큰으로 교체 (값 동일) |

`fillWidth(_:)`·`interactionPadding(_:)`은 메이저라 deprecated 없이 제거했습니다.

### 2. `feat: 비활성 컨테이너의 Avatar·Thumbnail에 Opacity/43 적용`

이미지 계열은 색 토큰으로 비활성을 표현할 수 없어 `@Environment(\.isEnabled)`를 읽어 `Opacity/43`을 적용합니다.

### 3. `feat: ListCell selected 상태에 체크 아이콘 추가`

선택 시 컴포넌트가 체크 아이콘(22×22, 브랜드 색)을 직접 그립니다. Figma 기준 trailing 자리를 대체하는 구조라 `Select`가 직접 그리던 체크는 제거했습니다.

### 4. `feat: ListCell 슬롯 요소 프리셋 ListCell.Resource 추가`

슬롯에 넣을 요소를 셀 스펙에 맞는 크기로 제공합니다. `TopNavigation.Resource` 선례를 따라 슬롯별 타입으로 나눠 다른 슬롯 전용 요소는 컴파일 단계에서 막습니다.

```swift
ListCell(label: "김티드")
    .leadingResources([.checkbox(checked: isChecked), .avatar(url, variant: .person)])
    .labelTrailingResources([.contentBadge(title: "신규")])
    .trailingResources([.value("값")])
    .extraResources([.contentBadge(.outlined, title: "서울")])

// .leadingResources([.switch(checked: x)])  ← 컴파일 에러
```

ViewBuilder 슬롯 모디파이어(`leadingContent { }` 등)는 제거했습니다. 병존하면 타입 제약을 우회할 수 있어서입니다. 자유 구성은 `slot(_:)` 하나로만 열어뒀습니다.

# 미리보기

Blueprint TestFlight 배포로 확인 부탁드립니다.

작업 전|작업 후
---|---
스크린샷|스크린샷

---

### 리뷰 포인트

- **`Accordion`은 기존 동작을 유지**했습니다. `ListCellInteractionModifier`를 공유해 시그니처 변경에 맞춰 호출부만 고쳤고, radius는 새 기본값 16이 아닌 기존 12를 넘겨 시각 변화가 없게 했습니다. 4.0.0 Accordion 티켓이 없어 스펙 근거 없는 변경을 피했습니다.
- **`ListCell`의 `disabled(_:)` 전환**은 기존 `allowsHitTesting`의 접근성 결함(보조 기술에 비활성 상태 미전달) 때문입니다. `SearchField.swift:195`에 같은 판단이 주석으로 남아 있습니다.
- `Trailing/Toggle Icon` 프리셋은 대응 iOS 컴포넌트가 없고 동작 정의가 확인되지 않아 넣지 않았습니다.

### 후속 티켓

- [WRP-2216](https://wantedlab.atlassian.net/browse/WRP-2216) 슬롯 프리셋 Resource 패턴 정합 (TextArea·TopNavigation)
- [WRP-2217](https://wantedlab.atlassian.net/browse/WRP-2217) `disable()` 제거하고 SwiftUI 표준 `disabled()` API로 전환

둘 다 breaking이라 4.0.0 배포 전이 유일한 창입니다.


[WRP-2216]: https://wantedlab.atlassian.net/browse/WRP-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ