### PR TITLE
fix: Popover 모디파이어가 앵커 뷰 크기를 키우던 문제 수정

### DIFF
--- a/Sources/Montage/1 Components/8 Presentation/Popover.swift
+++ b/Sources/Montage/1 Components/8 Presentation/Popover.swift
@@ -39,7 +39,6 @@ public enum Popover {
 
         func body(content: Content) -> some View {
             content
-                .padding(8)
                 .background {
                     popoverContent
                         .onGeometryChange(
@@ -157,7 +156,6 @@ public enum Popover {
 
         func body(content: Content) -> some View {
             content
-                .padding(8)
                 .background {
                     popoverContent()
                         .onGeometryChange(
@@ -176,10 +174,16 @@ public enum Popover {
     }
     
     struct PopoverPresenter<V: View>: UIViewControllerRepresentable {
+        /// 앵커와 팝오버 사이 간격.
+        ///
+        /// 앵커 뷰에 패딩을 주면 SwiftUI 레이아웃 크기까지 커지므로,
+        /// `sourceRect`를 바깥으로 넓혀 레이아웃에 영향 없이 간격만 확보한다.
+        private static var anchorSpacing: CGFloat { 8 }
+
         @Binding var isPresented: Bool
         let contentSize: CGSize
         let popoverContent: () -> V
-        
+
         func makeUIViewController(context: Context) -> UIViewController {
             let vc = UIViewController()
             vc.view.backgroundColor = .clear
@@ -211,11 +215,8 @@ public enum Popover {
             
             if let popover = contentVC.popoverPresentationController {
                 popover.sourceView = uiViewController.view
-                popover.sourceRect = CGRect(
-                    x: uiViewController.view.bounds.minX,
-                    y: uiViewController.view.bounds.minY,
-                    width: uiViewController.view.bounds.width,
-                    height: uiViewController.view.bounds.height)
+                popover.sourceRect = uiViewController.view.bounds
+                    .insetBy(dx: -Self.anchorSpacing, dy: -Self.anchorSpacing)
                 popover.permittedArrowDirections = [.any]
                 popover.popoverLayoutMargins = .init(top: 8, left: 8, bottom: 8, right: 8)
                 popover.popoverBackgroundViewClass = NoArrowPopoverBackground.self


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2316

`popoverNormal` / `popoverCustom` 모디파이어를 붙이면 팝오버를 띄우지 않아도 대상 뷰가 사방 8pt씩 총 16pt 커지는 문제를 수정했습니다. 사용처에서 HStack 높이가 밀리는 증상으로 제보됐습니다(안상훈님).

원인은 `Popover.NormalModifier` / `CustomModifier`의 `body`에서 `content`에 `.padding(8)`을 걸고 있던 부분입니다. 팝오버와 앵커 사이 간격을 만들려고 소스 뷰 자체를 키운 구현이라, 그 패딩이 SwiftUI 레이아웃에 그대로 반영됩니다.

# 수정사항
- `NormalModifier` / `CustomModifier`에서 `.padding(8)` 제거
- `PopoverPresenter`의 `sourceRect`를 `bounds.insetBy(dx: -8, dy: -8)`로 확장해 앵커와의 간격만 확보 (`sourceRect`는 `sourceView` 좌표계 기준이라 bounds를 벗어나도 정상 동작)
- 간격 값을 `anchorSpacing` 상수로 분리하고 의도를 주석으로 남김

부수 효과로 `.padding(8)` 때문에 앵커 버튼의 히트 영역이 16pt 넓어지던 문제도 함께 해소됩니다.

# 미리보기
Blueprint PopoverPreview에서 `Show Preview` 버튼 중심 y좌표로 측정했습니다. 팝오버 표시 위치와 앵커 간격은 normal / custom 모두 수정 전과 동일합니다.

작업 전|작업 후
---|---
버튼 중심 y = 208 (패딩 8pt만큼 아래로 밀림)|버튼 중심 y = 200
