### PR TITLE
fix: 입력 컴포넌트에 autocorrectionDisabled 모디파이어 추가

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/SearchFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SearchFieldPreview.swift
@@ -51,6 +51,7 @@ struct SearchFieldPreview: View {
     @State private var placeholder: Bool = true
     @State private var focused: Bool = false
     @State private var submittedKeyword: String = ""
+    @State private var autocorrectionDisabled: Bool = false
 
     var body: some View {
         PreviewLayout {
@@ -60,6 +61,7 @@ struct SearchFieldPreview: View {
                 .disable(disable)
                 .placeholder(placeholder ? "검색어를 입력해 주세요." : nil)
                 .focused($focused)
+                .autocorrectionDisabled(autocorrectionDisabled)
                 .onSubmit { submittedKeyword = text }
         } options: {
             SegmentedOptionRow("variant", selection: $variant)
@@ -69,6 +71,7 @@ struct SearchFieldPreview: View {
                 ToggleOption("disable", isOn: $disable)
             }
             ToggleOption("focused", isOn: $focused)
+            ToggleOption("autocorrectionDisabled", isOn: $autocorrectionDisabled)
             Text("제출된 검색어: \(submittedKeyword.isEmpty ? "-" : submittedKeyword)")
                 .foregroundStyle(SwiftUI.Color.secondary)
         }

--- a/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
@@ -90,6 +90,7 @@ struct TextAreaPreview: View {
     @State private var maxLength: CGFloat = 0
     @State private var characterCount: Int = 0
     @State private var segmentIndex: Int = 0
+    @State private var autocorrectionDisabled: Bool = false
 
     var body: some View {
         PreviewLayout {
@@ -103,6 +104,7 @@ struct TextAreaPreview: View {
                     trailing: trailingResources
                 )
                 .maxLength(maxLength > 0 ? Int(maxLength) : nil)
+                .autocorrectionDisabled(autocorrectionDisabled)
                 .onTextChange { characterCount = $0.count }
                 .placeholder(placeholder ? "텍스트를 입력해주세요" : nil)
                 // resize 변경 시 뷰 아이덴티티를 리셋해 높이를 재계산한다.
@@ -128,6 +130,7 @@ struct TextAreaPreview: View {
                 ToggleOption("disable", isOn: $disable)
                 ToggleOption("negative", isOn: $negative)
             }
+            ToggleOption("autocorrectionDisabled", isOn: $autocorrectionDisabled)
             MenuOptionRow("leading", menuLabel: "add") {
                 ForEach(resources.indices, id: \.self) { index in
                     if resources[index]?.isLeadingAllowed ?? false {

--- a/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
@@ -111,6 +111,7 @@ struct TextFieldPreview: View {
     @State private var autoCompletionDataSource: Montage.TextField.AutoCompletionDataSource? = nil
     @State private var maxLength: CGFloat = 0
     @State private var characterCount: Int = 0
+    @State private var autocorrectionDisabled: Bool = false
     
     let candidates: [String] = [
         "aaa1", "bbb1", "ccc1", "ddd1", "eee1", "fff1", "ggg1", "hhh1", "iii1", "jjj1", "kkk1",
@@ -198,6 +199,7 @@ struct TextFieldPreview: View {
                         }
                     }
                     .maxLength(maxLength > 0 ? Int(maxLength) : nil)
+                    .autocorrectionDisabled(autocorrectionDisabled)
                     .onTextChange { characterCount = $0.count }
                     .onChange(of: text) { _ in
                         refreshAutoCompletion()
@@ -226,6 +228,7 @@ struct TextFieldPreview: View {
                 SwiftUI.Slider(value: $maxLength, in: 0...100, step: 10)
                 Text(maxLength > 0 ? "\(characterCount)/\(Int(maxLength))" : "off")
             }
+            ToggleOption("autocorrectionDisabled", isOn: $autocorrectionDisabled)
             HStack {
                 ToggleOption("autoComplete", isOn: $usingSuggestions)
             }

--- a/Sources/Montage/1 Components/3 Selection And Input/SearchField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/SearchField.swift
@@ -171,7 +171,7 @@ public struct SearchField: View {
     /// 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙이면 내부 설정에 덮어써집니다.
     /// 반드시 이 모디파이어로 설정해 주세요.
     ///
-    /// - Parameter disable: 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음
+    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 검색 필드 인스턴스
     public func autocorrectionDisabled(_ disable: Bool = true) -> Self {
         var zelf = self

--- a/Sources/Montage/1 Components/3 Selection And Input/SearchField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/SearchField.swift
@@ -28,6 +28,10 @@ import SwiftUI
 /// SearchField(text: $keyword)
 ///    .focused($isFocused)
 ///    .onSubmit { search(keyword) }
+///
+/// // 자동수정·맞춤법 검사를 끈 검색 필드
+/// SearchField(text: $keyword)
+///    .autocorrectionDisabled()
 /// ```
 public struct SearchField: View {
     // MARK: - Types
@@ -72,6 +76,7 @@ public struct SearchField: View {
     private var onSubmit: (() -> Void)?
     private var onTextChange: ((String) -> Void)?
     private var onFocusChange: ((Bool) -> Void)?
+    private var autocorrectionDisabled = false
 
     /// 검색 필드의 스타일을 설정합니다.
     ///
@@ -157,6 +162,23 @@ public struct SearchField: View {
         return zelf
     }
 
+    /// 자동수정과 맞춤법 검사를 비활성화할지 설정합니다.
+    ///
+    /// 사람 이름·회사명·약어처럼 사전에 없는 검색어를 자주 입력하는 화면에서 사용합니다.
+    /// `true`이면 입력 중 자동수정이 적용되지 않고, 맞춤법 검사 밑줄도 표시되지 않습니다.
+    ///
+    /// 검색 필드가 내부에서 SwiftUI의 `autocorrectionDisabled(_:)`를 직접 적용하므로,
+    /// 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙이면 내부 설정에 덮어써집니다.
+    /// 반드시 이 모디파이어로 설정해 주세요.
+    ///
+    /// - Parameter disable: 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음
+    /// - Returns: 수정된 검색 필드 인스턴스
+    public func autocorrectionDisabled(_ disable: Bool = true) -> Self {
+        var zelf = self
+        zelf.autocorrectionDisabled = disable
+        return zelf
+    }
+
     // MARK: - Body
 
     @FocusState private var focusState: Bool
@@ -206,7 +228,9 @@ private extension SearchField {
                 .padding(size.iconPadding)
 
             SwiftUI.TextField("", text: $text)
-                .autocorrectionDisabled(fixAutocorrection)
+                // fixAutocorrection은 clear 버튼의 자동완성 잔상을 지우려고 한 프레임만 켜는 내부 트릭이므로,
+                // 호출부 설정(autocorrectionDisabled)과 OR로 합성해 외부 설정을 덮어쓰지 않게 한다.
+                .autocorrectionDisabled(autocorrectionDisabled || fixAutocorrection)
                 .textInputAutocapitalization(.never)
                 .submitLabel(.search)
                 .onSubmit { onSubmit?() }

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -30,6 +30,10 @@ import SwiftUI
 /// TextArea(text: $longText)
 ///     .maxLength(100)
 ///     .onTextChange { characterCount = $0.count }
+///
+/// // 자동수정·맞춤법 검사를 끈 텍스트 영역
+/// TextArea(text: $longText)
+///     .autocorrectionDisabled()
 /// ```
 public struct TextArea: View {
     // MARK: - Types
@@ -191,6 +195,7 @@ public struct TextArea: View {
     private var maxLength: Int?
     private var inputTransform: ((String) -> String)?
     private var onTextChange: ((String) -> Void)?
+    private var autocorrectionDisabled = false
 
     /// 텍스트 영역의 사이즈를 설정합니다.
     ///
@@ -251,6 +256,22 @@ public struct TextArea: View {
     public func onTextChange(_ handler: @escaping (String) -> Void) -> Self {
         var zelf = self
         zelf.onTextChange = handler
+        return zelf
+    }
+
+    /// 자동수정과 맞춤법 검사를 비활성화할지 설정합니다.
+    ///
+    /// 코드 조각·고유명사처럼 사전에 없는 텍스트를 자주 입력하는 화면에서 사용합니다.
+    /// `true`이면 입력 중 자동수정이 적용되지 않고, 맞춤법 검사 밑줄도 표시되지 않습니다.
+    ///
+    /// 텍스트 영역의 입력부는 `UITextView`를 감싼 뷰이므로 SwiftUI의 `autocorrectionDisabled(_:)`를
+    /// 인스턴스 바깥에 붙여도 입력부까지 전달되지 않습니다. 반드시 이 모디파이어로 설정해 주세요.
+    ///
+    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
+    /// - Returns: 수정된 텍스트 영역 인스턴스
+    public func autocorrectionDisabled(_ disable: Bool = true) -> Self {
+        var zelf = self
+        zelf.autocorrectionDisabled = disable
         return zelf
     }
 
@@ -373,6 +394,9 @@ public struct TextArea: View {
                 UITextViewWrapper(text: $text, inputVariant: size.inputVariant)
                     .inputLimit(maxLength)
                     .inputTransform(inputTransform)
+                    // UITextView는 UIViewRepresentable 안에 있어 SwiftUI의 autocorrectionDisabled(_:)가
+                    // 닿지 않으므로, 래퍼가 값을 받아 입력 트레이트에 직접 반영한다.
+                    .autocorrection(disabled: autocorrectionDisabled)
                     .frameHeight(
                         minHeight: resolvedMinHeight,
                         maxHeight: resolvedMaxHeight
@@ -626,12 +650,14 @@ public struct TextArea: View {
             textView.isScrollEnabled = false
             textView.backgroundColor = .clear
             textView.delegate = context.coordinator
+            applyAutocorrectionTraits(to: textView)
             return textView
         }
 
         func updateUIView(_ uiView: UITextView, context: Context) {
             // 사이즈(=입력 타이포그래피) 변경에 반응하도록 폰트를 갱신한다.
             uiView.font = UIFont.font(variant: inputVariant)
+            applyAutocorrectionTraits(to: uiView)
 
             // inputLimit 인터페이스의 구현 책임: 현재 텍스트가 제한을 초과하면(예: 외부에서 inputLimit을
             // 축소한 경우) 잘라낸다. 입력 시점 제한(shouldChangeTextIn)이 막지 못하는 경로를 보완한다.
@@ -762,6 +788,31 @@ public struct TextArea: View {
         private var maxHeight: CGFloat?
         private var inputLimit: Int?
         private var inputTransform: ((String) -> String)?
+        private var autocorrectionDisabled = false
+
+        /// 자동수정·맞춤법 검사 설정을 UITextView의 입력 트레이트에 반영한다.
+        ///
+        /// `spellCheckingType`의 `.default`는 자동수정 설정을 따라가므로 `autocorrectionType`만
+        /// 지정해도 되지만, 의도를 드러내기 위해 두 트레이트를 함께 명시한다.
+        /// 이미 편집 중인 상태에서 값이 바뀌면 키보드가 새 트레이트를 읽도록 입력 뷰를 갱신한다.
+        private func applyAutocorrectionTraits(to textView: UITextView) {
+            let type: UITextAutocorrectionType = autocorrectionDisabled ? .no : .default
+            let spellChecking: UITextSpellCheckingType = autocorrectionDisabled ? .no : .default
+            guard textView.autocorrectionType != type || textView.spellCheckingType != spellChecking else {
+                return
+            }
+            textView.autocorrectionType = type
+            textView.spellCheckingType = spellChecking
+            if textView.isFirstResponder {
+                textView.reloadInputViews()
+            }
+        }
+
+        func autocorrection(disabled: Bool) -> Self {
+            var zelf = self
+            zelf.autocorrectionDisabled = disabled
+            return zelf
+        }
 
         func inputLimit(_ limit: Int?) -> Self {
             var zelf = self

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -36,6 +36,11 @@ import SwiftUI
 /// // 사이즈를 지정한 텍스트 필드
 /// TextField(text: $inputText)
 ///    .size(.medium)
+///
+/// // 자동수정·맞춤법 검사를 끈 이메일 입력 필드
+/// TextField(text: $inputText)
+///    .placeholder("이메일을 입력하세요")
+///    .autocorrectionDisabled()
 /// ```
 public struct TextField: View {
     // MARK: - Types
@@ -170,6 +175,7 @@ public struct TextField: View {
     private var customBackgroundColor: SwiftUI.Color?
     private var maxLength: Int?
     private var onTextChange: ((String) -> Void)?
+    private var autocorrectionDisabled = false
 
     /// 텍스트 필드의 사이즈를 설정합니다.
     ///
@@ -275,6 +281,23 @@ public struct TextField: View {
     public func onTextChange(_ handler: @escaping (String) -> Void) -> Self {
         var zelf = self
         zelf.onTextChange = handler
+        return zelf
+    }
+
+    /// 자동수정과 맞춤법 검사를 비활성화할지 설정합니다.
+    ///
+    /// 이메일·아이디·인증 코드처럼 자동수정이 오히려 방해가 되는 입력에서 사용합니다.
+    /// `true`이면 입력 중 자동수정이 적용되지 않고, 맞춤법 검사 밑줄도 표시되지 않습니다.
+    ///
+    /// 텍스트 필드가 내부에서 SwiftUI의 `autocorrectionDisabled(_:)`를 직접 적용하므로,
+    /// 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙이면 내부 설정에 덮어써집니다.
+    /// 반드시 이 모디파이어로 설정해 주세요.
+    ///
+    /// - Parameter disable: 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음
+    /// - Returns: 수정된 텍스트 필드 인스턴스
+    public func autocorrectionDisabled(_ disable: Bool = true) -> Self {
+        var zelf = self
+        zelf.autocorrectionDisabled = disable
         return zelf
     }
 
@@ -398,7 +421,9 @@ private extension TextField {
             }
 
             SwiftUI.TextField("", text: $text)
-            .autocorrectionDisabled(fixAutocorrection)
+            // fixAutocorrection은 clear 버튼의 자동완성 잔상을 지우려고 한 프레임만 켜는 내부 트릭이므로,
+            // 호출부 설정(autocorrectionDisabled)과 OR로 합성해 외부 설정을 덮어쓰지 않게 한다.
+            .autocorrectionDisabled(autocorrectionDisabled || fixAutocorrection)
             .font(.font(variant: size.inputVariant, weight: .regular))
             .foregroundStyle(fieldTextColor)
             .focused($textFieldFocusState)

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -293,7 +293,7 @@ public struct TextField: View {
     /// 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙이면 내부 설정에 덮어써집니다.
     /// 반드시 이 모디파이어로 설정해 주세요.
     ///
-    /// - Parameter disable: 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음
+    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 텍스트 필드 인스턴스
     public func autocorrectionDisabled(_ disable: Bool = true) -> Self {
         var zelf = self

--- a/documentation/components/selection and input/searchfield/ios.md
+++ b/documentation/components/selection and input/searchfield/ios.md
@@ -72,7 +72,7 @@ SearchField(text: $keyword)
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `disable` | 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음 |
+  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
 - **Return Value**
 
   수정된 검색 필드 인스턴스

--- a/documentation/components/selection and input/searchfield/ios.md
+++ b/documentation/components/selection and input/searchfield/ios.md
@@ -27,6 +27,10 @@ SearchField(text: $keyword)
 SearchField(text: $keyword)
    .focused($isFocused)
    .onSubmit { search(keyword) }
+
+// 자동수정·맞춤법 검사를 끈 검색 필드
+SearchField(text: $keyword)
+   .autocorrectionDisabled()
 ```
 
 ## Topics
@@ -58,6 +62,26 @@ SearchField(text: $keyword)
 
 ### Instance Methods
 
+<details>
+
+<summary>``func autocorrectionDisabled(Bool) -> SearchField``</summary>
+
+
+자동수정과 맞춤법 검사를 비활성화할지 설정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `disable` | 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음 |
+- **Return Value**
+
+  수정된 검색 필드 인스턴스
+- **Discussion**
+
+  사람 이름·회사명·약어처럼 사전에 없는 검색어를 자주 입력하는 화면에서 사용합니다. `true`이면 입력 중 자동수정이 적용되지 않고, 맞춤법 검사 밑줄도 표시되지 않습니다.
+
+  검색 필드가 내부에서 SwiftUI의 `autocorrectionDisabled(_:)`를 직접 적용하므로, 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙이면 내부 설정에 덮어써집니다. 반드시 이 모디파이어로 설정해 주세요.
+</details>
 <details>
 
 <summary>``func disable(Bool) -> SearchField``</summary>

--- a/documentation/components/selection and input/textarea/ios.md
+++ b/documentation/components/selection and input/textarea/ios.md
@@ -29,6 +29,10 @@ TextArea(text: $longText)
 TextArea(text: $longText)
     .maxLength(100)
     .onTextChange { characterCount = $0.count }
+
+// 자동수정·맞춤법 검사를 끈 텍스트 영역
+TextArea(text: $longText)
+    .autocorrectionDisabled()
 ```
 
 ## Topics
@@ -61,6 +65,26 @@ TextArea(text: $longText)
 
 ### Instance Methods
 
+<details>
+
+<summary>``func autocorrectionDisabled(Bool) -> TextArea``</summary>
+
+
+자동수정과 맞춤법 검사를 비활성화할지 설정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
+- **Return Value**
+
+  수정된 텍스트 영역 인스턴스
+- **Discussion**
+
+  코드 조각·고유명사처럼 사전에 없는 텍스트를 자주 입력하는 화면에서 사용합니다. `true`이면 입력 중 자동수정이 적용되지 않고, 맞춤법 검사 밑줄도 표시되지 않습니다.
+
+  텍스트 영역의 입력부는 `UITextView`를 감싼 뷰이므로 SwiftUI의 `autocorrectionDisabled(_:)`를 인스턴스 바깥에 붙여도 입력부까지 전달되지 않습니다. 반드시 이 모디파이어로 설정해 주세요.
+</details>
 <details>
 
 <summary>``func bottomResources(leading: [Resource], trailing: [Resource], leadingResourceSpacing: CGFloat?, trailingResourceSpacing: CGFloat?) -> TextArea``</summary>

--- a/documentation/components/selection and input/textfield/ios.md
+++ b/documentation/components/selection and input/textfield/ios.md
@@ -35,6 +35,11 @@ TextField(text: $inputText)
 // 사이즈를 지정한 텍스트 필드
 TextField(text: $inputText)
    .size(.medium)
+
+// 자동수정·맞춤법 검사를 끈 이메일 입력 필드
+TextField(text: $inputText)
+   .placeholder("이메일을 입력하세요")
+   .autocorrectionDisabled()
 ```
 
 ## Topics
@@ -146,6 +151,26 @@ TextField(text: $inputText)
 
 ### Instance Methods
 
+<details>
+
+<summary>``func autocorrectionDisabled(Bool) -> TextField``</summary>
+
+
+자동수정과 맞춤법 검사를 비활성화할지 설정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `disable` | 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음 |
+- **Return Value**
+
+  수정된 텍스트 필드 인스턴스
+- **Discussion**
+
+  이메일·아이디·인증 코드처럼 자동수정이 오히려 방해가 되는 입력에서 사용합니다. `true`이면 입력 중 자동수정이 적용되지 않고, 맞춤법 검사 밑줄도 표시되지 않습니다.
+
+  텍스트 필드가 내부에서 SwiftUI의 `autocorrectionDisabled(_:)`를 직접 적용하므로, 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙이면 내부 설정에 덮어써집니다. 반드시 이 모디파이어로 설정해 주세요.
+</details>
 <details>
 
 <summary>``func backgroundColor(SwiftUI.Color?) -> TextField``</summary>

--- a/documentation/components/selection and input/textfield/ios.md
+++ b/documentation/components/selection and input/textfield/ios.md
@@ -161,7 +161,7 @@ TextField(text: $inputText)
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `disable` | 비활성화 여부, `true`이면 자동수정과 맞춤법 검사를 사용하지 않음 |
+  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
 - **Return Value**
 
   수정된 텍스트 필드 인스턴스

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -2343,6 +2343,12 @@
       ],
       "modifiers": [
         {
+          "name": "autocorrectionDisabled(_:)",
+          "signature": "func autocorrectionDisabled(Bool) -> SearchField",
+          "summary": "자동수정과 맞춤법 검사를 비활성화할지 설정합니다.",
+          "kind": "method"
+        },
+        {
           "name": "disable(_:)",
           "signature": "func disable(Bool) -> SearchField",
           "summary": "검색 필드의 활성화 상태를 설정합니다.",
@@ -2976,6 +2982,12 @@
       ],
       "modifiers": [
         {
+          "name": "autocorrectionDisabled(_:)",
+          "signature": "func autocorrectionDisabled(Bool) -> TextArea",
+          "summary": "자동수정과 맞춤법 검사를 비활성화할지 설정합니다.",
+          "kind": "method"
+        },
+        {
           "name": "bottomResources(leading:trailing:leadingResourceSpacing:trailingResourceSpacing:)",
           "signature": "func bottomResources(leading: [Resource], trailing: [Resource], leadingResourceSpacing: CGFloat?, trailingResourceSpacing: CGFloat?) -> TextArea",
           "summary": "텍스트 영역 하단에 표시할 UI 요소를 설정합니다.",
@@ -3182,6 +3194,12 @@
         }
       ],
       "modifiers": [
+        {
+          "name": "autocorrectionDisabled(_:)",
+          "signature": "func autocorrectionDisabled(Bool) -> TextField",
+          "summary": "자동수정과 맞춤법 검사를 비활성화할지 설정합니다.",
+          "kind": "method"
+        },
         {
           "name": "backgroundColor(_:)",
           "signature": "func backgroundColor(SwiftUI.Color?) -> TextField",


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2224

# 수정사항
입력 컴포넌트에서 자동수정·맞춤법 검사를 호출부에서 끌 수 있도록 `autocorrectionDisabled(_:)` 모디파이어를 추가했습니다. 기본값은 `false`이므로 기존 동작은 그대로입니다.

- **TextField / SearchField**: 내부에서 `.autocorrectionDisabled(fixAutocorrection)`을 직접 붙이고 있어 평상시 항상 `false`가 적용됐고, 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙여도 내부 설정에 덮어써졌습니다. clear 버튼의 자동완성 잔상 제거 트릭(`fixAutocorrection`)은 유지하면서 호출부 설정과 OR로 합성합니다.
- **TextArea**: 입력부가 `UITextView`를 감싼 `UIViewRepresentable`이라 SwiftUI 모디파이어가 애초에 전달되지 않습니다. 래퍼가 설정을 받아 `autocorrectionType`·`spellCheckingType`에 직접 반영하고, 편집 중에 값이 바뀌면 `reloadInputViews()`로 키보드가 새 트레이트를 읽게 합니다.
- **Blueprint**: TextField·SearchField·TextArea 프리뷰에 `autocorrectionDisabled` 토글을 추가했습니다.

# 미리보기
작업 전|작업 후
---|---
이메일·아이디 입력에 맞춤법 밑줄과 자동수정 제안이 표시되고, 호출부에서 끌 방법이 없음|`.autocorrectionDisabled()`로 끄면 밑줄·제안 모두 표시되지 않음

검증(iOS 26.5 시뮬레이터, Blueprint):
- TextField·SearchField: 오타 입력 시 맞춤법 밑줄과 자동수정 제안이 사라지는 것을 확인
- TextArea: `UITextView`의 `autocorrectionType`·`spellCheckingType`이 `.default`↔`.no`로 전환되는 것을 확인(포커스 중 변경 포함) + 실제 타이핑으로 동작 확인
