### PR TITLE
fix: 검색 TopNavigation에서 검색어가 클리어 버튼(X)을 가리는 UI 버그 수정

### DIFF
--- a/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
+++ b/Sources/Montage/1 Components/6 Navigations/TopNavigation.swift
@@ -411,7 +411,7 @@ public struct TopNavigation: View {
                     .frame(width: 20, height: 20)
                     .padding(.horizontal, 2)
                 
-                ZStack(alignment: .trailing) {
+                HStack(alignment: .center, spacing: 8) {
                     SwiftUI.TextField(
                         "",
                         text: searchTerm,


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2425

검색 영역의 `TopNavigation`(variant `.search`)에서 검색어를 입력하면 텍스트가 클리어 버튼(X) 위를 덮어 버튼이 가려지는 문제를 수정했습니다.

원인은 `searchField` 내부에서 `TextField`와 클리어 버튼을 `ZStack(alignment: .trailing)`으로 겹쳐 배치한 것입니다. `TextField`가 `maxWidth: .infinity`로 전체 폭을 차지한 상태라 긴 검색어가 버튼 영역까지 그려졌습니다.

# 수정사항
- `searchField`의 `ZStack(alignment: .trailing)`을 `HStack(alignment: .center, spacing: 8)`으로 변경
- 클리어 버튼이 자기 폭을 차지하고 `TextField`가 남은 폭만 사용하도록 하여, 검색어가 길어져도 버튼 영역이 항상 확보됩니다
- 간격 8은 디자인 확인값입니다

# 미리보기
작업 전|작업 후
---|---
검색어가 길어지면 클리어 버튼(X)이 텍스트에 가려짐 (지라 티켓 스크린샷 참고)|긴 검색어 입력 시에도 클리어 버튼(X)이 온전히 노출

로컬 검증: Blueprint 앱 `TopNavigation Preview`에서 variant `search` 선택 후 긴 검색어를 입력해 클리어 버튼이 가려지지 않는 것을 확인했습니다.
