### PR TITLE
fix: .fixed 높이 팝업의 ActionArea 그래디언트 미표시 수정

### DIFF
--- a/Sources/Montage/1 Components/8 Presentation/Popup.swift
+++ b/Sources/Montage/1 Components/8 Presentation/Popup.swift
@@ -107,7 +107,9 @@ public struct Popup: View {
 
                 if let actionAreaModel {
                     ActionArea(variant: actionAreaModel.variant)
-                        .transparentBackground(scrolledToBottom)
+                        .transparentBackground(
+                            backgroundTransparency(for: actionAreaModel.backgroundTransparencyControl)
+                        )
                         .caption(actionAreaModel.caption)
                         .extra(actionAreaModel.extra, divider: actionAreaModel.extraDivider)
                         .padding(.bottom, 20)
@@ -220,15 +222,38 @@ public struct Popup: View {
         navigationHeight + contentHeight + actionAreaHeight
     }
 
+    /// 콘텐츠가 실제로 보이는 영역의 높이.
+    ///
+    /// `.fixed`는 지정한 높이를 그대로 쓰고, `.hug`는 콘텐츠 높이를 `popupMaxHeight`로 제한한 값이다.
+    /// 스크롤 가능 여부와 스크롤 끝 판정이 모두 이 값을 기준으로 계산된다.
+    private var viewportHeight: CGFloat {
+        if case .fixed(let height) = resize {
+            height
+        } else {
+            min(popupMaxHeight, popupContentHeight)
+        }
+    }
+
+    /// `contentOffset`은 최상단에서 0이고 아래로 스크롤할수록 음수가 되므로,
+    /// 스크롤 끝 오프셋은 `viewportHeight - popupContentHeight`가 된다.
     private var scrolledToBottom: Bool {
-        Int(contentOffset) <= Int(popupMaxHeight) - Int(popupContentHeight)
+        Int(contentOffset) <= Int(viewportHeight) - Int(popupContentHeight)
     }
 
     private var scrollable: Bool {
-        if case .fixed(let height) = resize {
-            popupContentHeight > height
+        popupContentHeight > viewportHeight
+    }
+
+    /// ActionArea의 배경 투명도.
+    ///
+    /// 모델이 `.manual`로 값을 지정하면 그 값을 존중하고, `.automatic`이면 스크롤이 끝에 닿았는지로 판단한다.
+    private func backgroundTransparency(
+        for control: ActionArea.BackgroundTransparencyControl
+    ) -> Bool {
+        if case .manual(let transparency) = control {
+            transparency
         } else {
-            popupContentHeight > popupMaxHeight
+            scrolledToBottom
         }
     }
 }

--- a/Sources/Montage/1 Components/8 Presentation/Popup.swift
+++ b/Sources/Montage/1 Components/8 Presentation/Popup.swift
@@ -234,10 +234,18 @@ public struct Popup: View {
         }
     }
 
+    /// 스크롤 끝 판정에 허용하는 오프셋 오차.
+    ///
+    /// @2x·@3x 화면에서 1pt는 2~3픽셀이므로, 1픽셀에도 못 미치는 레이아웃 오차로 판정이 뒤집히지 않도록 둔다.
+    private static let bottomOffsetTolerance: CGFloat = 0.5
+
     /// `contentOffset`은 최상단에서 0이고 아래로 스크롤할수록 음수가 되므로,
     /// 스크롤 끝 오프셋은 `viewportHeight - popupContentHeight`가 된다.
+    ///
+    /// 비교는 `CGFloat`로 직접 한다. `Int` 변환은 세 값의 소수부를 각각 버리기 때문에
+    /// 실제로 끝에 닿은 상황에서도 판정이 최대 1pt 어긋날 수 있다.
     private var scrolledToBottom: Bool {
-        Int(contentOffset) <= Int(viewportHeight) - Int(popupContentHeight)
+        contentOffset <= viewportHeight - popupContentHeight + Self.bottomOffsetTolerance
     }
 
     private var scrollable: Bool {


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2270

`resize: .fixed(height)`로 띄운 Popup에서 하단 ActionArea 그래디언트가 표시되지 않는 문제를 수정합니다.

원티드 iOS 앱(WRP-2230) 작업 중, 지원하기 화면의 "이력서 및 개인정보" 링크로 띄우는 개인정보 국외이전 안내 팝업(`.fixed(432)`)에서 제보로 발견했습니다. 콘텐츠가 길어 스크롤은 되는데 그래디언트만 없는 상태였습니다.

# 수정사항

## 1. `scrolledToBottom`이 실제 뷰포트 높이를 무시하던 문제

기존 판정식은 뷰포트가 `popupMaxHeight`라는 전제로 작성되어 있었습니다.

```swift
Int(contentOffset) <= Int(popupMaxHeight) - Int(popupContentHeight)
```

`popupMaxHeight`는 `min(760, UIScreen.main.bounds.height - 40)`이라 `.hug`에서는 우연히 맞지만, `.fixed(432)`처럼 뷰포트가 더 작은 경우엔 임계값이 328pt만큼 관대해집니다. `contentOffset`은 최상단에서 0이고 아래로 스크롤할수록 음수이므로, `popupContentHeight`가 760 미만이면 임계값이 양수가 되어 **팝업을 여는 순간 `scrolledToBottom == true`** 가 됩니다. 그 결과 `transparentBackground(true)` → `gradientOpacity = 0`으로 그래디언트가 처음부터 사라집니다.

`resize`에 따라 실제 뷰포트를 계산하는 `viewportHeight`를 도입하고, `scrolledToBottom`과 `scrollable`이 이 값을 쓰도록 정정했습니다.

```swift
private var viewportHeight: CGFloat {
    if case .fixed(let height) = resize {
        height
    } else {
        min(popupMaxHeight, popupContentHeight)
    }
}
```

`scrollable`은 기존 `.fixed`/`.hug` 분기를 `popupContentHeight > viewportHeight` 하나로 합쳤습니다. 두 경우 모두 결과가 기존과 동일합니다.

- `.fixed(h)`: `popupContentHeight > h` — 기존과 같음
- `.hug`, 콘텐츠가 `popupMaxHeight` 이하: `min`이 `popupContentHeight`가 되어 `false` — 기존도 `false`
- `.hug`, 콘텐츠가 `popupMaxHeight` 초과: `min`이 `popupMaxHeight`가 되어 `true` — 기존도 `true`

`scrolledToBottom`도 `.hug` 경로의 판정 결과는 기존과 같고, `.fixed`에서만 올바르게 바뀝니다.

## 2. `actionAreaModel.backgroundTransparencyControl`을 무시하던 문제

`ActionArea.Model`에 `backgroundTransparencyControl` 필드가 있는데도 Popup이 이를 읽지 않고 항상 `scrolledToBottom`으로 덮어쓰고 있었습니다. 소비처에서 `.manual(false)`로 명시해도 무시되어 우회할 방법이 없었습니다.

`.manual`이면 지정값을 존중하고 `.automatic`이면 기존처럼 `scrolledToBottom`을 쓰도록 했습니다.

```swift
private func backgroundTransparency(
    for control: ActionArea.BackgroundTransparencyControl
) -> Bool {
    if case .manual(let transparency) = control {
        transparency
    } else {
        scrolledToBottom
    }
}
```

현재 `actionAreaModel`에 `.manual`을 넘기는 소비처는 없어서(`.init(variant:)`의 기본값이 `.automatic`) 동작이 바뀌는 호출자는 없습니다.

## 변경 범위

- `Sources/Montage/1 Components/8 Presentation/Popup.swift` 1개 파일, `+30 -5`
- public API 시그니처 변경 없음 (private 멤버만 추가·수정)
- `make generate` 결과 문서/MCP 데이터 변경 없음 (private docstring은 DocC 출력에 미반영)

# 미리보기
작업 전|작업 후
---|---
<img width="368" height="800" alt="before-broken" src="https://github.com/user-attachments/assets/60b40eb3-1e6e-4bfb-8ec1-c349bb0d8cd5" />|<img width="368" height="800" alt="after-fixed" src="https://github.com/user-attachments/assets/5f059e23-e7a5-43ce-a95b-1f443fa6d9a6" />

원티드 iOS 앱(`feature/WRP-2230`)에서 Montage 서브모듈 핀만 바꿔가며 동일 경로를 실제로 비교했습니다. 대상 화면은 개인정보 국외이전 안내 팝업(`.fixed(432)`)입니다.

| | 하단 액션 영역 |
|---|---|
| **작업 전** (`ada6698c`) | 그래디언트 없음. "최종 합격 시: 입사일 기준 90일까지" 줄이 확인 버튼 배경에 그대로 잘려 끊긴다. 스크롤이 남아있다는 단서가 시각적으로 없다.|
| **작업 후** (이 PR) | "보유 및 이용기간" 항목부터 아래로 페이드된다. 스크롤 여지가 드러나고 의도한 그래디언트가 표시된다. |

검증 환경: Xcode 26.3 (17C529), iPhone 17 / iOS 26.3 시뮬레이터, Wanted Dev 구성. `Montage` 스킴 Debug 단독 빌드도 에러·경고 없이 성공했습니다.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
