### PR TITLE
refactor: disable() 제거하고 SwiftUI 표준 disabled() API로 전환

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ButtonPreview.swift
@@ -45,13 +45,13 @@ struct ButtonPreview: View {
                 ) {
                     print("tapped")
                 }
-                .disable(disable)
                 .contentColor(contentColor ? .semantic(.foregroundAccentCyan) : nil)
                 .backgroundColor(backgroundColor ? .semantic(.surfaceAccentCyanOpaque) : nil)
                 .borderColor(borderColor ? .semantic(.surfaceAccentPurpleOpaque) : nil)
                 .fontVariant(fontVariant ? .heading1 : nil)
                 .fontWeight(fontWeight ? .regular : nil)
                 .loading(loading)
+                .disabled(disable)
             } else {
                 VStack {
                     Button(
@@ -64,7 +64,6 @@ struct ButtonPreview: View {
                     ) {
                         print("tapped")
                     }
-                    .disable(disable)
                     .contentColor(contentColor ? .semantic(.foregroundAccentCyan) : nil)
                     .backgroundColor(backgroundColor ? .semantic(.surfaceAccentCyanOpaque) : nil)
                     .borderColor(borderColor ? .semantic(.surfaceAccentPurpleOpaque) : nil)
@@ -72,6 +71,7 @@ struct ButtonPreview: View {
                     .fontWeight(fontWeight ? .regular : nil)
                     .loading(loading)
                     .fillWidth(fillWidth)
+                    .disabled(disable)
                     Button(
                         variant: variants[variantIndex],
                         color: color,
@@ -82,7 +82,6 @@ struct ButtonPreview: View {
                     ) {
                         print("tapped")
                     }
-                    .disable(disable)
                     .contentColor(contentColor ? .semantic(.foregroundAccentCyan) : nil)
                     .backgroundColor(backgroundColor ? .semantic(.surfaceAccentCyanOpaque) : nil)
                     .borderColor(borderColor ? .semantic(.surfaceAccentPurpleOpaque) : nil)
@@ -90,6 +89,7 @@ struct ButtonPreview: View {
                     .fontWeight(fontWeight ? .regular : nil)
                     .loading(loading)
                     .fillWidth(fillWidth)
+                    .disabled(disable)
                 }
             }
         } options: {

--- a/Sources/Blueprint/Sources/Scene/Previews/CategoryPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/CategoryPreview.swift
@@ -9,15 +9,15 @@ import SwiftUI
 import Montage
 
 struct CategoryPreview: View {
-    @State var showGuideLine: Bool = false
-    @State var selectedIndex: Int = 0
-    @State var items: [Select.Item] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"].map { Select.Item(text: $0) }
-    @State var isAlternative: Bool = false
-    @State var sizeIndex: Int = 1
-    @State var horizontalPadding: Bool = false
-    @State var verticalPadding: Bool = false
-    @State var icon: Bool = false
-    @State var alertPresented = false
+    @State private var showGuideLine: Bool = false
+    @State private var selectedIndex: Int = 0
+    @State private var items: [Select.Item] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"].map { Select.Item(text: $0) }
+    @State private var isAlternative: Bool = false
+    @State private var sizeIndex: Int = 1
+    @State private var horizontalPadding: Bool = false
+    @State private var verticalPadding: Bool = false
+    @State private var icon: Bool = false
+    @State private var alertPresented = false
 
     private let sizes: [Montage.Category.Size] = [
         .small, .medium, .large, .xlarge
@@ -25,9 +25,8 @@ struct CategoryPreview: View {
 
     var body: some View {
         PreviewLayout {
-            Category(selectedIndex: $selectedIndex, items: items.map(\.text), itemModifier: { index, chip in
-                chip.disabled(items[index].isSelected)
-            })
+            Category(selectedIndex: $selectedIndex, items: items.map(\.text))
+            .itemDisabled { items[$0].isSelected }
             .variant(isAlternative ? .alternative : .normal)
             .size(sizes[sizeIndex])
             .horizontalPadding(horizontalPadding)

--- a/Sources/Blueprint/Sources/Scene/Previews/ChipPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ChipPreview.swift
@@ -24,7 +24,6 @@ struct ChipPreview: View {
                 text: text
             )
             .active(active)
-            .disabled(disable)
             .modifying {
                 if backgroundColor == .clear {
                     $0
@@ -81,6 +80,7 @@ struct ChipPreview: View {
                     $0
                 }
             }
+            .disabled(disable)
         } options: {
             SegmentedIndexRow("Variant", index: Binding(
                 get: { variant == .solid ? 0 : 1 },

--- a/Sources/Blueprint/Sources/Scene/Previews/ControlPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ControlPreview.swift
@@ -39,7 +39,6 @@ struct ControlPreview: View {
                     ) {
                         state = $0
                     }
-                    .disable(disabled)
                     .bold(bold)
                     .tight(tight)
                     .label(label, fillWidth: fillWidth)
@@ -47,6 +46,7 @@ struct ControlPreview: View {
                         $0.labelTypography(.heading2, weight: .medium, color: .semantic(.foregroundAccentPink))
                     }
                     .border(guideLine ? Color.blue : Color.clear)
+                    .disabled(disabled)
                     Spacer()
                 }
                 HStack {
@@ -57,7 +57,6 @@ struct ControlPreview: View {
                     ) {
                         checked = $0
                     }
-                    .disable(disabled)
                     .bold(bold)
                     .tight(tight)
                     .label(label, fillWidth: fillWidth)
@@ -65,6 +64,7 @@ struct ControlPreview: View {
                         $0.labelTypography(.heading2, weight: .bold, color: .semantic(.foregroundAccentPink))
                     }
                     .border(guideLine ? Color.blue : Color.clear)
+                    .disabled(disabled)
                     Spacer()
                 }
                 HStack {
@@ -75,7 +75,6 @@ struct ControlPreview: View {
                     ) {
                         selected = $0
                     }
-                    .disable(disabled)
                     .bold(bold)
                     .tight(tight)
                     .label(label, fillWidth: fillWidth)
@@ -83,6 +82,7 @@ struct ControlPreview: View {
                         $0.labelTypography(.heading2, weight: .bold, color: .semantic(.foregroundAccentPink))
                     }
                     .border(guideLine ? Color.blue : Color.clear)
+                    .disabled(disabled)
                     Spacer()
                 }
                 Switch(
@@ -91,7 +91,7 @@ struct ControlPreview: View {
                 ) {
                     switched = $0
                 }
-                .disable(disabled)
+                .disabled(disabled)
                 .border(guideLine ? Color.blue : Color.clear)
             }
         } options: {

--- a/Sources/Blueprint/Sources/Scene/Previews/FilterButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/FilterButtonPreview.swift
@@ -21,7 +21,6 @@ struct FilterButtonPreview: View {
                 state: $state
             )
             .active(active, label: activeLabel)
-            .disabled(disable)
             .modifying {
                 if fontColor == .clear {
                     $0
@@ -36,6 +35,7 @@ struct FilterButtonPreview: View {
                     $0.iconColor(iconColor)
                 }
             }
+            .disabled(disable)
         } options: {
             SegmentedIndexRow("Variant", index: Binding(
                 get: { variant == .solid ? 0 : 1 },

--- a/Sources/Blueprint/Sources/Scene/Previews/FramedStylePreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/FramedStylePreview.swift
@@ -16,18 +16,22 @@ struct FramedStylePreview: View {
 
     var body: some View {
         PreviewLayout {
+            // 콘텐츠를 Button으로 두면 disabled가 프레임 테두리뿐 아니라 내부 콘텐츠까지
+            // 전달되는지 함께 확인할 수 있다. (Text는 `disabled(_:)`에 시각적으로 반응하지 않는다)
             ZStack {
                 Rectangle()
                     .foregroundColor(.semantic(.backgroundNeutralSecondary))
                     .frame(height: 80)
-                Text("Preview")
+                Montage.Button(size: .small, text: "Preview") {
+                    print("tapped")
+                }
             }
             .framedStyle(
                 status: FramedStyle.Status.allCases[statusIndex],
                 borderRadius: borderRadius,
-                shadowLevel: Shadow.Level.allCases[shadowIndex],
-                disabled: disabled
+                shadowLevel: Shadow.Level.allCases[shadowIndex]
             )
+            .disabled(disabled)
         } options: {
             SegmentedIndexRow("status", index: $statusIndex, labels: FramedStyle.Status.allCases.map(\.description))
             SliderOptionRow("borderRadius", value: $borderRadius, in: 0...20, step: 1)

--- a/Sources/Blueprint/Sources/Scene/Previews/IconButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/IconButtonPreview.swift
@@ -105,7 +105,6 @@ struct IconButtonPreview: View {
                     print("tapped")
                 }
             )
-            .disable(disable)
             .disableInteraction(disableInteraction)
             .showPushBadge(isNormal ? showPushBadge : false)
             .padding(isOutlinedOrSolid ? padding : 0)
@@ -137,6 +136,7 @@ struct IconButtonPreview: View {
                     $0
                 }
             }
+            .disabled(disable)
         } options: {
             SegmentedIndexRow("variant", index: $variantIndex, labels: variants.map(\.description))
             if variantIndex == 0 {

--- a/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ListCellPreview.swift
@@ -90,13 +90,13 @@ struct ListCellPreview: View {
             .extraResources(extraResourceList)
             .textEllipsis(textEllipsis)
             .divider(divider)
-            .disable(disable)
             .interactionOutset(interactionOutset)
             .interactionRadius(interactionRadius)
             .selected(selected)
             .if(!highlightText.isEmpty) {
                 $0.highlight(highlightText)
             }
+            .disabled(disable)
         } options: {
             SegmentedIndexRow("Vertical Padding", index: $verticalPaddingIndex, labels: verticalPaddings.map(\.description))
             if isCustomVerticalPadding {

--- a/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/ModalNavigationPreview.swift
@@ -95,18 +95,18 @@ struct ModalNavigationPreview: View {
                                 {
                                     AnyView(TopNavigation.TrailingIconButton(
                                         icon: i,
-                                        disable: d,
                                         showPushBadge: s,
                                         action: a
-                                    ))
+                                    )
+                                    .disabled(d))
                                 }
                             case let .text(t, d, a):
                                 {
                                     AnyView(TopNavigation.TrailingTextButton(
                                         text: t,
-                                        disable: d,
                                         action: a
-                                    ))
+                                    )
+                                    .disabled(d))
                                 }
                             }
                         }

--- a/Sources/Blueprint/Sources/Scene/Previews/SearchFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SearchFieldPreview.swift
@@ -58,11 +58,11 @@ struct SearchFieldPreview: View {
             SearchField(text: $text)
                 .variant(variant.v)
                 .size(fieldSize.s)
-                .disable(disable)
                 .placeholder(placeholder ? "검색어를 입력해 주세요." : nil)
                 .focused($focused)
                 .autocorrectionDisabled(autocorrectionDisabled)
                 .onSubmit { submittedKeyword = text }
+                .disabled(disable)
         } options: {
             SegmentedOptionRow("variant", selection: $variant)
             SegmentedOptionRow("size", selection: $fieldSize)

--- a/Sources/Blueprint/Sources/Scene/Previews/SelectPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SelectPreview.swift
@@ -83,9 +83,9 @@ struct SelectPreview: View {
             .size(sizes[sizeIndex])
             .negative(negative)
             .placeholder("선택해 주세요.")
-            .disable(disable)
             .leadingContent(leadingContents[leadingContentIndex])
             .menuResize(bottomSheetResizes[menuResizeIndex])
+            .disabled(disable)
             .bottomSheet(isPresented: $showSheet) {
                 VStack {
                     ForEach(items.indices, id: \.self) { index in

--- a/Sources/Blueprint/Sources/Scene/Previews/SliderPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/SliderPreview.swift
@@ -25,14 +25,14 @@ struct SliderPreview: View {
                 })
                 .heading(heading)
                 .label(label)
-                .disable(disable)
+                .disabled(disable)
             } else {
                 Slider(isRangeSlider: true, minValue: CGFloat(lowerBound), maxValue: CGFloat(upperBound), labelFormatter: { value in
                     "\(Int(value.rounded()))\(unit)"
                 })
                 .heading(heading)
                 .label(label)
-                .disable(disable)
+                .disabled(disable)
             }
         } options: {
             HStack {

--- a/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
@@ -122,7 +122,6 @@ struct TextAreaPreview: View {
                 .size(size.s)
                 .resize(resize.r)
                 .negative(negative)
-                .disable(disable)
                 .bottomResources(
                     leading: leadingResources,
                     trailing: trailingResources
@@ -134,6 +133,7 @@ struct TextAreaPreview: View {
                 // resize 변경 시 뷰 아이덴티티를 리셋해 높이를 재계산한다.
                 // text를 건드리면 placeholder 조건(text.isEmpty)이 깨지므로 .id로 처리한다.
                 .id(resize)
+                .disabled(disable)
         } options: {
             SegmentedIndexRow("size", index: Binding(
                 get: { Size.allCases.firstIndex(of: size) ?? 0 },

--- a/Sources/Blueprint/Sources/Scene/Previews/TextButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextButtonPreview.swift
@@ -40,12 +40,12 @@ struct TextButtonPreview: View {
             ) {
                 print("tapped")
             }
-            .disable(disable)
             .contentColor(contentColor ? .semantic(.foregroundAccentCyan) : nil)
             .fontVariant(fontVariant ? .heading1 : nil)
             .fontWeight(fontWeight ? .regular : nil)
             .loading(loading)
             .padding(.vertical, 4)
+            .disabled(disable)
         } options: {
             SegmentedIndexRow("color", index: $colorIndex, labels: colors.map(\.description))
             SegmentedIndexRow("size", index: $sizeIndex, labels: sizes.map(\.description))

--- a/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextFieldPreview.swift
@@ -106,6 +106,7 @@ struct TextFieldPreview: View {
     @State private var icon: Bool = false
     @State private var placeholder: Bool = true
     @State private var trailingButton: Bool = false
+    @State private var trailingButtonDisable: Bool = false
     @State private var trailingContent: Content = .none
     @State private var usingSuggestions: Bool = false
     @State private var autoCompletionDataSource: Montage.TextField.AutoCompletionDataSource? = nil
@@ -182,12 +183,12 @@ struct TextFieldPreview: View {
                     )
                     .size(fieldSize.s)
                     .status(variant.v)
-                    .disable(disable)
                     .placeholder(placeholder ? "텍스트를 입력해 주세요." : nil)
                     .icon(icon ? .verifiedCheckFill : nil)
                     .trailingButton(
                         trailingButton ? TextField.TrailingButtonInfo(
                             title: "텍스트",
+                            disable: trailingButtonDisable,
                             handler: { print("trailing button tapped") }
                         ) : nil
                     )
@@ -209,6 +210,7 @@ struct TextFieldPreview: View {
                     .onChange(of: usingSuggestions) { _ in
                         refreshAutoCompletion()
                     }
+                    .disabled(disable)
             }
         } options: {
             SegmentedOptionRow("size", selection: $fieldSize)
@@ -220,6 +222,10 @@ struct TextFieldPreview: View {
             HStack {
                 ToggleOption("disable", isOn: $disable)
                 ToggleOption("trailingButton", isOn: $trailingButton)
+            }
+            // 필드 전체 비활성(disable)과 트레일링 버튼만 비활성이 구분되는지 확인하는 옵션이다.
+            if trailingButton {
+                ToggleOptionRow("trailingButtonDisable", isOn: $trailingButtonDisable)
             }
             SegmentedOptionRow("trailingContent", selection: $trailingContent)
             HStack {

--- a/Sources/Blueprint/Sources/Utilities/PreviewLayout.swift
+++ b/Sources/Blueprint/Sources/Utilities/PreviewLayout.swift
@@ -28,7 +28,7 @@ import Montage
 /// ```swift
 /// // 상단 미리보기 / 하단 옵션
 /// PreviewLayout {
-///     MyComponent().disable(disable)
+///     MyComponent().disabled(disable)
 /// } options: {
 ///     SegmentedOptionRow("size", selection: $size)
 ///     ToggleOptionRow("disable", isOn: $disable)

--- a/Sources/Blueprint/Sources/Utilities/PreviewOption.swift
+++ b/Sources/Blueprint/Sources/Utilities/PreviewOption.swift
@@ -343,12 +343,12 @@ struct PrevNextOptionRow: View {
             Button(variant: .outlined, size: .small, text: "Previous") {
                 value = max(range.lowerBound, value - 1)
             }
-            .disable(value <= range.lowerBound)
+            .disabled(value <= range.lowerBound)
 
             Button(variant: .outlined, size: .small, text: "Next") {
                 value = min(range.upperBound, value + 1)
             }
-            .disable(value >= range.upperBound)
+            .disabled(value >= range.upperBound)
             Spacer()
         }
     }

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -26,7 +26,14 @@ import SwiftUI
 /// // 로딩 상태 설정
 /// Button(text: "저장")
 ///     .loading(true)
+///
+/// // 비활성화
+/// Button(text: "저장")
+///     .disabled(isFormInvalid)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Button: View {
     
     // MARK: - Types
@@ -168,7 +175,6 @@ public struct Button: View {
     
     // MARK: - Modifiers
     
-    private var disable: Bool = false
     private var contentColor: SwiftUI.Color? = nil
     private var customBackgroundColor: SwiftUI.Color? = nil
     private var customBorderColor: SwiftUI.Color? = nil
@@ -176,24 +182,7 @@ public struct Button: View {
     private var fontWeight: Typography.Weight? = nil
     private var loading = false
     private var fillWidth = false
-    
-    /// 버튼을 비활성화 상태로 설정합니다.
-    ///
-    /// 비활성화된 버튼은 시각적으로 흐리게 표시되며 사용자 상호작용에 반응하지 않습니다.
-    ///
-    /// ```swift
-    /// Button(text: "저장")
-    ///     .disable(isFormInvalid)
-    /// ```
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 버튼 인스턴스
-    public func disable(_ disable: Bool = true) -> Self {
-        var zelf = self
-        zelf.disable = disable
-        return zelf
-    }
-    
+
     /// 버튼 콘텐츠(텍스트와 아이콘)의 색상을 설정합니다.
     ///
     /// ```swift
@@ -338,9 +327,10 @@ public struct Button: View {
     }
     
     // MARK: - Body
-    
+
+    @Environment(\.isEnabled) private var isEnabled
     @State private var isPressed = false
-    
+
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
         ZStack {
@@ -397,7 +387,7 @@ public struct Button: View {
             .padding(.horizontal, -interactionHorizontalOffset)
         }
         .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: handler))
-        .allowsHitTesting(!disable && !loading)
+        .allowsHitTesting(!loading)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(text ?? leadingIcon?.rawValue ?? "")
         .accessibilityAddTraits(.isButton)
@@ -406,6 +396,8 @@ public struct Button: View {
 }
 
 private extension Button {
+    var isDisabled: Bool { isEnabled == false }
+
     static func resolveColor(variant: Variant, color: Color) -> Color {
         if variant == .outlined && color == .negative {
             #if DEBUG
@@ -419,7 +411,7 @@ private extension Button {
     var backgroundColor: SwiftUI.Color {
         switch variant {
         case .solid:
-            if disable {
+            if isDisabled {
                 .semantic(.surfaceDisablePrimary)
             } else {
                 if let customBackgroundColor {
@@ -433,7 +425,7 @@ private extension Button {
                 }
             }
         case .outlined:
-            if !disable, let customBackgroundColor {
+            if !isDisabled, let customBackgroundColor {
                 customBackgroundColor
             } else {
                 .clear
@@ -444,7 +436,7 @@ private extension Button {
     
     var borderColor: SwiftUI.Color {
         if variant == .outlined {
-            if disable {
+            if isDisabled {
                 .semantic(.lineNeutralSecondary)
             } else {
                 if let customBorderColor {
@@ -461,7 +453,7 @@ private extension Button {
     var foregroundColor: SwiftUI.Color {
         switch variant {
         case .solid:
-            if disable {
+            if isDisabled {
                 .semantic(.foregroundDisablePrimary)
             } else if let contentColor {
                 contentColor
@@ -473,7 +465,7 @@ private extension Button {
                 }
             }
         case .outlined, .text:
-            if disable {
+            if isDisabled {
                 .semantic(.foregroundDisablePrimary)
             } else if let contentColor {
                 contentColor

--- a/Sources/Montage/1 Components/2 Actions/Chip.swift
+++ b/Sources/Montage/1 Components/2 Actions/Chip.swift
@@ -21,7 +21,14 @@ import SwiftUI
 /// .backgroundColor(.semantic(.surfaceBrandPrimary))
 /// .fontColor(.semantic(.staticWhite))
 /// .leadingImage(Image(systemName: "heart"))
+///
+/// // 비활성화
+/// Chip(text: "필터")
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Chip: View {
     /// 칩의 외관을 결정하는 열거형입니다.
     public enum Variant {
@@ -73,9 +80,10 @@ public struct Chip: View {
     }
     
     // MARK: - Body
-    
+
+    @Environment(\.isEnabled) private var isEnabled
     @State private var isPressed = false
-    
+
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
         content
@@ -90,7 +98,7 @@ public struct Chip: View {
                 .inset(by: 0.5)
                 .stroke(borderColor, lineWidth: currentBorderWidth)
         )
-        .opacity(disable ? 0.5 : 1.0)
+        .opacity(isDisabled ? 0.5 : 1.0)
         .contentShape(Rectangle())
         .background(
             Interaction(
@@ -101,7 +109,6 @@ public struct Chip: View {
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         )
         .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: handler))
-        .disabled(disable)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(text)
         .accessibilityAddTraits(.isButton)
@@ -164,7 +171,6 @@ public struct Chip: View {
 
     // MARK: - Modifiers
 
-    private var disable = false
     private var active = false
     private var iconOnly = false
     private var customBackgroundColor: SwiftUI.Color?
@@ -176,16 +182,6 @@ public struct Chip: View {
     private var trailingImage: Image?
     private var fillHorizontal = false
     private var fillVertical = false
-    
-    /// 칩의 비활성화 여부를 설정합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부
-    /// - Returns: 수정된 칩 인스턴스
-    public func disabled(_ disable: Bool = true) -> Self {
-        var view = self
-        view.disable = disable
-        return view
-    }
     
     /// 칩의 선택 상태를 설정합니다.
     ///
@@ -285,8 +281,10 @@ public struct Chip: View {
 }
 
 private extension Chip {
+    var isDisabled: Bool { isEnabled == false }
+
     var backgroundColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             switch variant {
             case .solid:
                 return .semantic(.surfaceDisablePrimary)
@@ -306,7 +304,7 @@ private extension Chip {
     }
     
     var fontColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             return .semantic(.foregroundDisablePrimary)
         } else if active {
             return activeContentColor
@@ -316,7 +314,7 @@ private extension Chip {
     }
     
     var imageColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             return .semantic(.foregroundDisablePrimary)
         } else if active {
             return activeContentColor
@@ -331,7 +329,7 @@ private extension Chip {
         
     var borderColor: SwiftUI.Color {
         guard variant == .outlined else { return .clear }
-        if disable {
+        if isDisabled {
             return .semantic(.lineNeutralSecondary)
         } else if active {
             return (customActiveColor ?? .semantic(.surfaceBrandPrimary)).opacity(0.28)

--- a/Sources/Montage/1 Components/2 Actions/IconButton.swift
+++ b/Sources/Montage/1 Components/2 Actions/IconButton.swift
@@ -22,8 +22,16 @@ import SwiftUI
 ///     icon: .arrowLeft,
 ///     handler: { print("뒤로 가기 버튼 탭됨") }
 /// )
+///
+/// // 비활성화
+/// IconButton(icon: .bell)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct IconButton: View {
+    @Environment(\.isEnabled) private var isEnabled
     @State private var isPressed = false
 
     private let variant: IconButton.Variant
@@ -44,7 +52,6 @@ public struct IconButton: View {
     ) {
         self.variant = variant
         self.icon = icon
-        self.disable = false
         self.disableInteraction = false
         self.showPushBadge = false
         self.extraPadding = .zero
@@ -57,7 +64,6 @@ public struct IconButton: View {
 
     // MARK: - Modifiers
 
-    private var disable: Bool
     private var disableInteraction: Bool
     private var showPushBadge: Bool
     private var extraPadding: CGFloat
@@ -65,15 +71,6 @@ public struct IconButton: View {
     private var backgroundColor: SwiftUI.Color?
     private var borderColor: SwiftUI.Color?
     private var customInteractionColor: Color.Semantic?
-
-    /// 버튼의 비활성화 여부를 설정합니다.
-    /// - Parameter value: 비활성화 여부, true이면 버튼이 비활성화됩니다.
-    /// - Returns: 수정된 IconButton 인스턴스
-    public func disable(_ value: Bool = true) -> Self {
-        var copy = self
-        copy.disable = value
-        return copy
-    }
 
     /// hover / press 인터랙션 효과만 차단합니다(탭 핸들러는 계속 동작).
     /// - Parameter value: 인터랙션 효과 차단 여부
@@ -160,8 +157,10 @@ public struct IconButton: View {
 
     // MARK: Private Computed Property
 
+    private var isDisabled: Bool { isEnabled == false }
+
     private var _iconColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             SwiftUI.Color(uiColor: variant.disabledIconColor)
         } else {
             if let iconColor {
@@ -181,7 +180,7 @@ public struct IconButton: View {
     }
 
     private var _backgroundColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             SwiftUI.Color(uiColor: variant.disabledBackgroundColor)
         } else {
             if let backgroundColor {
@@ -210,7 +209,7 @@ public struct IconButton: View {
             .padding(totalPadding)
             .background {
                 Interaction(
-                    state: (isPressed && !disable && !disableInteraction) ? .pressed : .normal,
+                    state: (isPressed && !isDisabled && !disableInteraction) ? .pressed : .normal,
                     variant: variant.interactionVariant,
                     color: customInteractionColor ?? variant.interactionColor
                 )
@@ -220,7 +219,6 @@ public struct IconButton: View {
                 backgroundLayer(metrics: m)
             }
             .frame(width: containerSize, height: containerSize)
-            .allowsHitTesting(disable == false)
             .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: handler))
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("\(icon.rawValue) \(String(localized: "아이콘", bundle: .module))")

--- a/Sources/Montage/1 Components/2 Actions/TextButton.swift
+++ b/Sources/Montage/1 Components/2 Actions/TextButton.swift
@@ -15,7 +15,14 @@ import SwiftUI
 /// ```swift
 /// TextButton(text: "더 보기", handler: { showMore() })
 /// TextButton(color: .assistive, text: "상세보기", trailingIcon: .chevronRight)
+///
+/// // 비활성화
+/// TextButton(text: "저장")
+///     .disabled(isFormInvalid)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct TextButton: View {
     private let base: Button
 
@@ -78,21 +85,6 @@ public struct TextButton: View {
 
     private init(base: Button) {
         self.base = base
-    }
-
-    /// 버튼을 비활성화 상태로 설정합니다.
-    ///
-    /// 비활성화된 버튼은 시각적으로 흐리게 표시되며 사용자 상호작용에 반응하지 않습니다.
-    ///
-    /// ```swift
-    /// TextButton(text: "저장")
-    ///     .disable(isFormInvalid)
-    /// ```
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 버튼 인스턴스
-    public func disable(_ disable: Bool = true) -> Self {
-        .init(base: base.disable(disable))
     }
 
     /// 버튼 콘텐츠(텍스트와 아이콘)의 색상을 설정합니다.

--- a/Sources/Montage/1 Components/3 Selection And Input/Checkbox.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Checkbox.swift
@@ -17,7 +17,14 @@ import SwiftUI
 /// Checkbox(state: .unchecked, size: .small) { state in
 ///     print("체크박스 상태: \(state)")
 /// }
+///
+/// // 비활성화
+/// Checkbox(state: .unchecked)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Checkbox: View {
     private let base: Control
 
@@ -154,14 +161,6 @@ public struct Checkbox: View {
     /// - Note: 레이블이 지정되지 않은 경우 이 설정은 적용되지 않습니다.
     public func tight(_ tight: Bool = true) -> Self {
         .init(base: base.tight(tight))
-    }
-
-    /// 컨트롤을 비활성화합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 체크박스 컴포넌트
-    public func disable(_ disable: Bool = true) -> Self {
-        .init(base: base.disable(disable))
     }
 
     /// 뷰의 내용과 동작을 정의합니다.

--- a/Sources/Montage/1 Components/3 Selection And Input/Checkmark.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Checkmark.swift
@@ -8,7 +8,14 @@ import SwiftUI
 /// Checkmark(checked: true) { checked in
 ///     print("체크마크 선택 상태: \(checked)")
 /// }
+///
+/// // 비활성화
+/// Checkmark(checked: true)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Checkmark: View {
     private let base: Control
 
@@ -90,14 +97,6 @@ public struct Checkmark: View {
     /// - Note: 레이블이 지정되지 않은 경우 이 설정은 적용되지 않습니다.
     public func tight(_ tight: Bool = true) -> Self {
         .init(base: base.tight(tight))
-    }
-
-    /// 컨트롤을 비활성화합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 체크마크 컴포넌트
-    public func disable(_ disable: Bool = true) -> Self {
-        .init(base: base.disable(disable))
     }
 
     /// 뷰의 내용과 동작을 정의합니다.

--- a/Sources/Montage/1 Components/3 Selection And Input/Control.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Control.swift
@@ -75,7 +75,10 @@ struct Control: View {
 
     // MARK: - Body
 
+    @Environment(\.isEnabled) private var isEnabled
     @SwiftUI.State private var isPressed = false
+
+    private var isDisabled: Bool { isEnabled == false }
 
     @ViewBuilder private var switchThumb: some View {
         let thumbInset: CGFloat = 2
@@ -107,7 +110,7 @@ struct Control: View {
             // (색을 `.tint`로 주든 `onTintColor`로 주든 동일).
             ZStack {
                 Capsule()
-                    .fill(SwiftUI.Color.semantic(.lineNeutralPrimary).opacity(disable ? 0.43 : 1))
+                    .fill(SwiftUI.Color.semantic(.lineNeutralPrimary).opacity(isDisabled ? 0.43 : 1))
                 Capsule()
                     .fill(backgroundColor)
             }
@@ -118,7 +121,6 @@ struct Control: View {
             .animation(.easeOut(duration: 0.2), value: state.isUnchecked)
             .contentShape(Capsule())
             .onTapGesture {
-                guard disable == false else { return }
                 onSelect?(state.isUnchecked ? .checked : .unchecked)
             }
             .accessibilityRepresentation {
@@ -129,7 +131,6 @@ struct Control: View {
                         set: { onSelect?($0 ? .checked : .unchecked) })
                 )
                 .labelsHidden()
-                .disabled(disable)
             }
         default:
             HStack(alignment: .top, spacing: spacing) {
@@ -171,7 +172,6 @@ struct Control: View {
                             }
                     )
                 )
-                .disabled(disable)
 
                 if label.isNotEmpty {
                     Text(label)
@@ -185,7 +185,6 @@ struct Control: View {
                         .padding(.vertical, size == .medium ? 1 : 0)
                         .contentShape(Rectangle())
                         .onTapGesture {
-                            guard disable == false else { return }
                             onSelect?(state.isUnchecked ? .checked : .unchecked)
                         }
                 }
@@ -206,7 +205,6 @@ struct Control: View {
     private var labelColor: SwiftUI.Color?
     private var isBold = false
     private var tight = false
-    private var disable = false
 
     /// 레이블 텍스트를 설정합니다.
     ///
@@ -272,18 +270,6 @@ struct Control: View {
         zelf.tight = tight
         return zelf
     }
-
-    /// 컨트롤을 비활성화합니다.
-    ///
-    /// 비활성화된 컨트롤은 사용자 상호작용이 불가능하며, 시각적으로도 흐리게 표시됩니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 컨트롤 인스턴스
-    func disable(_ disable: Bool = true) -> Self {
-        var zelf = self
-        zelf.disable = disable
-        return zelf
-    }
 }
 
 extension Control {
@@ -305,7 +291,7 @@ extension Control {
         switch variant {
         case .checkmark:
             .semantic(state.isUnchecked ? .foregroundNeutralQuaternary : .surfaceBrandPrimary)
-                .opacity(disable ? 0.43 : 1)
+                .opacity(isDisabled ? 0.43 : 1)
         case .checkbox, .radio:
             .semantic(.staticWhite)
         case .switch:
@@ -338,14 +324,14 @@ extension Control {
         switch variant {
         case .switch:
             if state.isUnchecked {
-                disable ? .clear : .semantic(.surfaceNeutralStrong)
+                isDisabled ? .clear : .semantic(.surfaceNeutralStrong)
             } else {
-                .semantic(.surfaceBrandPrimary).opacity(disable ? 0.43 : 1)
+                .semantic(.surfaceBrandPrimary).opacity(isDisabled ? 0.43 : 1)
             }
         case .checkmark:
             .clear
         case .checkbox, .radio:
-            state.isUnchecked ? .clear : .semantic(.surfaceBrandPrimary).opacity(disable ? 0.43 : 1)
+            state.isUnchecked ? .clear : .semantic(.surfaceBrandPrimary).opacity(isDisabled ? 0.43 : 1)
         }
     }
 
@@ -353,7 +339,7 @@ extension Control {
         switch variant {
         case .checkmark, .switch: .clear
         case .checkbox, .radio:
-            .semantic(state.isUnchecked ? .lineNeutralPrimary : .surfaceBrandPrimary).opacity(disable ? 0.43 : 1)
+            .semantic(state.isUnchecked ? .lineNeutralPrimary : .surfaceBrandPrimary).opacity(isDisabled ? 0.43 : 1)
         }
     }
 
@@ -443,7 +429,7 @@ extension Control {
         (
             variant: labelVariant ?? (size == .small ? .label1 : .body2),
             weight: labelWeight ?? .regular,
-            color: disable ? .semantic(.foregroundDisablePrimary) : labelColor ?? .semantic(.foregroundNeutralPrimary)
+            color: isDisabled ? .semantic(.foregroundDisablePrimary) : labelColor ?? .semantic(.foregroundNeutralPrimary)
         )
     }
 

--- a/Sources/Montage/1 Components/3 Selection And Input/FilterButton.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/FilterButton.swift
@@ -22,8 +22,14 @@ import SwiftUI
 /// .backgroundColor(.semantic(.surfaceBrandPrimary))
 /// .fontColor(.semantic(.staticWhite))
 /// .active(true, label: "최신순")
+///
+/// // 비활성화
+/// FilterButton(text: "카테고리", state: $state)
+///     .disabled(true)
 /// ```
 ///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct FilterButton: View {
     // MARK: - Types
 
@@ -87,6 +93,7 @@ public struct FilterButton: View {
     
     // MARK: - Body
     
+    @Environment(\.isEnabled) private var isEnabled
     @SwiftUI.State private var isPressed = false
     
     /// 뷰의 내용과 동작을 정의합니다.
@@ -122,7 +129,6 @@ public struct FilterButton: View {
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         )
         .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: handler))
-        .disabled(disable)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(text)
         .accessibilityAddTraits(.isButton)
@@ -133,7 +139,6 @@ public struct FilterButton: View {
     
     private var active = false
     private var activeLabel: String?
-    private var disable = false
     private var customBackgroundColor: SwiftUI.Color?
     private var customFontColor: SwiftUI.Color?
     private var customActiveColor: SwiftUI.Color?
@@ -150,16 +155,6 @@ public struct FilterButton: View {
         var view = self
         view.active = active
         view.activeLabel = label
-        return view
-    }
-    
-    /// 버튼의 비활성화 여부를 설정합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 버튼 인스턴스
-    public func disabled(_ disable: Bool = true) -> Self {
-        var view = self
-        view.disable = disable
         return view
     }
     
@@ -261,8 +256,10 @@ extension FilterButton.Variant {
 }
 
 private extension FilterButton {
+    var isDisabled: Bool { isEnabled == false }
+
     var backgroundColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             switch variant {
             case .solid:
                 return .semantic(.surfaceDisablePrimary)
@@ -282,7 +279,7 @@ private extension FilterButton {
     }
     
     var fontColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             return .semantic(.foregroundDisablePrimary)
         } else if active {
             return activeContentColor
@@ -292,7 +289,7 @@ private extension FilterButton {
     }
     
     var iconColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             return .semantic(.foregroundDisablePrimary)
         } else if active {
             return activeContentColor
@@ -314,7 +311,7 @@ private extension FilterButton {
     
     var borderColor: SwiftUI.Color {
         guard variant == .outlined else { return .clear }
-        if disable {
+        if isDisabled {
             return .semantic(.lineNeutralSecondary)
         } else if active {
             return (customActiveColor ?? .semantic(.surfaceBrandPrimary)).opacity(0.28)

--- a/Sources/Montage/1 Components/3 Selection And Input/FramedStyle.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/FramedStyle.swift
@@ -24,21 +24,20 @@ public enum FramedStyle {
     // MARK: - ViewModifier
 
     struct Modifier: ViewModifier {
+        @Environment(\.isEnabled) private var isEnabled
+
         private let status: FramedStyle.Status
         private let borderRadius: CGFloat
         private let shadowLevel: Shadow.Level
-        private let disabled: Bool
 
         init(
             status: FramedStyle.Status = .normal,
             borderRadius: CGFloat = 0,
-            shadowLevel: Shadow.Level = .xsmall,
-            disabled: Bool = false
+            shadowLevel: Shadow.Level = .xsmall
         ) {
             self.status = status
             self.borderRadius = borderRadius
             self.shadowLevel = shadowLevel
-            self.disabled = disabled
         }
 
         func body(content: Content) -> some View {
@@ -46,7 +45,7 @@ public enum FramedStyle {
                 .overlay {
                     RoundedRectangle(cornerRadius: borderRadius)
                         .strokeBorder(borderColor, lineWidth: borderWidth)
-                        .opacity(disabled ? 0.43 : 1)
+                        .opacity(isEnabled ? 1 : Double(CGFloat.opacity43))
                 }
                 .clipShape(RoundedRectangle(cornerRadius: borderRadius))
                 // 그림자를 배경 Shape의 fill에 analytic(`ShapeStyle.shadow`)으로 적용해 오프스크린
@@ -55,7 +54,6 @@ public enum FramedStyle {
                     RoundedRectangle(cornerRadius: borderRadius)
                         .fill(SwiftUI.Color.semantic(.backgroundNeutralPrimary).shadow(shadowLevel))
                 )
-                .disabled(disabled)
         }
 
         private var borderWidth: CGFloat {
@@ -87,10 +85,12 @@ extension View {
     ///   - status: 프레임 상태, 생략하면 기본값으로 `.normal` 적용
     ///   - borderRadius: 테두리 반경, 생략하면 기본값으로 `0` 적용
     ///   - shadowLevel: 그림자 레벨, 생략하면 기본값으로 `.xsmall` 적용
-    ///   - disabled: 비활성화 상태 여부, 생략하면 기본값으로 `false` 적용
     /// - Returns: 프레임 스타일이 적용된 뷰
     ///
     /// - Note: 그림자에는 원본 View 배경색의 opacity가 동일하게 적용되므로, 원본 View의 opacity가 0.0인 경우 그림자가 표시되지 않습니다.
+    ///
+    /// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+    /// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
     ///
     /// ```swift
     /// // 기본 사용법
@@ -108,7 +108,8 @@ extension View {
     ///
     /// // 비활성화된 프레임
     /// Text("비활성화된 텍스트")
-    ///     .framedStyle(disabled: true)
+    ///     .framedStyle()
+    ///     .disabled(true)
     ///
     /// // 부정적 상태의 프레임 (오류 표시)
     /// Text("오류 메시지")
@@ -121,15 +122,13 @@ extension View {
     public func framedStyle(
         status: FramedStyle.Status = .normal,
         borderRadius: CGFloat = 0,
-        shadowLevel: Shadow.Level = .xsmall,
-        disabled: Bool = false
+        shadowLevel: Shadow.Level = .xsmall
     ) -> some View {
         modifier(
             FramedStyle.Modifier(
                 status: status,
                 borderRadius: borderRadius,
-                shadowLevel: shadowLevel,
-                disabled: disabled
+                shadowLevel: shadowLevel
             ))
     }
 }

--- a/Sources/Montage/1 Components/3 Selection And Input/Radio.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Radio.swift
@@ -13,7 +13,14 @@ import SwiftUI
 /// Radio(checked: false, size: .small) { checked in
 ///     print("라디오 버튼 선택 상태: \(checked)")
 /// }
+///
+/// // 비활성화
+/// Radio(checked: false)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Radio: View {
     private let base: Control
 
@@ -95,14 +102,6 @@ public struct Radio: View {
     /// - Note: 레이블이 지정되지 않은 경우 이 설정은 적용되지 않습니다.
     public func tight(_ tight: Bool = true) -> Self {
         .init(base: base.tight(tight))
-    }
-
-    /// 컨트롤을 비활성화합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 라디오 버튼 컴포넌트
-    public func disable(_ disable: Bool = true) -> Self {
-        .init(base: base.disable(disable))
     }
 
     /// 뷰의 내용과 동작을 정의합니다.

--- a/Sources/Montage/1 Components/3 Selection And Input/SearchField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/SearchField.swift
@@ -32,7 +32,14 @@ import SwiftUI
 /// // 자동수정·맞춤법 검사를 끈 검색 필드
 /// SearchField(text: $keyword)
 ///    .autocorrectionDisabled()
+///
+/// // 비활성화
+/// SearchField(text: $keyword)
+///    .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct SearchField: View {
     // MARK: - Types
 
@@ -70,7 +77,6 @@ public struct SearchField: View {
 
     private var variant: Variant = .solid
     private var size: Size = .large
-    private var disable = false
     private var placeholder: String?
     private var externalFocused: Binding<Bool>?
     private var onSubmit: (() -> Void)?
@@ -95,16 +101,6 @@ public struct SearchField: View {
     public func size(_ size: Size) -> Self {
         var zelf = self
         zelf.size = size
-        return zelf
-    }
-
-    /// 검색 필드의 활성화 상태를 설정합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, `true`이면 비활성화
-    /// - Returns: 수정된 검색 필드 인스턴스
-    public func disable(_ disable: Bool) -> Self {
-        var zelf = self
-        zelf.disable = disable
         return zelf
     }
 
@@ -181,6 +177,7 @@ public struct SearchField: View {
 
     // MARK: - Body
 
+    @Environment(\.isEnabled) private var isEnabled
     @FocusState private var focusState: Bool
     @State private var internalFocused = false
     @State private var fixAutocorrection = false
@@ -194,6 +191,8 @@ public struct SearchField: View {
 // MARK: - Private
 
 private extension SearchField {
+    var isDisabled: Bool { isEnabled == false }
+
     var focused: Binding<Bool> {
         externalFocused ?? $internalFocused
     }
@@ -214,9 +213,6 @@ private extension SearchField {
             .onTapGesture {
                 focusState = true
             }
-            // allowsHitTesting은 포인터 입력만 막아 보조 기술에 비활성 상태가 전달되지 않는다.
-            // disabled를 써야 VoiceOver가 "사용 안 함"으로 읽고 포커스 이동도 함께 차단된다.
-            .disabled(disable)
     }
 
     var contentRow: some View {
@@ -248,17 +244,17 @@ private extension SearchField {
                     onTextChange?(newValue)
                 }
                 // 비활성 상태에서는 외부 바인딩이 포커스를 켜지 못하게 막는다.
-                // (막지 않으면 disable인 필드에 키보드가 올라온다)
+                // (막지 않으면 비활성 필드에 키보드가 올라온다)
                 .onChange(of: focused.wrappedValue) { newValue in
-                    let target = disable ? false : newValue
+                    let target = isDisabled ? false : newValue
                     if focusState != target {
                         focusState = target
                     }
                 }
                 // 비활성화되면 열려 있던 포커스를 내리고, 다시 활성화되면 바인딩이 요청한 포커스를 반영한다.
                 // (활성화 방향을 처리하지 않으면 focused == true인데 포커스가 없는 상태로 남는다)
-                .onChange(of: disable) { isDisabled in
-                    let target = isDisabled ? false : focused.wrappedValue
+                .onChange(of: isEnabled) { isEnabled in
+                    let target = isEnabled ? focused.wrappedValue : false
                     if focusState != target {
                         focusState = target
                     }
@@ -293,7 +289,7 @@ private extension SearchField {
 
     @ViewBuilder
     var clearButton: some View {
-        if text.isNotEmpty, disable == false {
+        if text.isNotEmpty, isDisabled == false {
             IconButton(
                 variant: .normal(size: size.clearButtonSize),
                 icon: .circleCloseFill
@@ -317,8 +313,8 @@ private extension SearchField {
                 .fill(SwiftUI.Color.semantic(.surfaceNeutralSecondary))
                 .background(.ultraThinMaterial, in: surface)
         case .outlined:
-            // outlined는 배경을 비워 뒤 콘텐츠가 비치도록 하고, disable일 때만 표면을 채운다.
-            if disable {
+            // outlined는 배경을 비워 뒤 콘텐츠가 비치도록 하고, 비활성일 때만 표면을 채운다.
+            if isDisabled {
                 surface
                     .fill(SwiftUI.Color.semantic(.surfaceNeutralSecondary))
             } else {
@@ -335,16 +331,16 @@ private extension SearchField {
         case .solid:
             nil
         case .outlined:
-            disable ? .semantic(.lineNeutralTertiary) : .semantic(.lineNeutralSecondary)
+            isDisabled ? .semantic(.lineNeutralTertiary) : .semantic(.lineNeutralSecondary)
         }
     }
 
     var iconColor: SwiftUI.Color {
-        disable ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
+        isDisabled ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
     }
 
     var placeholderTextColor: SwiftUI.Color {
-        disable ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
+        isDisabled ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
     }
 }
 

--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -22,7 +22,14 @@ import SwiftUI
 ///     items: $items
 /// )
 /// .placeholder("선택하세요")
+///
+/// // 비활성화
+/// Select(variant: .single(), items: $items)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Select: View {
     // MARK: - Types
 
@@ -153,7 +160,6 @@ public struct Select: View {
     private var negative = false
     private var render: Render = .text
     private var placeholder = ""
-    private var disable = false
     private var leadingContent: LeadingContent?
     private var menuResize: BottomSheet.Resize = .hug
     private var size: Size = .large
@@ -185,15 +191,6 @@ public struct Select: View {
         return zelf
     }
 
-    /// 활성화 여부를 조정합니다.
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 Select 인스턴스
-    public func disable(_ disable: Bool = true) -> Self {
-        var zelf = self
-        zelf.disable = disable
-        return zelf
-    }
-
     /// 왼쪽 컨텐츠를 추가합니다.
     /// - Parameter content: 표시할 선행 콘텐츠
     /// - Returns: 수정된 Select 인스턴스
@@ -214,10 +211,13 @@ public struct Select: View {
 
     // MARK: - Body
 
+    @Environment(\.isEnabled) private var isEnabled
     @Environment(\.colorScheme) private var colorScheme
     @State private var defaultMenuPresented = false
     @State private var bottomSheetContentHeight: CGFloat = .zero
     @State private var pureBottomSheetHeight: CGFloat = .zero
+
+    private var isDisabled: Bool { isEnabled == false }
 
     /// 뷰의 내용과 동작을 정의합니다.
     public var body: some View {
@@ -286,7 +286,6 @@ public struct Select: View {
                             } else {
                                 let chips = Chips(
                                     items: selectedItems,
-                                    disable: disable,
                                     onTapItem: { item in
                                         let index = items.enumerated()
                                             .first { $0.element == item }?
@@ -326,10 +325,8 @@ public struct Select: View {
             ) {
                 menuPresented.wrappedValue.toggle()
             }
-            .iconColor(
-                disable
-                    ? SwiftUI.Color.semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
-            )
+            // 비활성 색상(foreground/disable/primary)은 IconButton이 `\.isEnabled`를 읽어 직접 적용한다.
+            .iconColor(.semantic(.foregroundNeutralTertiary))
             .padding(.horizontal, 4)
             .frame(height: size.contentMinHeight)
             .rotationEffect(.degrees(menuPresented.wrappedValue ? 180 : 0))
@@ -343,7 +340,7 @@ public struct Select: View {
         // 외형(둥근 모서리·머티리얼·테두리)은 동일하게 유지한다. (drop shadow 제거)
         .background {
             let surface = surfaceShape
-            if disable {
+            if isDisabled {
                 surface
                     .fill(SwiftUI.Color.semantic(.surfaceNeutralTertiary))
             } else {
@@ -363,7 +360,6 @@ public struct Select: View {
         // 메뉴가 열렸을 때 TextField와 동일하게 내부 border(primary 43%)에 더해
         // 외부 Focus Ring(primary 12%)을 그린다.
         .background { focusRing }
-        .allowsHitTesting(disable == false)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(placeholder)
         .accessibilityValue(selectedItems.map(\.text).joined(separator: ", "))
@@ -478,7 +474,7 @@ public struct Select: View {
     }
 
     private var strokeColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             .semantic(.lineNeutralSecondary)
         } else if negative {
             menuPresented.wrappedValue
@@ -495,7 +491,7 @@ public struct Select: View {
 
     @ViewBuilder
     private var focusRing: some View {
-        if menuPresented.wrappedValue, disable == false {
+        if menuPresented.wrappedValue, isDisabled == false {
             RoundedRectangle(cornerRadius: size.cornerRadius + .spacing4)
                 .strokeBorder(focusRingColor, lineWidth: 4)
                 .padding(-.spacing4)
@@ -517,19 +513,22 @@ public struct Select: View {
     }
 
     private var placeholderTextColor: SwiftUI.Color {
-        disable ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralQuaternary)
+        isDisabled ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralQuaternary)
     }
 
     private var textColor: SwiftUI.Color {
-        disable ? .semantic(.foregroundNeutralTertiary) : .semantic(.foregroundNeutralPrimary)
+        isDisabled ? .semantic(.foregroundNeutralTertiary) : .semantic(.foregroundNeutralPrimary)
     }
 
     // MARK: - Inner View
 
     private struct Chips: View {
+        @Environment(\.isEnabled) private var isEnabled
+
         var items: [Select.Item]
-        var disable: Bool
         var onTapItem: ((Select.Item) -> Void)?
+
+        private var isDisabled: Bool { isEnabled == false }
 
         var body: some View {
             ForEach(items.indices, id: \.self) { index in
@@ -547,7 +546,7 @@ public struct Select: View {
                     if let icon = item.icon {
                         mutated = mutated.leadingImage(Image.icon(icon))
                     }
-                    if item.isNegative, disable == false {
+                    if item.isNegative, isDisabled == false {
                         mutated = mutated.borderColor(.semantic(.lineNegativePrimary))
                     }
                     return mutated
@@ -559,9 +558,9 @@ public struct Select: View {
             }
         }
 
-        /// 아이콘(leading/close) 색상입니다. disable은 foreground/disable/primary, negative는 foreground/negative/primary, 그 외 foreground/neutral/primary.
+        /// 아이콘(leading/close) 색상입니다. 비활성은 foreground/disable/primary, negative는 foreground/negative/primary, 그 외 foreground/neutral/primary.
         private func iconColor(_ item: Select.Item) -> SwiftUI.Color {
-            if disable {
+            if isDisabled {
                 return .semantic(.foregroundDisablePrimary)
             } else if item.isNegative {
                 return .semantic(.foregroundNegativePrimary)
@@ -570,9 +569,9 @@ public struct Select: View {
             }
         }
 
-        /// 텍스트 색상입니다. disable/그 외는 foreground/neutral/primary, negative는 foreground/negative/primary.
+        /// 텍스트 색상입니다. 비활성·그 외는 foreground/neutral/primary, negative는 foreground/negative/primary.
         private func fontColor(_ item: Select.Item) -> SwiftUI.Color {
-            if item.isNegative, disable == false {
+            if item.isNegative, isDisabled == false {
                 return .semantic(.foregroundNegativePrimary)
             } else {
                 return .semantic(.foregroundNeutralPrimary)

--- a/Sources/Montage/1 Components/3 Selection And Input/Slider.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Slider.swift
@@ -28,7 +28,14 @@ import SwiftUI
 /// )
 /// .label()
 /// .heading()
+///
+/// // 비활성화
+/// Slider()
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Slider: View {
     // MARK: - Initializer
     private let isRangeSlider: Bool
@@ -86,6 +93,7 @@ public struct Slider: View {
     
     // MARK: - Body
     
+    @Environment(\.isEnabled) private var isEnabled
     @State private var thumbRatio1 = 0.0
     @State private var thumbRatio2 = 1.0
     @State private var focusedThumb: Int?
@@ -101,18 +109,18 @@ public struct Slider: View {
                     .typography(
                         variant: .headline2,
                         weight: .bold,
-                        semantic: disable ? .surfaceDisablePrimary : .foregroundNeutralPrimary
+                        semantic: isEnabled ? .foregroundNeutralPrimary : .surfaceDisablePrimary
                     )
             }
-            
+
             ZStack(alignment: .topLeading) {
                 // lines
                 GeometryReader { geo in
                     ZStack(alignment: .leading) {
-                        Line(kind: .outer, disable: disable)
+                        Line(kind: .outer)
                             .frame(width: lineLength)
                         
-                        Line(kind: .inner, disable: disable)
+                        Line(kind: .inner)
                             .frame(width: min(lineLength, lineLength * (highThumbRatio - lowThumbRatio)))
                             .offset(x: max(0, lineLength * lowThumbRatio))
                     }
@@ -149,8 +157,7 @@ public struct Slider: View {
                     Thumb(
                         title: label ? labelFormatter(value(from: thumbRatio1)) : nil,
                         value: thumbRatio1,
-                        maxValue: lineLength,
-                        disable: disable
+                        maxValue: lineLength
                     )
                     .zIndex(focusedThumb == 1 ? 1 : 0)
                     .offset(x: max(0, lineLength * thumbRatio1))
@@ -168,8 +175,7 @@ public struct Slider: View {
                 Thumb(
                     title: label ? labelFormatter(value(from: thumbRatio2)) : nil,
                     value: thumbRatio2,
-                    maxValue: lineLength,
-                    disable: disable
+                    maxValue: lineLength
                 )
                 .zIndex(focusedThumb == 2 ? 1 : 0)
                 .offset(x: max(0, lineLength * thumbRatio2))
@@ -231,11 +237,9 @@ public struct Slider: View {
                 onChanged?(lowValue, highValue)
             }
         }
-        .allowsHitTesting(!disable)
         .modifier(SliderAccessibilityModifier(
             label: String(localized: "슬라이더", bundle: .module),
             value: headingLabel,
-            disable: disable,
             onAdjust: handleAccessibilityAdjust
         ))
     }
@@ -243,7 +247,6 @@ public struct Slider: View {
     // MARK: - Modifiers
     private var heading = false
     private var label = false
-    private var disable = false
     /// 슬라이더 상단에 제목을 표시할지 여부를 설정합니다.
     ///
     /// - Parameter heading: 제목 표시 여부, 생략하면 기본값으로 `true` 적용
@@ -264,20 +267,10 @@ public struct Slider: View {
         return zelf
     }
     
-    /// 슬라이더의 활성화 상태를 설정합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 슬라이더 인스턴스
-    public func disable(_ disable: Bool = true) -> Self {
-        var zelf = self
-        zelf.disable = disable
-        return zelf
-    }
-    
     // MARK: - private
 
     private func handleAccessibilityAdjust(_ direction: AccessibilityAdjustmentDirection) {
-        guard !disable else { return }
+        guard isEnabled else { return }
         let step = 0.05
         switch direction {
         case .increment:
@@ -338,22 +331,22 @@ public struct Slider: View {
         enum Kind {
             case inner, outer
         }
-        
+
+        @Environment(\.isEnabled) private var isEnabled
+
         private let kind: Kind
-        private let disable: Bool
-        
-        init(kind: Kind, disable: Bool) {
+
+        init(kind: Kind) {
             self.kind = kind
-            self.disable = disable
         }
-        
+
         var body: some View {
             RoundedRectangle(cornerRadius: .infinity)
                 .fill(lineColor)
         }
-        
+
         var lineColor: SwiftUI.Color {
-            guard !disable else { return .semantic(.surfaceDisablePrimary) }
+            guard isEnabled else { return .semantic(.surfaceDisablePrimary) }
             return switch kind {
             case .inner:
                 .semantic(.surfaceBrandPrimary)
@@ -364,18 +357,18 @@ public struct Slider: View {
     }
     
     private struct Thumb: View {
+        @Environment(\.isEnabled) private var isEnabled
+
         private let title: String?
         private let value: CGFloat
         private let maxValue: CGFloat
-        private let disable: Bool
 
-        init(title: String?, value: CGFloat, maxValue: CGFloat, disable: Bool) {
+        init(title: String?, value: CGFloat, maxValue: CGFloat) {
             self.title = title
             self.value = value
             self.maxValue = maxValue
-            self.disable = disable
         }
-        
+
         @State private var isDragging = false
         @State private var textSize: CGSize = .zero
         var body: some View {
@@ -383,7 +376,7 @@ public struct Slider: View {
                 Circle()
                     .frame(width: Slider.diameter, height: Slider.diameter)
                     .foregroundStyle(
-                        SwiftUI.Color.semantic(disable ? .surfaceDisablePrimary : .surfaceBrandPrimary)
+                        SwiftUI.Color.semantic(isEnabled ? .surfaceBrandPrimary : .surfaceDisablePrimary)
                     )
                     .contentShape(Rectangle())
                     .background {
@@ -397,7 +390,7 @@ public struct Slider: View {
                     }
                     .overlay {
                         if let title {
-                            Label(title: title, value: value, maxValue: maxValue, disable: disable)
+                            Label(title: title, value: value, maxValue: maxValue)
                         }
                     }
                 
@@ -414,21 +407,21 @@ public struct Slider: View {
     }
     
     private struct Label: View {
+        @Environment(\.isEnabled) private var isEnabled
+
         private let title: String
         private let value: CGFloat
         private let maxValue: CGFloat
-        private let disable: Bool
         private var isSpacer = false
-        
-        init(title: String, value: CGFloat, maxValue: CGFloat, disable: Bool) {
+
+        init(title: String, value: CGFloat, maxValue: CGFloat) {
             self.title = title
             self.value = value
             self.maxValue = maxValue
-            self.disable = disable
         }
-        
+
         static func spacer(for title: String) -> Label {
-            var view = Label(title: title, value: 0, maxValue: 0, disable: false)
+            var view = Label(title: title, value: 0, maxValue: 0)
             view.isSpacer = true
             return view
         }
@@ -440,7 +433,7 @@ public struct Slider: View {
                 .typography(
                     variant: .label1,
                     weight: .medium,
-                    semantic: disable ? .surfaceDisablePrimary : .foregroundNeutralPrimary
+                    semantic: isEnabled ? .foregroundNeutralPrimary : .surfaceDisablePrimary
                 )
             Group {
                 if isSpacer {
@@ -481,7 +474,6 @@ public struct Slider: View {
 private struct SliderAccessibilityModifier: ViewModifier {
     let label: String
     let value: String
-    let disable: Bool
     let onAdjust: (AccessibilityAdjustmentDirection) -> Void
 
     func body(content: Content) -> some View {

--- a/Sources/Montage/1 Components/3 Selection And Input/Switch.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Switch.swift
@@ -8,7 +8,14 @@ import SwiftUI
 /// Switch(checked: true) { checked in
 ///     print("스위치 선택 상태: \(checked)")
 /// }
+///
+/// // 비활성화
+/// Switch(checked: true)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct Switch: View {
     private let base: Control
 
@@ -43,14 +50,6 @@ public struct Switch: View {
 
     private init(base: Control) {
         self.base = base
-    }
-
-    /// 컨트롤을 비활성화합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 스위치 컴포넌트
-    public func disable(_ disable: Bool = true) -> Self {
-        .init(base: base.disable(disable))
     }
 
     /// 뷰의 내용과 동작을 정의합니다.

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -34,7 +34,14 @@ import SwiftUI
 /// // 자동수정·맞춤법 검사를 끈 텍스트 영역
 /// TextArea(text: $longText)
 ///     .autocorrectionDisabled()
+///
+/// // 비활성화
+/// TextArea(text: $longText)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 public struct TextArea: View {
     // MARK: - Types
 
@@ -241,7 +248,6 @@ public struct TextArea: View {
     private var size: Size = .large
     private var resize: Resize = .normal
     private var negative = false
-    private var disable = false
     private var placeholder: String? = nil
     private var leadingResources: [Resource.Leading] = []
     private var trailingResources: [Resource.Trailing] = []
@@ -343,16 +349,6 @@ public struct TextArea: View {
         return zelf
     }
 
-    /// 텍스트 영역의 활성화 상태를 설정합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 텍스트 영역 인스턴스
-    public func disable(_ disable: Bool = true) -> Self {
-        var zelf = self
-        zelf.disable = disable
-        return zelf
-    }
-
     /// 텍스트 영역 하단에 표시할 UI 요소를 설정합니다.
     ///
     /// - Parameters:
@@ -390,7 +386,11 @@ public struct TextArea: View {
 
     // MARK: - Body
 
+    @Environment(\.isEnabled) private var isEnabled
     @Environment(\.colorScheme) private var colorScheme
+
+    private var isDisabled: Bool { isEnabled == false }
+
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @FocusState private var internalFocusState
 
@@ -465,7 +465,7 @@ public struct TextArea: View {
                     .foregroundStyle(editorTextColor)
                     .font(.font(variant: size.inputVariant))
                     .lineSpacing(size.inputVariant.lineSpacing)
-                    .if(!disable) {
+                    .if(!isDisabled) {
                         $0.focused(focus)
                     }
                     .onChange(of: text) { newValue in
@@ -493,7 +493,6 @@ public struct TextArea: View {
             if leadingResources.isEmpty == false || trailingResources.isEmpty == false {
                 Bottom(
                     size,
-                    disable,
                     leadingResources,
                     leadingResourceSpacing,
                     trailingResources,
@@ -511,7 +510,6 @@ public struct TextArea: View {
         }
         // focusRing은 어떤 clip보다 뒤(=바깥)에 그려져야 테두리 밖으로 번질 수 있다.
         .background { focusRing }
-        .allowsHitTesting(disable == false)
         .contentShape(RoundedRectangle(cornerRadius: size.cornerRadius))
         .onTapGesture {
             focus.wrappedValue = true
@@ -523,7 +521,7 @@ public struct TextArea: View {
     @ViewBuilder
     private var editorBackground: some View {
         Group {
-            if disable {
+            if isDisabled {
                 SwiftUI.Color.semantic(.surfaceNeutralTertiary)
             } else {
                 if colorScheme == .light {
@@ -542,7 +540,7 @@ public struct TextArea: View {
     /// negative 상태에서는 빨간 ring을 사용한다.
     @ViewBuilder
     private var focusRing: some View {
-        if focus.wrappedValue, disable == false {
+        if focus.wrappedValue, isDisabled == false {
             RoundedRectangle(cornerRadius: size.cornerRadius + 4)
                 .strokeBorder(focusRingColor, lineWidth: 4)
                 .padding(-4)
@@ -556,7 +554,7 @@ public struct TextArea: View {
     }
 
     private var editorStrokeColor: SwiftUI.Color {
-        if disable {
+        if isDisabled {
             SwiftUI.Color.semantic(.lineNeutralTertiary)
         } else if negative {
             SwiftUI.Color.semantic(.lineNegativeStrong)
@@ -572,18 +570,17 @@ public struct TextArea: View {
     }
 
     private var placeholderTextColor: SwiftUI.Color {
-        disable ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
+        isDisabled ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
     }
 
     private var editorTextColor: SwiftUI.Color {
-        disable ? .semantic(.foregroundNeutralTertiary) : .semantic(.foregroundNeutralPrimary)
+        isDisabled ? .semantic(.foregroundNeutralTertiary) : .semantic(.foregroundNeutralPrimary)
     }
 
     // MARK: - Inner View
 
     private struct Bottom: View {
         private let size: Size
-        private let disable: Bool
         private let leadingResources: [Resource.Leading]
         private let leadingResourceSpacing: CGFloat?
         private let trailingResources: [Resource.Trailing]
@@ -591,14 +588,12 @@ public struct TextArea: View {
 
         init(
             _ size: Size,
-            _ disable: Bool,
             _ leadingResources: [Resource.Leading],
             _ leadingResourceSpacing: CGFloat?,
             _ trailingResources: [Resource.Trailing],
             _ trailingResourceSpacing: CGFloat?
         ) {
             self.size = size
-            self.disable = disable
             self.leadingResources = leadingResources
             self.leadingResourceSpacing = leadingResourceSpacing
             self.trailingResources = trailingResources

--- a/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextField.swift
@@ -41,7 +41,15 @@ import SwiftUI
 /// TextField(text: $inputText)
 ///    .placeholder("이메일을 입력하세요")
 ///    .autocorrectionDisabled()
+///
+/// // 비활성화
+/// TextField(text: $inputText)
+///    .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
+/// 트레일링 버튼만 따로 비활성화하려면 ``TrailingButtonInfo``의 `disable`을 사용합니다.
 public struct TextField: View {
     // MARK: - Types
 
@@ -166,7 +174,6 @@ public struct TextField: View {
 
     private var size: Size = .large
     private var status: Status = .normal
-    private var disable = false
     private var placeholder: String? = nil
     private var icon: Icon? = nil
     private var trailingButton: TrailingButtonInfo? = nil
@@ -194,16 +201,6 @@ public struct TextField: View {
     public func status(_ status: Status) -> Self {
         var zelf = self
         zelf.status = status
-        return zelf
-    }
-    
-    /// 텍스트 필드의 활성화 상태를 설정합니다.
-    ///
-    /// - Parameter disable: 비활성화 여부, `true`이면 비활성화
-    /// - Returns: 수정된 텍스트 필드 인스턴스
-    public func disable(_ disable: Bool) -> Self {
-        var zelf = self
-        zelf.disable = disable
         return zelf
     }
     
@@ -303,6 +300,7 @@ public struct TextField: View {
 
     // MARK: - Body
     
+    @Environment(\.isEnabled) private var isEnabled
     @Environment(\.safeAreaInsets) private var safeAreaInsets
     @Environment(\.colorScheme) private var colorScheme
     @State private var textFieldGlobalFrame: CGRect = .zero
@@ -319,6 +317,8 @@ public struct TextField: View {
 // MARK: - Private
 
 private extension TextField {
+    var isDisabled: Bool { isEnabled == false }
+
     var inputField: some View {
         HStack(spacing: .spacing4) {
             contentRow
@@ -328,7 +328,7 @@ private extension TextField {
                 TrailingButton(
                     size: size,
                     title: trailingButton.title,
-                    disable: disable || trailingButton.disable,
+                    disable: trailingButton.disable,
                     handler: trailingButton.handler
                 )
             }
@@ -353,7 +353,6 @@ private extension TextField {
         .onTapGesture {
             textFieldFocusState = true
         }
-        .allowsHitTesting(disable == false)
         .overlay {
             autoCompletionContent.opacity(0)
                 .onGeometryChange(
@@ -506,7 +505,7 @@ private extension TextField {
         // 둥근 표면을 배경 Shape로 직접 그려 `clipShape`의 오프스크린 마스킹을 제거한다.
         // 외형(둥근 모서리·머티리얼)은 동일하게 유지한다. (drop shadow 제거)
         let surface = RoundedRectangle(cornerRadius: size.cornerRadius)
-        if disable {
+        if isDisabled {
             surface
                 .fill(SwiftUI.Color.semantic(.surfaceNeutralTertiary))
         } else {
@@ -522,7 +521,7 @@ private extension TextField {
 
     @ViewBuilder
     var focusRing: some View {
-        if textFieldFocusState, disable == false {
+        if textFieldFocusState, isDisabled == false {
             RoundedRectangle(cornerRadius: size.cornerRadius + .spacing4)
                 .strokeBorder(focusRingColor, lineWidth: 4)
                 .padding(-.spacing4)
@@ -591,8 +590,8 @@ private extension TextField {
     }
     
     var fieldStrokeColor: SwiftUI.Color {
-        // disable 상태에서는 status와 무관하게 normal과 동일한 border 색상을 사용한다. (negative 포함)
-        if disable {
+        // 비활성 상태에서는 status와 무관하게 normal과 동일한 border 색상을 사용한다. (negative 포함)
+        if isDisabled {
             .semantic(.lineNeutralSecondary)
         } else if textFieldFocusState {
             switch status {
@@ -639,7 +638,7 @@ private extension TextField {
     }
 
     var placeholderTextColor: SwiftUI.Color {
-        disable ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
+        isDisabled ? .semantic(.foregroundDisablePrimary) : .semantic(.foregroundNeutralTertiary)
     }
     
     var fieldTextColor: SwiftUI.Color {
@@ -753,7 +752,11 @@ private extension TextField {
             self.handler = handler
         }
 
+        @Environment(\.isEnabled) private var isEnabled
         @State private var isPressed = false
+
+        /// 필드 전체가 비활성이거나(`isEnabled == false`) 트레일링 버튼만 따로 비활성인 경우를 함께 다룬다.
+        private var isDisabled: Bool { isEnabled == false || disable }
 
         var body: some View {
             Text(title)
@@ -772,16 +775,16 @@ private extension TextField {
                     RoundedRectangle(cornerRadius: size.trailingButtonRadius)
                         .strokeBorder(SwiftUI.Color.semantic(.lineNeutralSecondary), lineWidth: 1)
                 }
-                .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: disable ? nil : handler))
-                .allowsHitTesting(disable == false)
+                .modifier(PressActionDetectingModifier(isPressed: $isPressed, action: isDisabled ? nil : handler))
+                .allowsHitTesting(isDisabled == false)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(title)
                 .accessibilityAddTraits(.isButton)
-                .accessibilityRespondsToUserInteraction(disable == false)
+                .accessibilityRespondsToUserInteraction(isDisabled == false)
         }
 
         var textColor: Color.Semantic {
-            disable ? .foregroundDisablePrimary : .foregroundNeutralPrimary
+            isDisabled ? .foregroundDisablePrimary : .foregroundNeutralPrimary
         }
     }
 }

--- a/Sources/Montage/1 Components/4 Contents/Avatar.swift
+++ b/Sources/Montage/1 Components/4 Contents/Avatar.swift
@@ -24,7 +24,15 @@ import SwiftUI
 /// // 푸시 알림 표시가 있는 아바타
 /// Avatar("https://example.com/profile.jpg", variant: .person)
 ///     .pushBadge()
+///
+/// // 비활성화
+/// Avatar("https://example.com/profile.jpg", variant: .person)
+///     .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
+/// 이미지는 색 토큰으로 비활성을 표현할 수 없어 불투명도 `Opacity/43`을 적용합니다.
 public struct Avatar: View {
     // MARK: - Types
     
@@ -161,9 +169,7 @@ public struct Avatar: View {
     
     @State private var isPressed = false
 
-    /// 상위 컨테이너가 `disabled(_:)`로 비활성화되면 이미지도 흐리게 표시한다.
-    ///
-    /// 이미지 계열은 색 토큰으로 비활성을 표현할 수 없어 불투명도를 낮춘다.
+    // 이미지 계열은 색 토큰으로 비활성을 표현할 수 없어 불투명도를 낮춘다.
     @Environment(\.isEnabled) private var isEnabled
     
     /// 뷰의 내용과 동작을 정의합니다.

--- a/Sources/Montage/1 Components/4 Contents/ListCell.swift
+++ b/Sources/Montage/1 Components/4 Contents/ListCell.swift
@@ -54,6 +54,19 @@ import SwiftUI
 /// ListCell(label: "커스텀")
 ///     .trailingResources([.slot { MyCustomView() }])
 /// ```
+///
+/// ## 비활성화
+///
+/// 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지
+/// 함께 비활성 스타일로 표시됩니다. 비활성 셀은 탭 이벤트를 받지 않으며 라벨·설명·콘텐츠 슬롯에
+/// `foregroundDisablePrimary` 색상이 적용됩니다.
+///
+/// ```swift
+/// ListCell(label: "비활성 셀")
+///     .disabled(true)
+/// ```
+///
+/// - Note: 콘텐츠 슬롯에는 전경색으로 전달되므로, 슬롯 안에서 색상을 직접 지정한 뷰에는 적용되지 않습니다.
 public struct ListCell: View {
     // MARK: - Types
     /// 상하 여백을 나타내는 열거형입니다.
@@ -136,6 +149,7 @@ public struct ListCell: View {
     }
 
     // MARK: - Body
+    @Environment(\.isEnabled) private var isEnabled
     @State private var isPressed = false
 
     /// 뷰의 내용과 동작을 정의합니다.
@@ -164,9 +178,6 @@ public struct ListCell: View {
         // 선택 상태는 체크 아이콘으로만 표현되는데 children을 combine하므로
         // 트레이트로 따로 전달하지 않으면 보조 기술이 선택 여부를 알 수 없다.
         .if(selected) { $0.accessibilityAddTraits(.isSelected) }
-        // allowsHitTesting은 포인터 입력만 막아 보조 기술에 비활성 상태가 전달되지 않는다.
-        // disabled를 써야 VoiceOver가 "사용 안 함"으로 읽고 포커스 이동도 함께 차단된다.
-        .disabled(disable)
     }
 
     // MARK: - Modifiers
@@ -175,7 +186,6 @@ public struct ListCell: View {
     private var verticalPadding: VerticalPadding = .medium
     private var textEllipsis = false
     private var descriptionText: String? = nil
-    private var disable = false
     private var selected = false
     private var divider = false
     private var chevron = false
@@ -309,21 +319,6 @@ public struct ListCell: View {
     public func description(_ description: String? = nil) -> Self {
         var zelf = self
         zelf.descriptionText = description
-        return zelf
-    }
-
-    /// 셀의 비활성화 상태를 설정합니다.
-    ///
-    /// 비활성화된 셀은 탭 이벤트를 받지 않으며, 라벨·설명·콘텐츠 슬롯에 `foregroundDisablePrimary` 색상이 적용됩니다.
-    ///
-    /// - Parameters:
-    ///   - disable: 비활성화 여부, 생략하면 기본값으로 `true` 적용
-    /// - Returns: 수정된 ListCell 인스턴스
-    ///
-    /// - Note: 콘텐츠 슬롯에는 전경색으로 전달되므로, 슬롯 안에서 색상을 직접 지정한 뷰에는 적용되지 않습니다.
-    public func disable(_ disable: Bool = true) -> Self {
-        var zelf = self
-        zelf.disable = disable
         return zelf
     }
 
@@ -472,6 +467,8 @@ public struct ListCell: View {
 
 // MARK: - Private
 extension ListCell {
+    private var isDisabled: Bool { isEnabled == false }
+
     /// 인터랙션 효과 적용 여부.
     ///
     /// 상하 여백이 없는 셀은 배경이 텍스트에 바짝 붙어 눌림 표현이 오히려 노이즈가 되므로 사용하지 않는다.
@@ -485,7 +482,7 @@ extension ListCell {
     }
 
     private var resolvedLabelColor: Color.Semantic {
-        if disable {
+        if isDisabled {
             .foregroundDisablePrimary
         } else {
             selected ? .surfaceBrandPrimary : labelTypography.color
@@ -493,15 +490,15 @@ extension ListCell {
     }
 
     private var resolvedDescriptionColor: Color.Semantic {
-        disable ? .foregroundDisablePrimary : .foregroundNeutralTertiary
+        isDisabled ? .foregroundDisablePrimary : .foregroundNeutralTertiary
     }
 
     private var chevronColor: Color.Semantic {
-        disable ? .foregroundDisablePrimary : .foregroundNeutralQuaternary
+        isDisabled ? .foregroundDisablePrimary : .foregroundNeutralQuaternary
     }
 
     private var selectedCheckColor: Color.Semantic {
-        disable ? .foregroundDisablePrimary : .surfaceBrandPrimary
+        isDisabled ? .foregroundDisablePrimary : .surfaceBrandPrimary
     }
 
     private var row: some View {
@@ -573,7 +570,7 @@ extension ListCell {
         }
         // 슬롯 콘텐츠에는 비활성일 때만 색을 강제하고, 그 외에는 사용처가 지정한 색을 그대로 둔다.
         // 자기 색을 직접 그리는 컴포넌트(ContentBadge·Switch 등)는 이 전경색을 따르지 않는다.
-        .if(disable) {
+        .if(isDisabled) {
             $0.foregroundStyle(SwiftUI.Color.semantic(.foregroundDisablePrimary))
         }
     }

--- a/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
+++ b/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
@@ -30,7 +30,16 @@ import SwiftUI
 /// Thumbnail(urlString: imageURL, ratio: .r1x1)
 ///    .width(50)
 ///    .border(true)
+///
+/// // 비활성화
+/// Thumbnail(urlString: imageURL, ratio: .r1x1)
+///    .width(100)
+///    .disabled(true)
 /// ```
+///
+/// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
+/// 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
+/// 이미지는 색 토큰으로 비활성을 표현할 수 없어 불투명도 `Opacity/43`을 적용합니다.
 public struct Thumbnail: View {
 
     // MARK: - Ratio Enum
@@ -179,7 +188,7 @@ public struct Thumbnail: View {
 
     @State private var proposedWidth: CGFloat = .zero
 
-    /// 상위 컨테이너가 `disabled(_:)`로 비활성화되면 이미지도 흐리게 표시한다.
+    // 이미지 계열은 색 토큰으로 비활성을 표현할 수 없어 불투명도를 낮춘다.
     ///
     /// 이미지 계열은 색 토큰으로 비활성을 표현할 수 없어 불투명도를 낮춘다.
     @Environment(\.isEnabled) private var isEnabled

--- a/Sources/Montage/1 Components/6 Navigations/Category.swift
+++ b/Sources/Montage/1 Components/6 Navigations/Category.swift
@@ -100,6 +100,7 @@ public struct Category: View {
                                 itemModifier(index, $0)
                             }
                             .contentShape(Rectangle())
+                            .disabled(itemDisabled(index))
                         }
                     }
                     Spacer(minLength: 0)
@@ -146,7 +147,27 @@ public struct Category: View {
     private var verticalPadding = false
     private var icon: Icon? = nil
     private var iconButtonAction: (() -> Void)?
-    
+    private var itemDisabled: (Int) -> Bool = { _ in false }
+
+    /// 개별 카테고리 항목의 비활성 여부를 설정합니다.
+    ///
+    /// `itemModifier`는 `Chip`을 반환해야 하므로 SwiftUI 표준 `disabled(_:)`를 그 안에서 쓸 수 없습니다.
+    /// 항목별로 비활성 상태를 지정할 때 이 모디파이어를 사용합니다.
+    /// 카테고리 전체를 비활성화할 때는 `disabled(_:)`를 그대로 사용하면 됩니다.
+    ///
+    /// ```swift
+    /// Category(selectedIndex: $index, items: titles)
+    ///     .itemDisabled { soldOutIndices.contains($0) }
+    /// ```
+    ///
+    /// - Parameter predicate: 항목 인덱스를 받아 비활성 여부를 반환하는 클로저
+    /// - Returns: 수정된 카테고리 인스턴스
+    public func itemDisabled(_ predicate: @escaping (Int) -> Bool) -> Self {
+        var zelf = self
+        zelf.itemDisabled = predicate
+        return zelf
+    }
+
     /// 카테고리 아이템 스타일을 설정합니다.
     ///
     /// - Parameter variant: 아이템 스타일 (.normal 또는 .alternative)

--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -515,32 +515,28 @@ extension TopNavigation {
     /// 내비게이션 바의 오른쪽(trailing)에 위치하는 텍스트 버튼입니다.
     ///
     /// ```swift
-    /// TrailingTextButton(
-    ///     text: "확인",
-    ///     disable: false
-    /// ) {
+    /// TrailingTextButton(text: "확인") {
     ///     // 버튼 액션
     /// }
+    /// .disabled(isFormInvalid)
     /// ```
+    ///
+    /// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
     public struct TrailingTextButton: View {
         private let text: String
-        private let disable: Bool
         private let action: () -> Void
-        
+
         /// 내비게이션 바의 오른쪽(trailing)에 위치하는 텍스트 버튼을 초기화합니다.
         ///
         /// - Parameters:
         ///   - text: 버튼에 표시할 텍스트
-        ///   - disable: 버튼 비활성화 여부, 생략하면 기본값으로 `false` 적용
         ///   - action: 버튼 액션
         /// - Returns: TrailingTextButton 인스턴스
         public init(
             text: String,
-            disable: Bool = false,
             action: @escaping () -> Void
         ) {
             self.text = text
-            self.disable = disable
             self.action = action
         }
 
@@ -549,7 +545,6 @@ extension TopNavigation {
             TextButton(text: text) {
                 action()
             }
-            .disable(disable)
             .contentColor(.semantic(.foregroundNeutralPrimary))
             .fontVariant(.headline2)
             .fontWeight(.regular)
@@ -559,7 +554,7 @@ extension TopNavigation {
     
     /// 내비게이션 바의 오른쪽(trailing)에 위치하는 아이콘 버튼입니다.
     ///
-    /// 비활성화(disable), 푸시 뱃지 등을 옵션으로 설정할 수 있습니다.
+    /// 푸시 뱃지 등을 옵션으로 설정할 수 있습니다.
     ///
     /// ```swift
     /// TrailingIconButton(
@@ -568,39 +563,37 @@ extension TopNavigation {
     /// ) {
     ///     // 버튼 액션
     /// }
+    /// .disabled(true)
     /// ```
+    ///
+    /// - Note: 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
     public struct TrailingIconButton: View {
         private let icon: Icon
-        private let disable: Bool
         private let showPushBadge: Bool
         private let action: () -> Void
-        
+
         /// 내비게이션 바의 오른쪽(trailing)에 위치하는 아이콘 버튼을 초기화합니다.
         ///
         /// - Parameters:
         ///   - icon: 아이콘 버튼의 아이콘
-        ///   - disable: 버튼 비활성화 여부, 생략하면 기본값으로 `false` 적용
         ///   - showPushBadge: PushBadge의 노출 여부, 생략하면 기본값으로 `false` 적용
         ///   - action: 아이콘 버튼 클릭시 동작할 액션
         /// - Returns: TrailingIconButton 인스턴스
         public init(
             icon: Icon,
-            disable: Bool = false,
             showPushBadge: Bool = false,
             action: @escaping () -> Void
         ) {
             self.icon = icon
-            self.disable = disable
             self.showPushBadge = showPushBadge
             self.action = action
         }
-        
+
         /// 뷰의 내용과 동작을 정의합니다.
         public var body: some View {
             IconButton(icon: icon) {
                 action()
             }
-            .disable(disable)
             .showPushBadge(showPushBadge)
             .frame(width: 24, height: 24)
         }

--- a/documentation/components/actions/button/ios.md
+++ b/documentation/components/actions/button/ios.md
@@ -27,7 +27,15 @@ Button(icon: .bell, handler: { print("알림 보기") })
 // 로딩 상태 설정
 Button(text: "저장")
     .loading(true)
+
+// 비활성화
+Button(text: "저장")
+    .disabled(isFormInvalid)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -161,30 +169,6 @@ Button(text: "저장")
   ```swift
   Button(variant: .outlined, text: "복사")
       .contentColor(.red)
-  ```
-
-</details>
-<details>
-
-<summary>``func disable(Bool) -> Button``</summary>
-
-
-버튼을 비활성화 상태로 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 버튼 인스턴스
-- **Discussion**
-
-  비활성화된 버튼은 시각적으로 흐리게 표시되며 사용자 상호작용에 반응하지 않습니다.
-
-  ```swift
-  Button(text: "저장")
-      .disable(isFormInvalid)
   ```
 
 </details>

--- a/documentation/components/actions/chip/ios.md
+++ b/documentation/components/actions/chip/ios.md
@@ -20,7 +20,15 @@ Chip(
 .backgroundColor(.semantic(.surfaceBrandPrimary))
 .fontColor(.semantic(.staticWhite))
 .leadingImage(Image(systemName: "heart"))
+
+// 비활성화
+Chip(text: "필터")
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -118,21 +126,6 @@ Chip(
   >
   > `outlined` variant에서만 적용됩니다. (`solid`는 테두리를 그리지 않습니다.)
 
-</details>
-<details>
-
-<summary>``func disabled(Bool) -> Chip``</summary>
-
-
-칩의 비활성화 여부를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부 |
-- **Return Value**
-
-  수정된 칩 인스턴스
 </details>
 <details>
 

--- a/documentation/components/actions/iconbutton/ios.md
+++ b/documentation/components/actions/iconbutton/ios.md
@@ -23,7 +23,15 @@ IconButton(
     icon: .arrowLeft,
     handler: { print("뒤로 가기 버튼 탭됨") }
 )
+
+// 비활성화
+IconButton(icon: .bell)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -95,21 +103,6 @@ IconButton(
   >
   > Outlined 에서만 사용 가능합니다.
 
-</details>
-<details>
-
-<summary>``func disable(Bool) -> IconButton``</summary>
-
-
-버튼의 비활성화 여부를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `value` | 비활성화 여부, true이면 버튼이 비활성화됩니다. |
-- **Return Value**
-
-  수정된 IconButton 인스턴스
 </details>
 <details>
 

--- a/documentation/components/actions/textbutton/ios.md
+++ b/documentation/components/actions/textbutton/ios.md
@@ -14,7 +14,15 @@ Text만 있는 스타일의 버튼으로, 가벼운 액션이나 링크 형태�
 ```swift
 TextButton(text: "더 보기", handler: { showMore() })
 TextButton(color: .assistive, text: "상세보기", trailingIcon: .chevronRight)
+
+// 비활성화
+TextButton(text: "저장")
+    .disabled(isFormInvalid)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -69,30 +77,6 @@ Text 스타일의 버튼을 생성합니다.
   ```swift
   TextButton(text: "복사")
       .contentColor(.red)
-  ```
-
-</details>
-<details>
-
-<summary>``func disable(Bool) -> TextButton``</summary>
-
-
-버튼을 비활성화 상태로 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 버튼 인스턴스
-- **Discussion**
-
-  비활성화된 버튼은 시각적으로 흐리게 표시되며 사용자 상호작용에 반응하지 않습니다.
-
-  ```swift
-  TextButton(text: "저장")
-      .disable(isFormInvalid)
   ```
 
 </details>

--- a/documentation/components/contents/avatar/ios.md
+++ b/documentation/components/contents/avatar/ios.md
@@ -22,7 +22,15 @@ Avatar("https://example.com/company-logo.png", variant: .company, size: .medium)
 // 푸시 알림 표시가 있는 아바타
 Avatar("https://example.com/profile.jpg", variant: .person)
     .pushBadge()
+
+// 비활성화
+Avatar("https://example.com/profile.jpg", variant: .person)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다. 이미지는 색 토큰으로 비활성을 표현할 수 없어 불투명도 `Opacity/43`을 적용합니다.
 
 ## Topics
 

--- a/documentation/components/contents/listcell/ios.md
+++ b/documentation/components/contents/listcell/ios.md
@@ -52,6 +52,19 @@ ListCell(label: "커스텀")
     .trailingResources([.slot { MyCustomView() }])
 ```
 
+## 비활성화
+
+비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다. 비활성 셀은 탭 이벤트를 받지 않으며 라벨·설명·콘텐츠 슬롯에 `foregroundDisablePrimary` 색상이 적용됩니다.
+
+```swift
+ListCell(label: "비활성 셀")
+    .disabled(true)
+```
+
+>  **Note**
+>
+> 콘텐츠 슬롯에는 전경색으로 전달되므로, 슬롯 안에서 색상을 직접 지정한 뷰에는 적용되지 않습니다.
+
 ## Topics
 
 ### Initializers
@@ -117,28 +130,6 @@ ListCell(label: "커스텀")
 - **Discussion**
 
   설명은 라벨 아래에 작은 글씨로 표시되는 부가 설명 텍스트입니다.
-</details>
-<details>
-
-<summary>``func disable(Bool) -> ListCell``</summary>
-
-
-셀의 비활성화 상태를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 ListCell 인스턴스
-- **Discussion**
-
-  비활성화된 셀은 탭 이벤트를 받지 않으며, 라벨·설명·콘텐츠 슬롯에 `foregroundDisablePrimary` 색상이 적용됩니다.
-  >  **Note**
-  >
-  > 콘텐츠 슬롯에는 전경색으로 전달되므로, 슬롯 안에서 색상을 직접 지정한 뷰에는 적용되지 않습니다.
-
 </details>
 <details>
 

--- a/documentation/components/contents/thumbnail/ios.md
+++ b/documentation/components/contents/thumbnail/ios.md
@@ -27,7 +27,16 @@ Thumbnail(urlString: imageURL, ratio: .r16x9)
 Thumbnail(urlString: imageURL, ratio: .r1x1)
    .width(50)
    .border(true)
+
+// 비활성화
+Thumbnail(urlString: imageURL, ratio: .r1x1)
+   .width(100)
+   .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다. 이미지는 색 토큰으로 비활성을 표현할 수 없어 불투명도 `Opacity/43`을 적용합니다.
 
 ## Topics
 

--- a/documentation/components/navigations/category/ios.md
+++ b/documentation/components/navigations/category/ios.md
@@ -92,6 +92,30 @@ Category(
 </details>
 <details>
 
+<summary>``func itemDisabled((Int) -> Bool) -> Category``</summary>
+
+
+개별 카테고리 항목의 비활성 여부를 설정합니다.
+
+- **Parameters**
+  | Parameter | Description |
+  | --- | --- |
+  | `predicate` | 항목 인덱스를 받아 비활성 여부를 반환하는 클로저 |
+- **Return Value**
+
+  수정된 카테고리 인스턴스
+- **Discussion**
+
+  `itemModifier`는 `Chip`을 반환해야 하므로 SwiftUI 표준 `disabled(_:)`를 그 안에서 쓸 수 없습니다. 항목별로 비활성 상태를 지정할 때 이 모디파이어를 사용합니다. 카테고리 전체를 비활성화할 때는 `disabled(_:)`를 그대로 사용하면 됩니다.
+
+  ```swift
+  Category(selectedIndex: $index, items: titles)
+      .itemDisabled { soldOutIndices.contains($0) }
+  ```
+
+</details>
+<details>
+
 <summary>``func size(Size) -> Category``</summary>
 
 

--- a/documentation/components/navigations/topnavigation/ios.md
+++ b/documentation/components/navigations/topnavigation/ios.md
@@ -95,7 +95,7 @@ TopNavigation(
 내비게이션 바의 오른쪽(trailing)에 위치하는 아이콘 버튼입니다.
 - **Overview**
 
-  비활성화(disable), 푸시 뱃지 등을 옵션으로 설정할 수 있습니다.
+  푸시 뱃지 등을 옵션으로 설정할 수 있습니다.
 
   ```swift
   TrailingIconButton(
@@ -104,13 +104,18 @@ TopNavigation(
   ) {
       // 버튼 액션
   }
+  .disabled(true)
   ```
+
+  >  **Note**
+  >
+  > 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
 
 #### Initializers
 
 <details>
 
-<summary>``init(icon: Icon, disable: Bool, showPushBadge: Bool, action: () -> Void)``</summary>
+<summary>``init(icon: Icon, showPushBadge: Bool, action: () -> Void)``</summary>
 
 
 내비게이션 바의 오른쪽(trailing)에 위치하는 아이콘 버튼을 초기화합니다.
@@ -119,7 +124,6 @@ TopNavigation(
   | Parameter | Description |
   | --- | --- |
   | `icon` | 아이콘 버튼의 아이콘 |
-  | `disable` | 버튼 비활성화 여부, 생략하면 기본값으로 `false` 적용 |
   | `showPushBadge` | PushBadge의 노출 여부, 생략하면 기본값으로 `false` 적용 |
   | `action` | 아이콘 버튼 클릭시 동작할 액션 |
 </details>
@@ -144,19 +148,21 @@ TopNavigation(
 - **Overview**
 
   ```swift
-  TrailingTextButton(
-      text: "확인",
-      disable: false
-  ) {
+  TrailingTextButton(text: "확인") {
       // 버튼 액션
   }
+  .disabled(isFormInvalid)
   ```
+
+  >  **Note**
+  >
+  > 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다.
 
 #### Initializers
 
 <details>
 
-<summary>``init(text: String, disable: Bool, action: () -> Void)``</summary>
+<summary>``init(text: String, action: () -> Void)``</summary>
 
 
 내비게이션 바의 오른쪽(trailing)에 위치하는 텍스트 버튼을 초기화합니다.
@@ -165,7 +171,6 @@ TopNavigation(
   | Parameter | Description |
   | --- | --- |
   | `text` | 버튼에 표시할 텍스트 |
-  | `disable` | 버튼 비활성화 여부, 생략하면 기본값으로 `false` 적용 |
   | `action` | 버튼 액션 |
 </details>
 

--- a/documentation/components/selection and input/checkbox/ios.md
+++ b/documentation/components/selection and input/checkbox/ios.md
@@ -24,7 +24,15 @@ Checkbox(checked: true) { checked in
 Checkbox(state: .unchecked, size: .small) { state in
     print("체크박스 상태: \(state)")
 }
+
+// 비활성화
+Checkbox(state: .unchecked)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -104,21 +112,6 @@ Checkbox(state: .unchecked, size: .small) { state in
   >
   > 레이블이 지정되지 않은 경우 이 설정은 적용되지 않습니다.
 
-</details>
-<details>
-
-<summary>``func disable(Bool) -> Checkbox``</summary>
-
-
-컨트롤을 비활성화합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 체크박스 컴포넌트
 </details>
 <details>
 

--- a/documentation/components/selection and input/checkmark/ios.md
+++ b/documentation/components/selection and input/checkmark/ios.md
@@ -15,7 +15,15 @@ description: 체크마크 컴포넌트입니다.
 Checkmark(checked: true) { checked in
     print("체크마크 선택 상태: \(checked)")
 }
+
+// 비활성화
+Checkmark(checked: true)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -71,21 +79,6 @@ Checkmark(checked: true) { checked in
   >
   > 레이블이 지정되지 않은 경우 이 설정은 적용되지 않습니다.
 
-</details>
-<details>
-
-<summary>``func disable(Bool) -> Checkmark``</summary>
-
-
-컨트롤을 비활성화합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 체크마크 컴포넌트
 </details>
 <details>
 

--- a/documentation/components/selection and input/filterbutton/ios.md
+++ b/documentation/components/selection and input/filterbutton/ios.md
@@ -21,7 +21,15 @@ FilterButton(
 .backgroundColor(.semantic(.surfaceBrandPrimary))
 .fontColor(.semantic(.staticWhite))
 .active(true, label: "최신순")
+
+// 비활성화
+FilterButton(text: "카테고리", state: $state)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -98,21 +106,6 @@ FilterButton(
   | Parameter | Description |
   | --- | --- |
   | `color` | 적용할 배경색 |
-- **Return Value**
-
-  수정된 버튼 인스턴스
-</details>
-<details>
-
-<summary>``func disabled(Bool) -> FilterButton``</summary>
-
-
-버튼의 비활성화 여부를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
 - **Return Value**
 
   수정된 버튼 인스턴스

--- a/documentation/components/selection and input/framedstyle/ios.md
+++ b/documentation/components/selection and input/framedstyle/ios.md
@@ -53,7 +53,7 @@ enum FramedStyle
 
 <details>
 
-<summary>``func framedStyle(status: FramedStyle.Status, borderRadius: CGFloat, shadowLevel: Shadow.Level, disabled: Bool) -> some View``</summary>
+<summary>``func framedStyle(status: FramedStyle.Status, borderRadius: CGFloat, shadowLevel: Shadow.Level) -> some View``</summary>
 
 
 현재 뷰에 프레임 스타일을 적용합니다.
@@ -64,7 +64,6 @@ enum FramedStyle
   | `status` | 프레임 상태, 생략하면 기본값으로 `.normal` 적용 |
   | `borderRadius` | 테두리 반경, 생략하면 기본값으로 `0` 적용 |
   | `shadowLevel` | 그림자 레벨, 생략하면 기본값으로 `.xsmall` 적용 |
-  | `disabled` | 비활성화 상태 여부, 생략하면 기본값으로 `false` 적용 |
 - **Return Value**
 
   프레임 스타일이 적용된 뷰
@@ -74,6 +73,10 @@ enum FramedStyle
   >  **Note**
   >
   > 그림자에는 원본 View 배경색의 opacity가 동일하게 적용되므로, 원본 View의 opacity가 0.0인 경우 그림자가 표시되지 않습니다.
+
+  >  **Note**
+  >
+  > 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 
   ```swift
@@ -92,7 +95,8 @@ enum FramedStyle
   
   // 비활성화된 프레임
   Text("비활성화된 텍스트")
-      .framedStyle(disabled: true)
+      .framedStyle()
+      .disabled(true)
   
   // 부정적 상태의 프레임 (오류 표시)
   Text("오류 메시지")

--- a/documentation/components/selection and input/radio/ios.md
+++ b/documentation/components/selection and input/radio/ios.md
@@ -20,7 +20,15 @@ Radio(checked: true) { checked in
 Radio(checked: false, size: .small) { checked in
     print("라디오 버튼 선택 상태: \(checked)")
 }
+
+// 비활성화
+Radio(checked: false)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -76,21 +84,6 @@ Radio(checked: false, size: .small) { checked in
   >
   > 레이블이 지정되지 않은 경우 이 설정은 적용되지 않습니다.
 
-</details>
-<details>
-
-<summary>``func disable(Bool) -> Radio``</summary>
-
-
-컨트롤을 비활성화합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 라디오 버튼 컴포넌트
 </details>
 <details>
 

--- a/documentation/components/selection and input/searchfield/ios.md
+++ b/documentation/components/selection and input/searchfield/ios.md
@@ -31,7 +31,15 @@ SearchField(text: $keyword)
 // 자동수정·맞춤법 검사를 끈 검색 필드
 SearchField(text: $keyword)
    .autocorrectionDisabled()
+
+// 비활성화
+SearchField(text: $keyword)
+   .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -81,21 +89,6 @@ SearchField(text: $keyword)
   사람 이름·회사명·약어처럼 사전에 없는 검색어를 자주 입력하는 화면에서 사용합니다. `true`이면 입력 중 자동수정이 적용되지 않고, 맞춤법 검사 밑줄도 표시되지 않습니다.
 
   검색 필드가 내부에서 SwiftUI의 `autocorrectionDisabled(_:)`를 직접 적용하므로, 호출부에서 인스턴스 바깥에 같은 모디파이어를 붙이면 내부 설정에 덮어써집니다. 반드시 이 모디파이어로 설정해 주세요.
-</details>
-<details>
-
-<summary>``func disable(Bool) -> SearchField``</summary>
-
-
-검색 필드의 활성화 상태를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, `true`이면 비활성화 |
-- **Return Value**
-
-  수정된 검색 필드 인스턴스
 </details>
 <details>
 

--- a/documentation/components/selection and input/select/ios.md
+++ b/documentation/components/selection and input/select/ios.md
@@ -21,7 +21,15 @@ Select(
     items: $items
 )
 .placeholder("선택하세요")
+
+// 비활성화
+Select(variant: .single(), items: $items)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -114,21 +122,6 @@ Select 컴포넌트 초기화
 
 ### Instance Methods
 
-<details>
-
-<summary>``func disable(Bool) -> Select``</summary>
-
-
-활성화 여부를 조정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 Select 인스턴스
-</details>
 <details>
 
 <summary>``func leadingContent(LeadingContent?) -> Select``</summary>

--- a/documentation/components/selection and input/slider/ios.md
+++ b/documentation/components/selection and input/slider/ios.md
@@ -26,7 +26,15 @@ Slider(
 )
 .label()
 .heading()
+
+// 비활성화
+Slider()
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -76,21 +84,6 @@ Slider(
 
 ### Instance Methods
 
-<details>
-
-<summary>``func disable(Bool) -> Slider``</summary>
-
-
-슬라이더의 활성화 상태를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 슬라이더 인스턴스
-</details>
 <details>
 
 <summary>``func heading(Bool) -> Slider``</summary>

--- a/documentation/components/selection and input/switch/ios.md
+++ b/documentation/components/selection and input/switch/ios.md
@@ -15,7 +15,15 @@ description: 스위치 컴포넌트입니다.
 Switch(checked: true) { checked in
     print("스위치 선택 상태: \(checked)")
 }
+
+// 비활성화
+Switch(checked: true)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -44,24 +52,6 @@ Switch(checked: true) { checked in
 
 
 뷰의 내용과 동작을 정의합니다.
-</details>
-
-### Instance Methods
-
-<details>
-
-<summary>``func disable(Bool) -> Switch``</summary>
-
-
-컨트롤을 비활성화합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 스위치 컴포넌트
 </details>
 
 ### Enumerations

--- a/documentation/components/selection and input/textarea/ios.md
+++ b/documentation/components/selection and input/textarea/ios.md
@@ -33,7 +33,15 @@ TextArea(text: $longText)
 // 자동수정·맞춤법 검사를 끈 텍스트 영역
 TextArea(text: $longText)
     .autocorrectionDisabled()
+
+// 비활성화
+TextArea(text: $longText)
+    .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 ## Topics
 
@@ -107,21 +115,6 @@ TextArea(text: $longText)
   >
   > `button`·`primaryIconButton`은 디자인 가이드상 trailing 전용이므로 [TextArea.Resource.Trailing](/documentation/montage/textarea/resource/trailing.md)에만 정의되어 있습니다. leading에 넘기면 컴파일되지 않습니다.
 
-</details>
-<details>
-
-<summary>``func disable(Bool) -> TextArea``</summary>
-
-
-텍스트 영역의 활성화 상태를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, 생략하면 기본값으로 `true` 적용 |
-- **Return Value**
-
-  수정된 텍스트 영역 인스턴스
 </details>
 <details>
 

--- a/documentation/components/selection and input/textfield/ios.md
+++ b/documentation/components/selection and input/textfield/ios.md
@@ -40,7 +40,15 @@ TextField(text: $inputText)
 TextField(text: $inputText)
    .placeholder("이메일을 입력하세요")
    .autocorrectionDisabled()
+
+// 비활성화
+TextField(text: $inputText)
+   .disabled(true)
 ```
+
+>  **Note**
+>
+> 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다. 트레일링 버튼만 따로 비활성화하려면 [TextField.TrailingButtonInfo](/documentation/montage/textfield/trailingbuttoninfo.md)의 `disable`을 사용합니다.
 
 ## Topics
 
@@ -182,21 +190,6 @@ TextField(text: $inputText)
   | Parameter | Description |
   | --- | --- |
   | `color` | 설정할 배경색 |
-- **Return Value**
-
-  수정된 텍스트 필드 인스턴스
-</details>
-<details>
-
-<summary>``func disable(Bool) -> TextField``</summary>
-
-
-텍스트 필드의 활성화 상태를 설정합니다.
-
-- **Parameters**
-  | Parameter | Description |
-  | --- | --- |
-  | `disable` | 비활성화 여부, `true`이면 비활성화 |
 - **Return Value**
 
   수정된 텍스트 필드 인스턴스

--- a/documentation/utilities/ios-extensions/swiftuicore.md
+++ b/documentation/utilities/ios-extensions/swiftuicore.md
@@ -216,7 +216,7 @@ View를 UIImage로 변환합니다.
 </details>
 <details>
 
-<summary>``func framedStyle(status: FramedStyle.Status, borderRadius: CGFloat, shadowLevel: Shadow.Level, disabled: Bool) -> some View``</summary>
+<summary>``func framedStyle(status: FramedStyle.Status, borderRadius: CGFloat, shadowLevel: Shadow.Level) -> some View``</summary>
 
 
 현재 뷰에 프레임 스타일을 적용합니다.
@@ -227,7 +227,6 @@ View를 UIImage로 변환합니다.
   | `status` | 프레임 상태, 생략하면 기본값으로 `.normal` 적용 |
   | `borderRadius` | 테두리 반경, 생략하면 기본값으로 `0` 적용 |
   | `shadowLevel` | 그림자 레벨, 생략하면 기본값으로 `.xsmall` 적용 |
-  | `disabled` | 비활성화 상태 여부, 생략하면 기본값으로 `false` 적용 |
 - **Return Value**
 
   프레임 스타일이 적용된 뷰
@@ -237,6 +236,10 @@ View를 UIImage로 변환합니다.
   >  **Note**
   >
   > 그림자에는 원본 View 배경색의 opacity가 동일하게 적용되므로, 원본 View의 opacity가 0.0인 경우 그림자가 표시되지 않습니다.
+
+  >  **Note**
+  >
+  > 비활성화는 SwiftUI 표준 `disabled(_:)`를 사용합니다. 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 함께 비활성 스타일로 표시됩니다.
 
 
   ```swift
@@ -255,7 +258,8 @@ View를 UIImage로 변환합니다.
   
   // 비활성화된 프레임
   Text("비활성화된 텍스트")
-      .framedStyle(disabled: true)
+      .framedStyle()
+      .disabled(true)
   
   // 부정적 상태의 프레임 (오류 표시)
   Text("오류 메시지")

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -395,12 +395,6 @@
           "kind": "method"
         },
         {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> Button",
-          "summary": "버튼을 비활성화 상태로 설정합니다.",
-          "kind": "method"
-        },
-        {
           "name": "fill(horizontal:vertical:)",
           "signature": "func fill(horizontal: Bool, vertical: Bool) -> Button",
           "summary": "버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.",
@@ -544,6 +538,12 @@
           "kind": "method"
         },
         {
+          "name": "itemDisabled(_:)",
+          "signature": "func itemDisabled((Int) -> Bool) -> Category",
+          "summary": "개별 카테고리 항목의 비활성 여부를 설정합니다.",
+          "kind": "method"
+        },
+        {
           "name": "size(_:)",
           "signature": "func size(Size) -> Category",
           "summary": "카테고리 아이템 크기를 설정합니다.",
@@ -609,12 +609,6 @@
           "kind": "method"
         },
         {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> Checkbox",
-          "summary": "컨트롤을 비활성화합니다.",
-          "kind": "method"
-        },
-        {
           "name": "label(_:fillWidth:)",
           "signature": "func label(String, fillWidth: Bool) -> Checkbox",
           "summary": "레이블 텍스트를 설정합니다.",
@@ -673,12 +667,6 @@
           "name": "bold(_:)",
           "signature": "func bold(Bool) -> Checkmark",
           "summary": "레이블을 볼드체로 설정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> Checkmark",
-          "summary": "컨트롤을 비활성화합니다.",
           "kind": "method"
         },
         {
@@ -748,12 +736,6 @@
           "name": "borderColor(_:)",
           "signature": "func borderColor(SwiftUI.Color) -> Chip",
           "summary": "칩의 테두리 색상을 설정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "disabled(_:)",
-          "signature": "func disabled(Bool) -> Chip",
-          "summary": "칩의 비활성화 여부를 설정합니다.",
           "kind": "method"
         },
         {
@@ -978,12 +960,6 @@
           "name": "backgroundColor(_:)",
           "signature": "func backgroundColor(SwiftUI.Color) -> FilterButton",
           "summary": "버튼의 배경색을 설정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "disabled(_:)",
-          "signature": "func disabled(Bool) -> FilterButton",
-          "summary": "버튼의 비활성화 여부를 설정합니다.",
           "kind": "method"
         },
         {
@@ -1244,12 +1220,6 @@
           "kind": "method"
         },
         {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> IconButton",
-          "summary": "버튼의 비활성화 여부를 설정합니다.",
-          "kind": "method"
-        },
-        {
           "name": "disableInteraction(_:)",
           "signature": "func disableInteraction(Bool) -> IconButton",
           "summary": "hover / press 인터랙션 효과만 차단합니다(탭 핸들러는 계속 동작).",
@@ -1449,12 +1419,6 @@
           "name": "description(_:)",
           "signature": "func description(String?) -> ListCell",
           "summary": "셀에 부가 설명을 추가합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> ListCell",
-          "summary": "셀의 비활성화 상태를 설정합니다.",
           "kind": "method"
         },
         {
@@ -2214,12 +2178,6 @@
           "kind": "method"
         },
         {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> Radio",
-          "summary": "컨트롤을 비활성화합니다.",
-          "kind": "method"
-        },
-        {
           "name": "label(_:fillWidth:)",
           "signature": "func label(String, fillWidth: Bool) -> Radio",
           "summary": "레이블 텍스트를 설정합니다.",
@@ -2346,12 +2304,6 @@
           "name": "autocorrectionDisabled(_:)",
           "signature": "func autocorrectionDisabled(Bool) -> SearchField",
           "summary": "자동수정과 맞춤법 검사를 비활성화할지 설정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> SearchField",
-          "summary": "검색 필드의 활성화 상태를 설정합니다.",
           "kind": "method"
         },
         {
@@ -2538,12 +2490,6 @@
         }
       ],
       "modifiers": [
-        {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> Select",
-          "summary": "활성화 여부를 조정합니다.",
-          "kind": "method"
-        },
         {
           "name": "leadingContent(_:)",
           "signature": "func leadingContent(LeadingContent?) -> Select",
@@ -2789,12 +2735,6 @@
       ],
       "modifiers": [
         {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> Slider",
-          "summary": "슬라이더의 활성화 상태를 설정합니다.",
-          "kind": "method"
-        },
-        {
           "name": "heading(_:)",
           "signature": "func heading(Bool) -> Slider",
           "summary": "슬라이더 상단에 제목을 표시할지 여부를 설정합니다.",
@@ -2886,14 +2826,7 @@
           "signature": "init(checked:size:onSelect:)"
         }
       ],
-      "modifiers": [
-        {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> Switch",
-          "summary": "컨트롤을 비활성화합니다.",
-          "kind": "method"
-        }
-      ],
+      "modifiers": [],
       "staticMembers": [],
       "nestedTypes": [
         {
@@ -2991,12 +2924,6 @@
           "name": "bottomResources(leading:trailing:leadingResourceSpacing:trailingResourceSpacing:)",
           "signature": "func bottomResources(leading: [Resource.Leading], trailing: [Resource.Trailing], leadingResourceSpacing: CGFloat?, trailingResourceSpacing: CGFloat?) -> TextArea",
           "summary": "텍스트 영역 하단에 표시할 UI 요소를 설정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> TextArea",
-          "summary": "텍스트 영역의 활성화 상태를 설정합니다.",
           "kind": "method"
         },
         {
@@ -3153,12 +3080,6 @@
           "kind": "method"
         },
         {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> TextButton",
-          "summary": "버튼을 비활성화 상태로 설정합니다.",
-          "kind": "method"
-        },
-        {
           "name": "fill(horizontal:vertical:)",
           "signature": "func fill(horizontal: Bool, vertical: Bool) -> TextButton",
           "summary": "버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.",
@@ -3228,12 +3149,6 @@
           "name": "backgroundColor(_:)",
           "signature": "func backgroundColor(SwiftUI.Color?) -> TextField",
           "summary": "텍스트 필드의 배경색을 설정합니다.",
-          "kind": "method"
-        },
-        {
-          "name": "disable(_:)",
-          "signature": "func disable(Bool) -> TextField",
-          "summary": "텍스트 필드의 활성화 상태를 설정합니다.",
           "kind": "method"
         },
         {
@@ -3629,7 +3544,7 @@
           "summary": "내비게이션 바의 오른쪽(trailing)에 위치하는 아이콘 버튼입니다.",
           "initializers": [
             {
-              "signature": "init(icon:disable:showPushBadge:action:)"
+              "signature": "init(icon:showPushBadge:action:)"
             }
           ],
           "instanceProperties": [
@@ -3647,7 +3562,7 @@
           "summary": "내비게이션 바의 오른쪽(trailing)에 위치하는 텍스트 버튼입니다.",
           "initializers": [
             {
-              "signature": "init(text:disable:action:)"
+              "signature": "init(text:action:)"
             }
           ],
           "instanceProperties": [


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2217

컴포넌트마다 따로 제공하던 `disable(_:)`을 없애고 SwiftUI 표준 `disabled(_:)`를 쓰도록 전환했습니다. 비활성 시각 효과는 각 컴포넌트가 `@Environment(\.isEnabled)`를 읽어 그대로 유지합니다.

`disable(_:)` 제거는 breaking change라 4.0.0 배포 전이 유일한 창입니다.

# 수정사항

### 제거한 공개 API

**`disable(_:)` 모디파이어 (14개)**
Button, IconButton, TextButton, Checkbox, Checkmark, Control(internal), Radio, SearchField, Select, Slider, TextArea, TextField, Switch, ListCell

**SwiftUI 이름을 가로채던 자체 `disabled(_:)` (2개)**
Chip, FilterButton — `-> Self`를 반환해 표준 `disabled()`를 완전히 가리고 있었습니다.

**파라미터로 받던 disable (3개)**
- `framedStyle(disabled:)` → 파라미터 제거
- `TopNavigation.TrailingIconButton(disable:)`, `TrailingTextButton(disable:)` → 제거

### 얻는 것

- 상위 컨테이너에 한 번 걸면 하위 컴포넌트까지 한꺼번에 적용됩니다.
- 히트 테스트 차단과 접근성 비활성 전달(VoiceOver "사용 안 함")이 따라옵니다. 기존 `allowsHitTesting` 방식은 보조 기술에 비활성 상태가 전달되지 않았습니다.

### 추가한 API

- `Category.itemDisabled(_:)` — `itemModifier`가 `(Int, Chip) -> Chip` 타입이라 `Chip.disabled()` 제거 시 개별 항목 비활성화 수단이 사라집니다. 기능 유실을 막기 위한 인덱스 기반 predicate입니다.

### 유지한 것 (별개 기능이라 그대로 둠)

- `TextField.TrailingButtonInfo.disable` — 필드는 켜둔 채 트레일링 버튼만 비활성화
- `IconButton.disableInteraction` — 탭 핸들러는 살리고 press 효과만 차단
- `Button.loading` — 로딩 중 탭 차단은 `allowsHitTesting(!loading)`으로 유지

### 범위에서 뺀 것

티켓의 "비활성 표현 통일"(Control 5곳·FramedStyle 1곳의 `opacity(0.43)` → 색 토큰)은 반영하지 않았습니다. 티켓 일정에 "디자인 쪽은 opacity로 관리하던 컴포넌트만 따로 확인할 예정"으로 되어 있어, 디자인 확인 후 후속 티켓으로 처리하는 게 맞다고 판단했습니다. 이번 PR은 시각 결과를 바꾸지 않고 API만 전환합니다.

### Blueprint

모든 프리뷰를 `.disabled()`로 마이그레이션하고 disabled 토글 옵션은 유지했습니다. 추가로:
- `TextFieldPreview`에 `trailingButtonDisable` 옵션 추가 — 필드 전체 비활성과 트레일링 버튼만 비활성을 구분해 확인
- `FramedStylePreview` 콘텐츠를 Text → Button으로 교체 — 테두리뿐 아니라 내부 콘텐츠까지 비활성화되는지 확인 가능 (Text는 `disabled(_:)`에 시각적으로 반응하지 않음)

# 미리보기

시뮬레이터(iPhone 17 Pro, iOS 26.5)에서 컴포넌트별로 확인했습니다.

| 컴포넌트 | 확인 내용 | 결과 |
|---|---|---|
| Select | chevron 색 / 비활성 시 메뉴 차단 | 색 동일, 본체·chevron 모두 탭 타겟 제거 |
| Button | `loading`과 `disabled` 각각 | loading → 핸들러 미실행, disabled → 탭 타겟 제거 |
| Slider | 중첩 뷰(Line·Thumb·Label) 환경값 전파 | 3종 모두 비활성 색 전환 |
| SearchField | 비활성 시 포커스 처리 | 포커스 해제 + `focused` 바인딩 false 동기화 |
| Control | 내부 `.disabled()` 제거 후 조상 의존 | 체크박스·체크마크·라디오·스위치 전부 흐려지고 탭 타겟 제거 |
| FramedStyle | 테두리 + 내부 콘텐츠 | opacity 43% 적용, 콘텐츠 버튼도 비활성·핸들러 미실행 |
| IconButton | `disable` vs `disableInteraction` | disableInteraction → 핸들러 실행됨, disable → 탭 타겟 제거 |
| Category | 신규 `itemDisabled(_:)` | 지정 항목만 흐려지고 탭 타겟 제거 |

Slider의 드래그 차단만 직접 테스트하지 못했습니다(스냅샷에 드래그 가능한 elementRef가 잡히지 않음). 같은 `.disabled()` 메커니즘이 위 컴포넌트들에서 제스처 차단으로 확인됐습니다.
