### PR TITLE
feat: TextField에 secured() modifier 추가

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
@@ -261,12 +261,16 @@ struct TextFieldPreview: View {
                     HStack {
                         HStack {
                             Text("Secured")
-                            Switch(checked: secured) { secured = $0 }
+                            Switch(checked: secured) {
+                                secured = $0
+                                if $0 { usingSuggestions = false }
+                            }
                         }
                         Spacer()
                         HStack {
                             Text("AutoComplete")
                             Switch(checked: usingSuggestions) { usingSuggestions = $0 }
+                                .disable(secured)
                         }
                     }
                     if secured {

--- a/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
@@ -93,6 +93,7 @@ struct TextFieldPreview: View {
     @State private var description: Bool = false
     @State private var placeholder: Bool = true
     @State private var trailingButton: Bool = false
+    @State private var secured: Bool = false
     @State private var trailingContent: Content = .none
     @State private var usingSuggestions: Bool = false
     @State private var autoCompletionDataSource: Montage.TextField.AutoCompletionDataSource? = nil
@@ -125,6 +126,7 @@ struct TextFieldPreview: View {
                 .requiredBadge(requiredBadge)
                 .placeholder(placeholder ? "텍스트를 입력해 주세요." : nil)
                 .icon(icon ? .verifiedCheckFill : nil)
+                .secured(secured)
                 .trailingButton(
                     trailingButton ? TextField.TrailingButtonInfo(
                         variant: .primary,
@@ -257,8 +259,20 @@ struct TextFieldPreview: View {
                         }
                     }
                     HStack {
-                        Text("AutoComplete")
-                        Switch(checked: usingSuggestions) { usingSuggestions = $0 }
+                        HStack {
+                            Text("Secured")
+                            Switch(checked: secured) { secured = $0 }
+                        }
+                        Spacer()
+                        HStack {
+                            Text("AutoComplete")
+                            Switch(checked: usingSuggestions) { usingSuggestions = $0 }
+                        }
+                    }
+                    if secured {
+                        Text("* 가려진 입력에서는 자동완성이 동작하지 않습니다.")
+                            .font(.caption)
+                            .foregroundStyle(SwiftUI.Color.secondary)
                     }
                     if usingSuggestions {
                         Text("* 다음 목록 중 매칭되는 값들이 제안됩니다:\n  \(candidates.joined(separator: ", "))")

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -457,7 +457,9 @@ private extension TextField {
         }
         .modifier(
             FloatModifier(
-                isPresented: (autoCompletionDataSource?.totalNumberOfItems ?? 0) > 0 && textFieldFocusState,
+                isPresented: !secured
+                    && (autoCompletionDataSource?.totalNumberOfItems ?? 0) > 0
+                    && textFieldFocusState,
                 updatingValue: Binding(
                     get: {
                         if autoCompletionDataSource == nil || autoCompletionContentHeight == 0 {

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -166,6 +166,7 @@ public struct TextField: View {
     private var trailingContent: () -> AnyView = { AnyView(EmptyView()) }
     private var suggestions: Binding<[String]> = .constant([])
     private var customBackgroundColor: SwiftUI.Color?
+    private var secured = false
     /// 텍스트 필드의 상태를 설정합니다.
     ///
     /// - Parameter status: 텍스트 필드의 상태
@@ -256,6 +257,19 @@ public struct TextField: View {
         zelf.customBackgroundColor = color
         return zelf
     }
+
+    /// 입력한 내용을 가릴지 설정합니다.
+    ///
+    /// 비밀번호처럼 노출되면 안 되는 값을 입력받을 때 사용합니다.
+    ///
+    /// - Parameter secured: 입력 내용을 가릴지 여부, 생략하면 기본값으로 `true` 적용
+    /// - Returns: 수정된 텍스트 필드 인스턴스
+    /// - Note: 자동완성은 가려진 입력에서 동작하지 않습니다.
+    public func secured(_ secured: Bool = true) -> Self {
+        var zelf = self
+        zelf.secured = secured
+        return zelf
+    }
     
     // MARK: - Body
     
@@ -302,6 +316,29 @@ public struct TextField: View {
 // MARK: - Private
 
 private extension TextField {
+    /// 가려진 입력 여부에 따라 `SecureField`와 `TextField`를 분기한다.
+    ///
+    /// `secured`는 화면이 살아 있는 동안 바뀌지 않는 설정이므로, 이 분기로 입력 중 포커스를 잃지 않는다.
+    @ViewBuilder
+    var textInput: some View {
+        if secured {
+            SwiftUI.SecureField("", text: $text, prompt: promptText)
+        } else {
+            SwiftUI.TextField("", text: $text, prompt: promptText)
+        }
+    }
+
+    var promptText: Text? {
+        guard let placeholder else { return nil }
+
+        return Text(placeholder)
+            .typography(
+                variant: .body1,
+                weight: .regular,
+                color: placeholderTextColor
+            )
+    }
+
     var inputField: some View {
         HStack(spacing: -1) {
             ZStack {
@@ -312,22 +349,7 @@ private extension TextField {
                             .frame(width: 22, height: 22)
                             .foregroundStyle(SwiftUI.Color.semantic(.labelAlternative))
                     }
-                    SwiftUI.TextField(
-                        "",
-                        text: $text,
-                        prompt: {
-                            if let placeholder {
-                                Text(placeholder)
-                                    .typography(
-                                        variant: .body1,
-                                        weight: .regular,
-                                        color: placeholderTextColor
-                                    )
-                            } else {
-                                nil
-                            }
-                        }()
-                    )
+                    textInput
                     .autocorrectionDisabled(fixAutocorrection)
                     .font(.font(variant: .body1, weight: .regular))
                     .foregroundStyle(fieldTextColor)

--- a/documentation/components/selection and input/textfield/ios.md
+++ b/documentation/components/selection and input/textfield/ios.md
@@ -238,6 +238,28 @@ TextField(text: $inputText)
 </details>
 <details>
 
+<summary>``func secured(Bool) -> TextField``</summary>
+
+
+입력한 내용을 가릴지 설정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `secured` | 입력 내용을 가릴지 여부, 생략하면 기본값으로 `true` 적용 |
+- **Return Value**
+
+  수정된 텍스트 필드 인스턴스
+- **Discussion**
+
+  비밀번호처럼 노출되면 안 되는 값을 입력받을 때 사용합니다.
+  >  **Note**
+  >
+  > 자동완성은 가려진 입력에서 동작하지 않습니다.
+
+</details>
+<details>
+
 <summary>``func status(Status) -> TextField``</summary>
 
 

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -2591,6 +2591,12 @@
           "kind": "method"
         },
         {
+          "name": "secured(_:)",
+          "signature": "func secured(Bool) -> TextField",
+          "summary": "입력한 내용을 가릴지 설정합니다.",
+          "kind": "method"
+        },
+        {
           "name": "status(_:)",
           "signature": "func status(Status) -> TextField",
           "summary": "텍스트 필드의 상태를 설정합니다.",


### PR DESCRIPTION
# 개요
- 이슈 링크 : 

`TextField`가 가려진 입력(secure entry)을 지원하지 않아, 비밀번호 필드를 디자인 시스템으로 옮길 수 없었습니다. `secured()` modifier를 추가해 내부에서 `SecureField`와 `TextField`를 분기하도록 했습니다.

원티드 앱 회원가입 화면의 비밀번호·비밀번호 확인 입력을 Montage로 마이그레이션하다 발견한 공백입니다. 3.x와 4.0 라인 모두 미지원 상태였습니다.

# 수정사항

- `TextField.secured(_:)` public modifier 추가 (기본값 `true`)
- 내부에 `textInput` 프로퍼티를 두어 `secured` 값에 따라 `SecureField` / `TextField`를 분기
  - `secured`는 화면이 살아 있는 동안 바뀌지 않는 설정이므로, 이 분기 때문에 입력 중 포커스를 잃지 않습니다
- 두 분기가 공유하는 placeholder 처리를 `promptText`로 추출
- Blueprint `TextFieldPreview`에 Secured 토글 예제 추가
- DocC 문서 / MCP 데이터 재생성

## 알려진 제약

가려진 입력에서는 자동완성이 동작하지 않습니다. `SecureField`가 마스킹된 값을 다루기 때문이며, docstring에 `- Note:`로 명시했습니다.

# 미리보기

작업 전|작업 후
---|---
`TextField`에 secure 입력 수단이 없어 앱에서 `SwiftUI.SecureField`를 직접 써야 했음|`.secured()` 한 줄로 마스킹 입력 지원

원티드 앱(Wanted 스킴 Dev) 빌드 성공 및 시뮬레이터에서 회원가입 화면 비밀번호 필드 마스킹·negative 상태 캡션 동작을 확인했습니다.
