### PR TITLE
refactor: 슬롯 프리셋 Resource 패턴 정합

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,38 @@ Sources/
 
 메인 컴포넌트와 관련된 extension, protocol 등은 같은 파일에 정의한다. Public View struct는 Inner Type으로 정의하지 않는다.
 
+### 슬롯 프리셋은 `컴포넌트.Resource.슬롯명`
+
+컴포넌트가 슬롯(leading, trailing 등)에 넣을 요소의 프리셋을 제공할 때는 `Resource`를 네임스페이스로 두고 슬롯별 enum을 정의한다.
+
+```swift
+extension ListCell {
+    public enum Resource {
+        public enum Leading {
+            case icon(_ icon: Icon, tintColor: SwiftUI.Color = ...)
+            case slotView(() -> AnyView)
+
+            public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Leading {
+                .slotView { AnyView(content()) }
+            }
+        }
+
+        public enum Trailing { /* ... */ }
+    }
+}
+```
+
+규칙:
+
+- 슬롯 제약은 타입 분리로 컴파일 단계에서 막는다. 런타임 필터로 걸러내면 잘못 넘긴 요소가 아무 신호 없이 사라져 알아챌 수 없다.
+- 슬롯 enum 이름은 슬롯 이름을 그대로 쓴다(`Leading`, `Trailing`, `LabelTrailing`, `Extra`). `Info` 같은 접미사는 붙이지 않는다.
+- 프리셋에 없는 구성은 `slot(_:)` 하나로만 연다. `case slotView(() -> AnyView)`를 두고 `@ViewBuilder` 팩토리로 감싸 사용처가 `AnyView`를 직접 만들지 않게 한다.
+- 렌더링은 `extension 컴포넌트.Resource.슬롯명`의 `view`(크기 등 컨텍스트가 필요하면 `view(size:)`)에 두고, 슬롯이 공유하는 렌더링은 `extension 컴포넌트.Resource`의 `fileprivate static` 헬퍼로 뽑는다.
+
+모디파이어 형태와 개수 제한은 컴포넌트 사정에 맞춘다. `TextArea`는 좁은 입력 필드 안이라 `bottomResources(leading:trailing:)` 하나로 받고 슬롯당 3개로 제한하며, `ListCell`은 슬롯 4개가 셀 안 서로 다른 위치에 있어 슬롯별 모디파이어를 따로 둔다.
+
+적용 컴포넌트: `TextArea`, `TopNavigation`, `ListCell`.
+
 ### docstring 마크다운 서식 (틸드 이스케이프 필수)
 
 DocC는 docstring을 Markdown으로 파싱하며 **단일 `~`도 취소선으로 해석**한다. `~`를 숫자 범위 구분자로 쓰면(예: `65~90%`) 한 문단의 두 `~`가 짝지어져 텍스트가 취소선 처리되어 문서가 깨진다. **범위 표기의 `~`는 반드시 `\~`로 이스케이프**한다(예: `65\~90%, 40\~55%`). 볼드·이탤릭·심볼 링크는 그대로 보존되므로 의도적으로 사용해도 된다. 상세는 [DOCUMENTATION_GUIDELINES.ko.md](./DOCUMENTATION_GUIDELINES.ko.md) §9 참고. (`make` 실행 시 취소선이 감지되면 변환기가 경고를 출력한다.)

--- a/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
@@ -120,7 +120,7 @@ struct ModalNavigationPreview: View {
         [.normal, .display, .emphasized, .floating]
     }
 
-    private var leadingButtons: [TopNavigation.Resource.LeadingButtonInfo?] {
+    private var leadingButtons: [TopNavigation.Resource.Leading?] {
         [
             nil,
             .back(action: {
@@ -135,7 +135,7 @@ struct ModalNavigationPreview: View {
         ]
     }
 
-    private let actions: [TopNavigation.Resource.TrailingButtonInfo] = {
+    private let actions: [TopNavigation.Resource.Trailing] = {
         [
             .icon(.close, action: {}),
             .icon(.download, showPushBadge: true, action: {}),
@@ -145,8 +145,8 @@ struct ModalNavigationPreview: View {
 }
 
 extension ModalNavigation.Variant: CaseDescribable {}
-extension TopNavigation.Resource.LeadingButtonInfo: CaseDescribable {}
-extension TopNavigation.Resource.TrailingButtonInfo: CaseDescribable {}
+extension TopNavigation.Resource.Leading: CaseDescribable {}
+extension TopNavigation.Resource.Trailing: CaseDescribable {}
 
 #Preview {
     ModalNavigationPreview()

--- a/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
@@ -45,7 +45,31 @@ struct TextAreaPreview: View {
         }
     }
 
-    var resources: [TextArea.Resource?] {
+    var leadingPresets: [TextArea.Resource.Leading] {
+        [
+            .iconButton(
+                icon: .send,
+                handler: {}
+            ),
+            .icon(
+                .chevronDown
+            ),
+            .contentBadge(
+                title: "Badge"
+            ),
+            .segmentedControl(
+                selectedIndex: $segmentIndex,
+                icons: [.send, .chevronDown],
+                accessibilityLabels: ["전송", "더 보기"]
+            ),
+            .slot {
+                Image(systemName: "star.fill")
+                    .foregroundColor(.semantic(.foregroundBrandPrimary))
+            }
+        ]
+    }
+
+    var trailingPresets: [TextArea.Resource.Trailing] {
         [
             .button(
                 title: "Text",
@@ -85,8 +109,8 @@ struct TextAreaPreview: View {
     @FocusState private var focusState: Bool
     @State private var disable: Bool = false
     @State private var placeholder: Bool = true
-    @State private var leadingResources = [TextArea.Resource]()
-    @State private var trailingResources = [TextArea.Resource]()
+    @State private var leadingResources = [TextArea.Resource.Leading]()
+    @State private var trailingResources = [TextArea.Resource.Trailing]()
     @State private var maxLength: CGFloat = 0
     @State private var characterCount: Int = 0
     @State private var segmentIndex: Int = 0
@@ -132,30 +156,24 @@ struct TextAreaPreview: View {
             }
             ToggleOption("autocorrectionDisabled", isOn: $autocorrectionDisabled)
             MenuOptionRow("leading", menuLabel: "add") {
-                ForEach(resources.indices, id: \.self) { index in
-                    if resources[index]?.isLeadingAllowed ?? false {
-                        Button {
-                            if let resource = resources[index] {
-                                leadingResources.append(resource)
-                                leadingResources = Array(leadingResources.prefix(3))
-                            }
-                        } label: {
-                            Text(resources[index]?.description ?? "none")
-                        }
+                ForEach(leadingPresets.indices, id: \.self) { index in
+                    Button {
+                        leadingResources.append(leadingPresets[index])
+                        leadingResources = Array(leadingResources.prefix(3))
+                    } label: {
+                        Text(leadingPresets[index].description)
                     }
                 }
             } accessory: {
                 Button("reset") { leadingResources.removeAll() }
             }
             MenuOptionRow("trailing", menuLabel: "add") {
-                ForEach(resources.indices, id: \.self) { index in
+                ForEach(trailingPresets.indices, id: \.self) { index in
                     Button {
-                        if let resource = resources[index] {
-                            trailingResources.append(resource)
-                            trailingResources = Array(trailingResources.prefix(3))
-                        }
+                        trailingResources.append(trailingPresets[index])
+                        trailingResources = Array(trailingResources.prefix(3))
                     } label: {
-                        Text(resources[index]?.description ?? "none")
+                        Text(trailingPresets[index].description)
                     }
                 }
             } accessory: {
@@ -174,7 +192,8 @@ struct TextAreaPreview: View {
     }
 }
 
-extension TextArea.Resource: CaseDescribable {}
+extension TextArea.Resource.Leading: CaseDescribable {}
+extension TextArea.Resource.Trailing: CaseDescribable {}
 
 #Preview {
     TextAreaPreview()

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -68,95 +68,151 @@ public struct TextArea: View {
         }
     }
 
-    /// 텍스트 영역 하단(Bottom Content)에 표시할 수 있는 UI 요소를 정의합니다.
+    /// 텍스트 영역 하단(Bottom Content)에 표시할 요소들의 Namespace입니다.
     ///
-    /// 프리셋(``button``·``iconButton``·``icon``·``contentBadge``·``segmentedControl``·
-    /// ``primaryIconButton``)과 임의 뷰(``slot(_:)``)를 지원합니다. 각 요소의 크기는 TextArea의
-    /// ``Size``에 따라 자동으로 조정됩니다.
+    /// 슬롯마다 쓸 수 있는 요소가 다르므로 슬롯별로 타입을 나눠 두었습니다.
+    /// 예를 들어 ``Trailing/button(color:title:handler:)``는 디자인 가이드상 trailing 전용이라
+    /// ``TextArea/bottomResources(leading:trailing:leadingResourceSpacing:trailingResourceSpacing:)``의
+    /// `trailing`에만 넘길 수 있고, `leading`에 넘기면 컴파일되지 않습니다.
     ///
-    /// - Note: 디자인 가이드 기준 `button`·`primaryIconButton`은 trailing 전용으로 권장됩니다.
+    /// 각 요소의 크기는 TextArea의 ``Size``에 따라 자동으로 조정됩니다.
+    /// 목록에 없는 구성이 필요하면 각 타입의 `slot(_:)` 팩토리를 사용합니다.
     public enum Resource {
-        /// 텍스트 버튼(Outlined)
-        /// - Parameters:
-        ///   - color: 버튼 색상, 생략하면 기본값으로 `.assistive` 적용
-        ///   - title: 버튼 텍스트
-        ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
-        case button(
-            color: Button.Color = .assistive,
-            title: String,
-            handler: (() -> Void)? = nil
-        )
+        /// Bottom Content 왼쪽에 표시할 요소입니다.
+        public enum Leading {
+            /// 아이콘 버튼(배경 없음)
+            /// - Parameters:
+            ///   - icon: 버튼 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralTertiary)` 적용
+            ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
+            case iconButton(
+                icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralTertiary),
+                handler: (() -> Void)? = nil
+            )
 
-        /// 아이콘 버튼(배경 없음)
-        /// - Parameters:
-        ///   - icon: 버튼 아이콘
-        ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralTertiary)` 적용
-        ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
-        case iconButton(
-            icon: Icon,
-            tintColor: SwiftUI.Color = .semantic(.foregroundNeutralTertiary),
-            handler: (() -> Void)? = nil
-        )
+            /// 단순 아이콘
+            /// - Parameters:
+            ///   - icon: 표시할 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralQuaternary)` 적용
+            case icon(
+                _ icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralQuaternary)
+            )
 
-        /// Primary 아이콘 버튼(Solid)
-        /// - Parameters:
-        ///   - icon: 버튼 아이콘
-        ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
-        case primaryIconButton(
-            icon: Icon,
-            handler: (() -> Void)? = nil
-        )
+            /// 콘텐츠 뱃지
+            /// - Parameters:
+            ///   - variant: 뱃지 변형 스타일, 생략하면 기본값으로 `.solid` 적용
+            ///   - title: 뱃지 텍스트
+            case contentBadge(
+                _ variant: ContentBadge.Variant = .solid,
+                title: String
+            )
 
-        /// 단순 아이콘
-        /// - Parameters:
-        ///   - icon: 표시할 아이콘
-        ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralQuaternary)` 적용
-        case icon(
-            _ icon: Icon,
-            tintColor: SwiftUI.Color = .semantic(.foregroundNeutralQuaternary)
-        )
+            /// 세그먼트 컨트롤(아이콘 전용). 표준 ``SegmentedControl``을 `small` 크기·`iconOnly`로 렌더링하며 정방형 아이콘만 받습니다.
+            ///
+            /// `accessibilityLabels`는 각 세그먼트의 항목 제목으로 전달됩니다.
+            /// 라벨을 생략하거나 개수가 부족하면 해당 세그먼트는 아이콘 이름으로 대체됩니다.
+            /// - Parameters:
+            ///   - selectedIndex: 선택된 세그먼트 인덱스 바인딩
+            ///   - icons: 세그먼트 아이콘 배열
+            ///   - accessibilityLabels: 세그먼트별 VoiceOver 라벨 배열, 생략하면 기본값으로 `[]` 적용
+            ///   - onSelect: 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용
+            case segmentedControl(
+                selectedIndex: Binding<Int>,
+                icons: [Icon],
+                accessibilityLabels: [String] = [],
+                onSelect: ((Int) -> Void)? = nil
+            )
 
-        /// 콘텐츠 뱃지
-        /// - Parameters:
-        ///   - variant: 뱃지 변형 스타일, 생략하면 기본값으로 `.solid` 적용
-        ///   - title: 뱃지 텍스트
-        case contentBadge(
-            _ variant: ContentBadge.Variant = .solid,
-            title: String
-        )
+            /// 임의 뷰. ``slot(_:)`` 팩토리로 생성합니다.
+            case slotView(() -> AnyView)
 
-        /// 세그먼트 컨트롤(아이콘 전용). 표준 ``SegmentedControl``을 `small` 크기·`iconOnly`로 렌더링하며 정방형 아이콘만 받습니다.
-        ///
-        /// `accessibilityLabels`는 각 세그먼트의 항목 제목으로 전달됩니다.
-        /// 라벨을 생략하거나 개수가 부족하면 해당 세그먼트는 아이콘 이름으로 대체됩니다.
-        /// - Parameters:
-        ///   - selectedIndex: 선택된 세그먼트 인덱스 바인딩
-        ///   - icons: 세그먼트 아이콘 배열
-        ///   - accessibilityLabels: 세그먼트별 VoiceOver 라벨 배열, 생략하면 기본값으로 `[]` 적용
-        ///   - onSelect: 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용
-        case segmentedControl(
-            selectedIndex: Binding<Int>,
-            icons: [Icon],
-            accessibilityLabels: [String] = [],
-            onSelect: ((Int) -> Void)? = nil
-        )
-
-        /// 임의 뷰. `.slot { ... }` 팩토리로 생성합니다.
-        case slotView(() -> AnyView)
-
-        /// 임의 뷰를 Bottom Content에 배치합니다.
-        ///
-        /// - Parameter content: 표시할 뷰를 생성하는 클로저
-        /// - Returns: 구성된 리소스
-        public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Resource {
-            .slotView { AnyView(content()) }
+            /// 목록에 없는 구성을 직접 배치합니다.
+            ///
+            /// - Parameter content: 표시할 뷰를 생성하는 클로저
+            /// - Returns: 구성된 요소
+            public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Leading {
+                .slotView { AnyView(content()) }
+            }
         }
 
-        /// leading(왼쪽)에 배치할 수 있는 리소스인지 여부. `button`·`primaryIconButton`은 trailing 전용입니다.
-        public var isLeadingAllowed: Bool {
-            switch self {
-            case .button, .primaryIconButton: false
-            default: true
+        /// Bottom Content 오른쪽에 표시할 요소입니다.
+        public enum Trailing {
+            /// 텍스트 버튼(Outlined)
+            /// - Parameters:
+            ///   - color: 버튼 색상, 생략하면 기본값으로 `.assistive` 적용
+            ///   - title: 버튼 텍스트
+            ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
+            case button(
+                color: Button.Color = .assistive,
+                title: String,
+                handler: (() -> Void)? = nil
+            )
+
+            /// 아이콘 버튼(배경 없음)
+            /// - Parameters:
+            ///   - icon: 버튼 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralTertiary)` 적용
+            ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
+            case iconButton(
+                icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralTertiary),
+                handler: (() -> Void)? = nil
+            )
+
+            /// Primary 아이콘 버튼(Solid)
+            /// - Parameters:
+            ///   - icon: 버튼 아이콘
+            ///   - handler: 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용
+            case primaryIconButton(
+                icon: Icon,
+                handler: (() -> Void)? = nil
+            )
+
+            /// 단순 아이콘
+            /// - Parameters:
+            ///   - icon: 표시할 아이콘
+            ///   - tintColor: 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralQuaternary)` 적용
+            case icon(
+                _ icon: Icon,
+                tintColor: SwiftUI.Color = .semantic(.foregroundNeutralQuaternary)
+            )
+
+            /// 콘텐츠 뱃지
+            /// - Parameters:
+            ///   - variant: 뱃지 변형 스타일, 생략하면 기본값으로 `.solid` 적용
+            ///   - title: 뱃지 텍스트
+            case contentBadge(
+                _ variant: ContentBadge.Variant = .solid,
+                title: String
+            )
+
+            /// 세그먼트 컨트롤(아이콘 전용). 표준 ``SegmentedControl``을 `small` 크기·`iconOnly`로 렌더링하며 정방형 아이콘만 받습니다.
+            ///
+            /// `accessibilityLabels`는 각 세그먼트의 항목 제목으로 전달됩니다.
+            /// 라벨을 생략하거나 개수가 부족하면 해당 세그먼트는 아이콘 이름으로 대체됩니다.
+            /// - Parameters:
+            ///   - selectedIndex: 선택된 세그먼트 인덱스 바인딩
+            ///   - icons: 세그먼트 아이콘 배열
+            ///   - accessibilityLabels: 세그먼트별 VoiceOver 라벨 배열, 생략하면 기본값으로 `[]` 적용
+            ///   - onSelect: 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용
+            case segmentedControl(
+                selectedIndex: Binding<Int>,
+                icons: [Icon],
+                accessibilityLabels: [String] = [],
+                onSelect: ((Int) -> Void)? = nil
+            )
+
+            /// 임의 뷰. ``slot(_:)`` 팩토리로 생성합니다.
+            case slotView(() -> AnyView)
+
+            /// 목록에 없는 구성을 직접 배치합니다.
+            ///
+            /// - Parameter content: 표시할 뷰를 생성하는 클로저
+            /// - Returns: 구성된 요소
+            public static func slot<V: View>(@ViewBuilder _ content: @escaping () -> V) -> Trailing {
+                .slotView { AnyView(content()) }
             }
         }
     }
@@ -187,8 +243,8 @@ public struct TextArea: View {
     private var negative = false
     private var disable = false
     private var placeholder: String? = nil
-    private var leadingResources: [Resource] = []
-    private var trailingResources: [Resource] = []
+    private var leadingResources: [Resource.Leading] = []
+    private var trailingResources: [Resource.Trailing] = []
     // nil이면 사이즈별 기본 간격(``Size/resourceSpacing``)을 사용한다.
     private var leadingResourceSpacing: CGFloat?
     private var trailingResourceSpacing: CGFloat?
@@ -305,16 +361,16 @@ public struct TextArea: View {
     ///   - leadingResourceSpacing: 왼쪽 요소 간의 간격, 생략하면 사이즈별 기본값(large 8 / medium 6) 적용
     ///   - trailingResourceSpacing: 오른쪽 요소 간의 간격, 생략하면 사이즈별 기본값(large 8 / medium 6) 적용
     /// - Returns: 수정된 텍스트 영역 인스턴스
-    /// - Note: `button`·`primaryIconButton`은 디자인 가이드상 trailing 전용이므로 leading에 전달되면 무시됩니다.
+    /// - Note: `button`·`primaryIconButton`은 디자인 가이드상 trailing 전용이므로 ``Resource/Trailing``에만
+    ///   정의되어 있습니다. leading에 넘기면 컴파일되지 않습니다.
     public func bottomResources(
-        leading leadingResources: [Resource] = [],
-        trailing trailingResources: [Resource] = [],
+        leading leadingResources: [Resource.Leading] = [],
+        trailing trailingResources: [Resource.Trailing] = [],
         leadingResourceSpacing: CGFloat? = nil,
         trailingResourceSpacing: CGFloat? = nil
     ) -> Self {
         var zelf = self
-        // leading 전용 제약: trailing 전용 프리셋은 걸러낸다.
-        zelf.leadingResources = Array(leadingResources.filter(\.isLeadingAllowed).prefix(3))
+        zelf.leadingResources = Array(leadingResources.prefix(3))
         zelf.leadingResourceSpacing = leadingResourceSpacing
 
         zelf.trailingResources = Array(trailingResources.prefix(3))
@@ -528,17 +584,17 @@ public struct TextArea: View {
     private struct Bottom: View {
         private let size: Size
         private let disable: Bool
-        private let leadingResources: [Resource]
+        private let leadingResources: [Resource.Leading]
         private let leadingResourceSpacing: CGFloat?
-        private let trailingResources: [Resource]
+        private let trailingResources: [Resource.Trailing]
         private let trailingResourceSpacing: CGFloat?
 
         init(
             _ size: Size,
             _ disable: Bool,
-            _ leadingResources: [Resource],
+            _ leadingResources: [Resource.Leading],
             _ leadingResourceSpacing: CGFloat?,
-            _ trailingResources: [Resource],
+            _ trailingResources: [Resource.Trailing],
             _ trailingResourceSpacing: CGFloat?
         ) {
             self.size = size
@@ -555,7 +611,7 @@ public struct TextArea: View {
                 if leadingResources.isEmpty == false {
                     HStack(spacing: leadingResourceSpacing ?? size.resourceSpacing) {
                         ForEach(leadingResources.indices, id: \.self) { index in
-                            component(leadingResources[index])
+                            leadingResources[index].view(size: size)
                         }
                     }
                 }
@@ -563,70 +619,10 @@ public struct TextArea: View {
                 if trailingResources.isEmpty == false {
                     HStack(spacing: trailingResourceSpacing ?? size.resourceSpacing) {
                         ForEach(trailingResources.indices, id: \.self) { index in
-                            component(trailingResources[index])
+                            trailingResources[index].view(size: size)
                         }
                     }
                 }
-            }
-        }
-
-        @ViewBuilder
-        func component(_ resource: Resource) -> some View {
-            switch resource {
-            case let .button(color, title, handler):
-                Button(
-                    variant: .outlined,
-                    color: color,
-                    size: size.buttonSize,
-                    text: title,
-                    handler: handler
-                )
-            case let .iconButton(icon, tintColor, handler):
-                // 아이콘 계열 요소는 사이즈별 정렬 래퍼(``Size/resourceWrapperSize``)로 감싸 Bottom Content
-                // 정렬 기준을 통일한다. 요소가 래퍼보다 크면(예: 아이콘 버튼 large 32) 래퍼를 넘어 중앙 정렬로 렌더된다.
-                IconButton(
-                    variant: .normal(size: size.normalIconButtonSize),
-                    icon: icon,
-                    handler: handler
-                )
-                .iconColor(tintColor)
-                .frame(width: size.resourceWrapperSize.width, height: size.resourceWrapperSize.height)
-            case let .primaryIconButton(icon, handler):
-                Button(
-                    variant: .solid,
-                    color: .primary,
-                    size: size.buttonSize,
-                    icon: icon,
-                    handler: handler
-                )
-                .frame(width: size.resourceWrapperSize.width, height: size.resourceWrapperSize.height)
-            case let .icon(icon, tintColor):
-                Image.icon(icon)
-                    .resizable()
-                    .foregroundColor(tintColor)
-                    .frame(width: size.resourceIconSize, height: size.resourceIconSize)
-                    .frame(width: size.resourceWrapperSize.width, height: size.resourceWrapperSize.height)
-            case let .contentBadge(variant, title):
-                ContentBadge(variant: variant, text: title)
-                    .size(size.contentBadgeSize)
-                    .colorStyle(.neutral())
-            case let .segmentedControl(selectedIndex, icons, accessibilityLabels, onSelect):
-                SegmentedControl(
-                    selectedIndex: selectedIndex,
-                    items: icons.indices.map { index in
-                        SegmentedControl.Item(
-                            leadingIcon: .icon(icons[index]),
-                            title: index < accessibilityLabels.count && accessibilityLabels[index].isEmpty == false
-                                ? accessibilityLabels[index]
-                                : icons[index].rawValue
-                        )
-                    },
-                    onSelect: onSelect
-                )
-                .iconOnly()
-                .size(.small)
-            case let .slotView(content):
-                content()
             }
         }
     }
@@ -837,6 +833,158 @@ public struct TextArea: View {
     class CustomTextView: UITextView {
         override var intrinsicContentSize: CGSize {
             sizeThatFits(CGSize(width: frame.width, height: CGFloat.greatestFiniteMagnitude))
+        }
+    }
+}
+
+// MARK: - Resource Rendering
+
+extension TextArea.Resource {
+    /// 텍스트 버튼(Outlined).
+    fileprivate static func buttonView(
+        color: Button.Color,
+        title: String,
+        handler: (() -> Void)?,
+        size: TextArea.Size
+    ) -> some View {
+        Button(
+            variant: .outlined,
+            color: color,
+            size: size.buttonSize,
+            text: title,
+            handler: handler
+        )
+    }
+
+    /// 배경 없는 아이콘 버튼.
+    ///
+    /// 아이콘 계열 요소는 사이즈별 정렬 래퍼(`Size.resourceWrapperSize`)로 감싸 Bottom Content
+    /// 정렬 기준을 통일한다. 요소가 래퍼보다 크면(예: 아이콘 버튼 large 32) 래퍼를 넘어 중앙 정렬로 렌더된다.
+    fileprivate static func iconButtonView(
+        _ icon: Icon,
+        tintColor: SwiftUI.Color,
+        handler: (() -> Void)?,
+        size: TextArea.Size
+    ) -> some View {
+        IconButton(
+            variant: .normal(size: size.normalIconButtonSize),
+            icon: icon,
+            handler: handler
+        )
+        .iconColor(tintColor)
+        .frame(width: size.resourceWrapperSize.width, height: size.resourceWrapperSize.height)
+    }
+
+    /// Primary 아이콘 버튼(Solid).
+    fileprivate static func primaryIconButtonView(
+        _ icon: Icon,
+        handler: (() -> Void)?,
+        size: TextArea.Size
+    ) -> some View {
+        Button(
+            variant: .solid,
+            color: .primary,
+            size: size.buttonSize,
+            icon: icon,
+            handler: handler
+        )
+        .frame(width: size.resourceWrapperSize.width, height: size.resourceWrapperSize.height)
+    }
+
+    /// 단순 아이콘.
+    fileprivate static func iconView(
+        _ icon: Icon,
+        tintColor: SwiftUI.Color,
+        size: TextArea.Size
+    ) -> some View {
+        Image.icon(icon)
+            .resizable()
+            .foregroundColor(tintColor)
+            .frame(width: size.resourceIconSize, height: size.resourceIconSize)
+            .frame(width: size.resourceWrapperSize.width, height: size.resourceWrapperSize.height)
+    }
+
+    /// 콘텐츠 뱃지.
+    fileprivate static func contentBadgeView(
+        _ variant: ContentBadge.Variant,
+        title: String,
+        size: TextArea.Size
+    ) -> some View {
+        ContentBadge(variant: variant, text: title)
+            .size(size.contentBadgeSize)
+            .colorStyle(.neutral())
+    }
+
+    /// 아이콘 전용 세그먼트 컨트롤.
+    fileprivate static func segmentedControlView(
+        selectedIndex: Binding<Int>,
+        icons: [Icon],
+        accessibilityLabels: [String],
+        onSelect: ((Int) -> Void)?
+    ) -> some View {
+        SegmentedControl(
+            selectedIndex: selectedIndex,
+            items: icons.indices.map { index in
+                SegmentedControl.Item(
+                    leadingIcon: .icon(icons[index]),
+                    title: index < accessibilityLabels.count && accessibilityLabels[index].isEmpty == false
+                        ? accessibilityLabels[index]
+                        : icons[index].rawValue
+                )
+            },
+            onSelect: onSelect
+        )
+        .iconOnly()
+        .size(.small)
+    }
+}
+
+extension TextArea.Resource.Leading {
+    @ViewBuilder
+    func view(size: TextArea.Size) -> some View {
+        switch self {
+        case let .iconButton(icon, tintColor, handler):
+            TextArea.Resource.iconButtonView(icon, tintColor: tintColor, handler: handler, size: size)
+        case let .icon(icon, tintColor):
+            TextArea.Resource.iconView(icon, tintColor: tintColor, size: size)
+        case let .contentBadge(variant, title):
+            TextArea.Resource.contentBadgeView(variant, title: title, size: size)
+        case let .segmentedControl(selectedIndex, icons, accessibilityLabels, onSelect):
+            TextArea.Resource.segmentedControlView(
+                selectedIndex: selectedIndex,
+                icons: icons,
+                accessibilityLabels: accessibilityLabels,
+                onSelect: onSelect
+            )
+        case let .slotView(content):
+            content()
+        }
+    }
+}
+
+extension TextArea.Resource.Trailing {
+    @ViewBuilder
+    func view(size: TextArea.Size) -> some View {
+        switch self {
+        case let .button(color, title, handler):
+            TextArea.Resource.buttonView(color: color, title: title, handler: handler, size: size)
+        case let .iconButton(icon, tintColor, handler):
+            TextArea.Resource.iconButtonView(icon, tintColor: tintColor, handler: handler, size: size)
+        case let .primaryIconButton(icon, handler):
+            TextArea.Resource.primaryIconButtonView(icon, handler: handler, size: size)
+        case let .icon(icon, tintColor):
+            TextArea.Resource.iconView(icon, tintColor: tintColor, size: size)
+        case let .contentBadge(variant, title):
+            TextArea.Resource.contentBadgeView(variant, title: title, size: size)
+        case let .segmentedControl(selectedIndex, icons, accessibilityLabels, onSelect):
+            TextArea.Resource.segmentedControlView(
+                selectedIndex: selectedIndex,
+                icons: icons,
+                accessibilityLabels: accessibilityLabels,
+                onSelect: onSelect
+            )
+        case let .slotView(content):
+            content()
         }
     }
 }

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -356,24 +356,24 @@ public struct TextArea: View {
     /// 텍스트 영역 하단에 표시할 UI 요소를 설정합니다.
     ///
     /// - Parameters:
-    ///   - leadingResources: 왼쪽에 표시할 UI 요소 배열 (최대 3개)
-    ///   - trailingResources: 오른쪽에 표시할 UI 요소 배열 (최대 3개)
+    ///   - leading: 왼쪽에 표시할 UI 요소 배열 (최대 3개)
+    ///   - trailing: 오른쪽에 표시할 UI 요소 배열 (최대 3개)
     ///   - leadingResourceSpacing: 왼쪽 요소 간의 간격, 생략하면 사이즈별 기본값(large 8 / medium 6) 적용
     ///   - trailingResourceSpacing: 오른쪽 요소 간의 간격, 생략하면 사이즈별 기본값(large 8 / medium 6) 적용
     /// - Returns: 수정된 텍스트 영역 인스턴스
     /// - Note: `button`·`primaryIconButton`은 디자인 가이드상 trailing 전용이므로 ``Resource/Trailing``에만
     ///   정의되어 있습니다. leading에 넘기면 컴파일되지 않습니다.
     public func bottomResources(
-        leading leadingResources: [Resource.Leading] = [],
-        trailing trailingResources: [Resource.Trailing] = [],
+        leading: [Resource.Leading] = [],
+        trailing: [Resource.Trailing] = [],
         leadingResourceSpacing: CGFloat? = nil,
         trailingResourceSpacing: CGFloat? = nil
     ) -> Self {
         var zelf = self
-        zelf.leadingResources = Array(leadingResources.prefix(3))
+        zelf.leadingResources = Array(leading.prefix(3))
         zelf.leadingResourceSpacing = leadingResourceSpacing
 
-        zelf.trailingResources = Array(trailingResources.prefix(3))
+        zelf.trailingResources = Array(trailing.prefix(3))
         zelf.trailingResourceSpacing = trailingResourceSpacing
         return zelf
     }

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -469,14 +469,14 @@ extension TopNavigation {
     ///
     /// 버튼이 없을 경우에는 투명한 공간을 차지하여 레이아웃이 유지됩니다.
     public struct LeadingButton: View {
-        let action: Resource.LeadingButtonInfo?
+        let action: Resource.Leading?
         
         /// 내비게이션 바의 왼쪽(leading) 영역에 위치하는 기본 버튼을 초기화합니다.
         ///
         /// - Parameters:
         ///   - action: 버튼 액션
         /// - Returns: LeadingButton 인스턴스
-        public init(_ action: Resource.LeadingButtonInfo?) {
+        public init(_ action: Resource.Leading?) {
             self.action = action
         }
         
@@ -608,9 +608,11 @@ extension TopNavigation {
 }
 
 extension TopNavigation {
-    /// TopNavigation의 좌/우에 표시될 Resource들의 Namespace입니다.
+    /// TopNavigation의 좌/우에 표시될 요소들의 Namespace입니다.
+    ///
+    /// 슬롯마다 쓸 수 있는 요소가 다르므로 슬롯별로 타입을 나눠 두었습니다.
     public enum Resource {
-        /// TopNavigation의 좌측에 표시될 내용들의 열거형입니다.
+        /// 내비게이션 바 좌측(leading)에 표시할 요소입니다.
         ///
         /// 뒤로가기 버튼, 아이콘 버튼, 텍스트 버튼을 지원합니다.
         ///
@@ -619,7 +621,7 @@ extension TopNavigation {
         ///     .leadingContent { /* ... */ }
         ///
         /// ```
-        public enum LeadingButtonInfo {
+        public enum Leading {
             /// 뒤로가기 버튼
             /// - Parameter action: 뒤로가기 버튼 클릭시 동작할 액션
             case back(action: () -> Void)
@@ -635,7 +637,7 @@ extension TopNavigation {
             case text(_ text: String, action: () -> Void)
         }
         
-        /// TopNavigation의 우측에 표시될 내용들의 열거형입니다.
+        /// 내비게이션 바 우측(trailing)에 표시할 요소입니다.
         ///
         /// 아이콘 버튼과 텍스트 버튼을 지원합니다.
         ///
@@ -646,7 +648,7 @@ extension TopNavigation {
         ///         { TopNavigation.TrailingTextButton(text: "완료") { /* ... */ } }
         ///     )
         /// ```
-        public enum TrailingButtonInfo: Hashable {
+        public enum Trailing: Hashable {
             /// icon 형태의 Action입니다.
             /// - Parameters:
             ///   - icon: 아이콘 버튼의 아이콘
@@ -676,15 +678,15 @@ extension TopNavigation {
                 }
             }
             
-            /// 두 개의 TrailingButtonInfo 인스턴스를 비교합니다.
+            /// 두 개의 Trailing 인스턴스를 비교합니다.
             ///
             /// - Parameters:
-            ///   - lhs: 비교할 첫 번째 TrailingButtonInfo 인스턴스
-            ///   - rhs: 비교할 두 번째 TrailingButtonInfo 인스턴스
+            ///   - lhs: 비교할 첫 번째 Trailing 인스턴스
+            ///   - rhs: 비교할 두 번째 Trailing 인스턴스
             /// - Returns: 두 인스턴스가 같은지 여부
             public static func == (
-                lhs: TopNavigation.Resource.TrailingButtonInfo,
-                rhs: TopNavigation.Resource.TrailingButtonInfo
+                lhs: TopNavigation.Resource.Trailing,
+                rhs: TopNavigation.Resource.Trailing
             ) -> Bool {
                 switch (lhs, rhs) {
                 case let (.icon(li, ld, ls, _), .icon(ri, rd, rs, _)):

--- a/documentation/components/navigations/topnavigation/ios.md
+++ b/documentation/components/navigations/topnavigation/ios.md
@@ -65,7 +65,7 @@ TopNavigation(
 
 <details>
 
-<summary>``init(Resource.LeadingButtonInfo?)``</summary>
+<summary>``init(Resource.Leading?)``</summary>
 
 
 내비게이션 바의 왼쪽(leading) 영역에 위치하는 기본 버튼을 초기화합니다.
@@ -351,15 +351,18 @@ TopNavigation을 초기화합니다.
 <summary>``enum Resource``</summary>
 
 
-TopNavigation의 좌/우에 표시될 Resource들의 Namespace입니다.
+TopNavigation의 좌/우에 표시될 요소들의 Namespace입니다.
+- **Overview**
+
+  슬롯마다 쓸 수 있는 요소가 다르므로 슬롯별로 타입을 나눠 두었습니다.
 #### Enumerations
 
 <details>
 
-<summary>``enum LeadingButtonInfo``</summary>
+<summary>``enum Leading``</summary>
 
 
-TopNavigation의 좌측에 표시될 내용들의 열거형입니다.
+내비게이션 바 좌측(leading)에 표시할 요소입니다.
 - **Overview**
 
   뒤로가기 버튼, 아이콘 버튼, 텍스트 버튼을 지원합니다.
@@ -414,10 +417,10 @@ TopNavigation의 좌측에 표시될 내용들의 열거형입니다.
 </details>
 <details>
 
-<summary>``enum TrailingButtonInfo``</summary>
+<summary>``enum Trailing``</summary>
 
 
-TopNavigation의 우측에 표시될 내용들의 열거형입니다.
+내비게이션 바 우측(trailing)에 표시할 요소입니다.
 - **Overview**
 
   아이콘 버튼과 텍스트 버튼을 지원합니다.
@@ -434,16 +437,16 @@ TopNavigation의 우측에 표시될 내용들의 열거형입니다.
 
 <details>
 
-<summary>``static func == (TopNavigation.Resource.TrailingButtonInfo, TopNavigation.Resource.TrailingButtonInfo) -> Bool``</summary>
+<summary>``static func == (TopNavigation.Resource.Trailing, TopNavigation.Resource.Trailing) -> Bool``</summary>
 
 
-두 개의 TrailingButtonInfo 인스턴스를 비교합니다.
+두 개의 Trailing 인스턴스를 비교합니다.
 
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `lhs` | 비교할 첫 번째 TrailingButtonInfo 인스턴스 |
-  | `rhs` | 비교할 두 번째 TrailingButtonInfo 인스턴스 |
+  | `lhs` | 비교할 첫 번째 Trailing 인스턴스 |
+  | `rhs` | 비교할 두 번째 Trailing 인스턴스 |
 - **Return Value**
 
   두 인스턴스가 같은지 여부

--- a/documentation/components/selection and input/textarea/ios.md
+++ b/documentation/components/selection and input/textarea/ios.md
@@ -95,8 +95,8 @@ TextArea(text: $longText)
 - **Parameters**
   | Parameter | Description |
   | --- | --- |
-  | `leadingResources` | 왼쪽에 표시할 UI 요소 배열 (최대 3개) |
-  | `trailingResources` | 오른쪽에 표시할 UI 요소 배열 (최대 3개) |
+  | `leading` | 왼쪽에 표시할 UI 요소 배열 (최대 3개) |
+  | `trailing` | 오른쪽에 표시할 UI 요소 배열 (최대 3개) |
   | `leadingResourceSpacing` | 왼쪽 요소 간의 간격, 생략하면 사이즈별 기본값(large 8 / medium 6) 적용 |
   | `trailingResourceSpacing` | 오른쪽 요소 간의 간격, 생략하면 사이즈별 기본값(large 8 / medium 6) 적용 |
 - **Return Value**

--- a/documentation/components/selection and input/textarea/ios.md
+++ b/documentation/components/selection and input/textarea/ios.md
@@ -87,7 +87,7 @@ TextArea(text: $longText)
 </details>
 <details>
 
-<summary>``func bottomResources(leading: [Resource], trailing: [Resource], leadingResourceSpacing: CGFloat?, trailingResourceSpacing: CGFloat?) -> TextArea``</summary>
+<summary>``func bottomResources(leading: [Resource.Leading], trailing: [Resource.Trailing], leadingResourceSpacing: CGFloat?, trailingResourceSpacing: CGFloat?) -> TextArea``</summary>
 
 
 텍스트 영역 하단에 표시할 UI 요소를 설정합니다.
@@ -105,7 +105,7 @@ TextArea(text: $longText)
 - **Discussion**
   >  **Note**
   >
-  > `button`·`primaryIconButton`은 디자인 가이드상 trailing 전용이므로 leading에 전달되면 무시됩니다.
+  > `button`·`primaryIconButton`은 디자인 가이드상 trailing 전용이므로 [TextArea.Resource.Trailing](/documentation/montage/textarea/resource/trailing.md)에만 정의되어 있습니다. leading에 넘기면 컴파일되지 않습니다.
 
 </details>
 <details>
@@ -285,15 +285,114 @@ TextArea(text: $longText)
 <summary>``enum Resource``</summary>
 
 
-텍스트 영역 하단(Bottom Content)에 표시할 수 있는 UI 요소를 정의합니다.
+텍스트 영역 하단(Bottom Content)에 표시할 요소들의 Namespace입니다.
 - **Overview**
 
-  프리셋(`button`·`iconButton`·`icon`·`contentBadge`·`segmentedControl`· `primaryIconButton`)과 임의 뷰([slot(_:)](/documentation/montage/textarea/resource/slot(_:).md))를 지원합니다. 각 요소의 크기는 TextArea의 [TextArea.Size](/documentation/montage/textarea/size.md)에 따라 자동으로 조정됩니다.
-  >  **Note**
-  >
-  > 디자인 가이드 기준 `button`·`primaryIconButton`은 trailing 전용으로 권장됩니다.
+  슬롯마다 쓸 수 있는 요소가 다르므로 슬롯별로 타입을 나눠 두었습니다. 예를 들어 [TextArea.Resource.Trailing.button(color:title:handler:)](/documentation/montage/textarea/resource/trailing/button(color:title:handler:).md)는 디자인 가이드상 trailing 전용이라 [bottomResources(leading:trailing:leadingResourceSpacing:trailingResourceSpacing:)](/documentation/montage/textarea/bottomresources(leading:trailing:leadingresourcespacing:trailingresourcespacing:).md)의 `trailing`에만 넘길 수 있고, `leading`에 넘기면 컴파일되지 않습니다.
 
-#### Enumeration Cases
+  각 요소의 크기는 TextArea의 [TextArea.Size](/documentation/montage/textarea/size.md)에 따라 자동으로 조정됩니다. 목록에 없는 구성이 필요하면 각 타입의 `slot(_:)` 팩토리를 사용합니다.
+#### Enumerations
+
+<details>
+
+<summary>``enum Leading``</summary>
+
+
+Bottom Content 왼쪽에 표시할 요소입니다.
+##### Enumeration Cases
+
+<details>
+
+<summary>``case contentBadge(ContentBadge.Variant, title: String)``</summary>
+
+
+콘텐츠 뱃지
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `variant` | 뱃지 변형 스타일, 생략하면 기본값으로 `.solid` 적용 |
+  | `title` | 뱃지 텍스트 |
+</details>
+<details>
+
+<summary>``case icon(Icon, tintColor: SwiftUI.Color)``</summary>
+
+
+단순 아이콘
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `icon` | 표시할 아이콘 |
+  | `tintColor` | 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralQuaternary)` 적용 |
+</details>
+<details>
+
+<summary>``case iconButton(icon: Icon, tintColor: SwiftUI.Color, handler: (() -> Void)?)``</summary>
+
+
+아이콘 버튼(배경 없음)
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `icon` | 버튼 아이콘 |
+  | `tintColor` | 아이콘 색상, 생략하면 기본값으로 `.semantic(.foregroundNeutralTertiary)` 적용 |
+  | `handler` | 버튼 클릭 핸들러, 생략하면 기본값으로 `nil` 적용 |
+</details>
+<details>
+
+<summary>``case segmentedControl(selectedIndex: Binding<Int>, icons: [Icon], accessibilityLabels: [String], onSelect: ((Int) -> Void)?)``</summary>
+
+
+세그먼트 컨트롤(아이콘 전용). 표준 [SegmentedControl](/documentation/montage/segmentedcontrol.md)을 `small` 크기·`iconOnly`로 렌더링하며 정방형 아이콘만 받습니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `selectedIndex` | 선택된 세그먼트 인덱스 바인딩 |
+  | `icons` | 세그먼트 아이콘 배열 |
+  | `accessibilityLabels` | 세그먼트별 VoiceOver 라벨 배열, 생략하면 기본값으로 `[]` 적용 |
+  | `onSelect` | 선택 변경 핸들러, 생략하면 기본값으로 `nil` 적용 |
+- **Discussion**
+
+  `accessibilityLabels`는 각 세그먼트의 항목 제목으로 전달됩니다. 라벨을 생략하거나 개수가 부족하면 해당 세그먼트는 아이콘 이름으로 대체됩니다.
+</details>
+<details>
+
+<summary>``case slotView(() -> AnyView)``</summary>
+
+
+임의 뷰. [slot(_:)](/documentation/montage/textarea/resource/leading/slot(_:).md) 팩토리로 생성합니다.
+</details>
+
+##### Type Methods
+
+<details>
+
+<summary>``static func slot<V>(() -> V) -> Leading``</summary>
+
+
+목록에 없는 구성을 직접 배치합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `content` | 표시할 뷰를 생성하는 클로저 |
+- **Return Value**
+
+  구성된 요소
+</details>
+
+</details>
+<details>
+
+<summary>``enum Trailing``</summary>
+
+
+Bottom Content 오른쪽에 표시할 요소입니다.
+##### Enumeration Cases
 
 <details>
 
@@ -385,27 +484,17 @@ Primary 아이콘 버튼(Solid)
 <summary>``case slotView(() -> AnyView)``</summary>
 
 
-임의 뷰. `.slot { ... }` 팩토리로 생성합니다.
+임의 뷰. [slot(_:)](/documentation/montage/textarea/resource/trailing/slot(_:).md) 팩토리로 생성합니다.
 </details>
 
-#### Instance Properties
+##### Type Methods
 
 <details>
 
-<summary>``var isLeadingAllowed: Bool``</summary>
+<summary>``static func slot<V>(() -> V) -> Trailing``</summary>
 
 
-leading(왼쪽)에 배치할 수 있는 리소스인지 여부. `button`·`primaryIconButton`은 trailing 전용입니다.
-</details>
-
-#### Type Methods
-
-<details>
-
-<summary>``static func slot<V>(() -> V) -> Resource``</summary>
-
-
-임의 뷰를 Bottom Content에 배치합니다.
+목록에 없는 구성을 직접 배치합니다.
 
 - **Parameters**
   | Parameter | Description |
@@ -413,7 +502,9 @@ leading(왼쪽)에 배치할 수 있는 리소스인지 여부. `button`·`prima
   | `content` | 표시할 뷰를 생성하는 클로저 |
 - **Return Value**
 
-  구성된 리소스
+  구성된 요소
+</details>
+
 </details>
 
 </details>

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -2989,7 +2989,7 @@
         },
         {
           "name": "bottomResources(leading:trailing:leadingResourceSpacing:trailingResourceSpacing:)",
-          "signature": "func bottomResources(leading: [Resource], trailing: [Resource], leadingResourceSpacing: CGFloat?, trailingResourceSpacing: CGFloat?) -> TextArea",
+          "signature": "func bottomResources(leading: [Resource.Leading], trailing: [Resource.Trailing], leadingResourceSpacing: CGFloat?, trailingResourceSpacing: CGFloat?) -> TextArea",
           "summary": "텍스트 영역 하단에 표시할 UI 요소를 설정합니다.",
           "kind": "method"
         },
@@ -3062,7 +3062,39 @@
         {
           "name": "TextArea.Resource",
           "kind": "enum",
-          "summary": "텍스트 영역 하단(Bottom Content)에 표시할 수 있는 UI 요소를 정의합니다.",
+          "summary": "텍스트 영역 하단(Bottom Content)에 표시할 요소들의 Namespace입니다."
+        },
+        {
+          "name": "TextArea.Resource.Leading",
+          "kind": "enum",
+          "summary": "Bottom Content 왼쪽에 표시할 요소입니다.",
+          "cases": [
+            "contentBadge",
+            "icon",
+            "iconButton",
+            "segmentedControl",
+            "slotView"
+          ],
+          "caseSignatures": [
+            "contentBadge(_:title:)",
+            "icon(_:tintColor:)",
+            "iconButton(icon:tintColor:handler:)",
+            "segmentedControl(selectedIndex:icons:accessibilityLabels:onSelect:)",
+            "slotView(_:)"
+          ],
+          "staticMethods": [
+            {
+              "name": "slot(_:)",
+              "signature": "static func slot<V>(() -> V) -> Leading",
+              "summary": "목록에 없는 구성을 직접 배치합니다.",
+              "kind": "method"
+            }
+          ]
+        },
+        {
+          "name": "TextArea.Resource.Trailing",
+          "kind": "enum",
+          "summary": "Bottom Content 오른쪽에 표시할 요소입니다.",
           "cases": [
             "button",
             "contentBadge",
@@ -3084,17 +3116,9 @@
           "staticMethods": [
             {
               "name": "slot(_:)",
-              "signature": "static func slot<V>(() -> V) -> Resource",
-              "summary": "임의 뷰를 Bottom Content에 배치합니다.",
+              "signature": "static func slot<V>(() -> V) -> Trailing",
+              "summary": "목록에 없는 구성을 직접 배치합니다.",
               "kind": "method"
-            }
-          ],
-          "instanceProperties": [
-            {
-              "name": "isLeadingAllowed",
-              "signature": "var isLeadingAllowed: Bool",
-              "summary": "leading(왼쪽)에 배치할 수 있는 리소스인지 여부. button·primaryIconButton은 trailing 전용입니다.",
-              "kind": "property"
             }
           ]
         },
@@ -3561,12 +3585,12 @@
         {
           "name": "TopNavigation.Resource",
           "kind": "enum",
-          "summary": "TopNavigation의 좌/우에 표시될 Resource들의 Namespace입니다."
+          "summary": "TopNavigation의 좌/우에 표시될 요소들의 Namespace입니다."
         },
         {
-          "name": "TopNavigation.Resource.LeadingButtonInfo",
+          "name": "TopNavigation.Resource.Leading",
           "kind": "enum",
-          "summary": "TopNavigation의 좌측에 표시될 내용들의 열거형입니다.",
+          "summary": "내비게이션 바 좌측(leading)에 표시할 요소입니다.",
           "cases": [
             "back",
             "icon",
@@ -3579,9 +3603,9 @@
           ]
         },
         {
-          "name": "TopNavigation.Resource.TrailingButtonInfo",
+          "name": "TopNavigation.Resource.Trailing",
           "kind": "enum",
-          "summary": "TopNavigation의 우측에 표시될 내용들의 열거형입니다.",
+          "summary": "내비게이션 바 우측(trailing)에 표시할 요소입니다.",
           "cases": [
             "icon",
             "text"


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2216

슬롯 프리셋을 제공하는 컴포넌트가 셋인데 처리 방식이 제각각이었습니다. WRP-2178에서 `ListCell.Resource`를 추가하면서 드러난 후속 작업이고, 두 변경 모두 breaking change라 4.0.0 배포 전이 유일한 반영 창입니다.

| 축 | TextArea (변경 전) | TopNavigation (변경 전) | ListCell |
| --- | --- | --- | --- |
| 타입 구조 | 단일 flat enum | 네임스페이스 + 슬롯별 타입 | 네임스페이스 + 슬롯별 타입 |
| 슬롯 제약 | 런타임 필터(`isLeadingAllowed`) | 타입 분리 | 타입 분리 |
| 케이스 타입명 | 없음 | `LeadingButtonInfo` / `TrailingButtonInfo` | `Leading` / `Trailing` / `LabelTrailing` / `Extra` |

# 수정사항

### 1. TextArea 슬롯 제약을 런타임 필터에서 타입 분리로 전환

기존에는 leading에 trailing 전용 프리셋을 넘겨도 `isLeadingAllowed`로 조용히 걸러져 잘못 쓴 걸 알아챌 수 없었습니다. 이제 컴파일 단계에서 막힙니다.

- 단일 flat `TextArea.Resource` → `Resource.Leading` / `Resource.Trailing` 네임스페이스
  - `Leading`: `iconButton`, `icon`, `contentBadge`, `segmentedControl`, `slot(_:)`
  - `Trailing`: 위 전부 + `button`, `primaryIconButton` (디자인 가이드상 trailing 전용)
- `isLeadingAllowed`와 `bottomResources`의 런타임 필터 제거
- `bottomResources(leading:trailing:)` 시그니처가 슬롯별 타입을 받도록 변경
- 렌더링을 ListCell과 같은 형태로 정렬 — `extension Resource.Leading/Trailing`의 `view(size:)`, 슬롯이 공유하는 부분은 `extension Resource`의 `fileprivate static` 헬퍼로 추출. 뷰 구성 코드 자체는 그대로 옮겨 렌더 결과는 동일합니다.

```swift
// 변경 전 — 무시됨 (아무 신호 없음)
TextArea(text: $text)
    .bottomResources(leading: [.button(title: "확인")])

// 변경 후 — 컴파일 에러
TextArea(text: $text)
    .bottomResources(leading: [.button(title: "확인")])  // ❌ Leading에 button 없음
    .bottomResources(trailing: [.button(title: "확인")]) // ✅
```

### 2. TopNavigation `Info` 접미사 제거

버튼만 있던 시절의 잔재를 정리했습니다.

- `Resource.LeadingButtonInfo` → `Resource.Leading`
- `Resource.TrailingButtonInfo` → `Resource.Trailing`

### 3. 컨벤션 명문화 (CLAUDE.md)

슬롯 있는 컴포넌트를 새로 만들 때 또 갈라지지 않도록 규칙을 적었습니다.

- 슬롯 프리셋은 `컴포넌트.Resource.슬롯명` 값 enum으로 정의
- 슬롯 제약은 타입 분리로 컴파일 단계에서 막고 런타임 필터를 쓰지 않는다
- 슬롯 enum 이름은 슬롯 이름 그대로 쓰고 `Info` 같은 접미사를 붙이지 않는다
- 프리셋에 없는 구성은 `slot(_:)` 하나로만 연다
- 렌더링 위치(`extension 컴포넌트.Resource.슬롯명`의 `view`, 공유 로직은 `Resource`의 static 헬퍼)

### 범위에서 제외

- 모디파이어 형태(TextArea `bottomResources(leading:trailing:)` 통합 vs ListCell 슬롯별 개별)와 개수 제한(`prefix(3)`)은 컴포넌트 사정이라 통일하지 않았습니다. CLAUDE.md에 그 예외도 함께 적었습니다.
- `TextField.TrailingButtonInfo`도 `Info` 접미사를 쓰지만, 슬롯에 여러 프리셋을 넣는 구조가 아니라 트레일링 버튼 하나의 속성을 담는 `struct`여서 이번 컨벤션 대상이 아닙니다. 손대지 않았습니다.

### Breaking change

| 변경 전 | 변경 후 |
| --- | --- |
| `TextArea.Resource` | `TextArea.Resource.Leading` / `TextArea.Resource.Trailing` |
| `TextArea.Resource.isLeadingAllowed` | 제거 (타입으로 대체) |
| `TopNavigation.Resource.LeadingButtonInfo` | `TopNavigation.Resource.Leading` |
| `TopNavigation.Resource.TrailingButtonInfo` | `TopNavigation.Resource.Trailing` |

# 미리보기
작업 전|작업 후
---|---
UI 변경 없음|UI 변경 없음

API 형태만 바꾼 변경이라 렌더 결과는 동일합니다. `TextArea` Bottom Content의 뷰 구성 코드는 헬퍼로 위치만 옮겼고, leading/trailing 프리셋 목록과 크기·정렬 토큰은 그대로입니다.

검증:
- `xcodebuild -scheme Montage` / `-scheme Blueprint` 모두 경고·에러 없이 빌드 성공
- `make` 실행해 DocC 문서·MCP 데이터 재생성 (DocC 심볼 링크 전부 해석, 취소선 경고 없음)
- Blueprint `TextAreaPreview`는 leading/trailing 프리셋 목록을 슬롯별로 분리해 각 슬롯에서 넣을 수 있는 요소만 노출
