### PR TITLE
chore: 문서 변환기가 DocC 아카이브 없이 documentation을 지우지 않도록 가드 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Wanted One Design System",
   "main": "screenshot_script.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test scripts/tests/*.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/docc_to_md.js
+++ b/scripts/docc_to_md.js
@@ -6,6 +6,13 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const jsonCache = new Map();
 
+// 변환 결과 집계
+//
+// 변환기는 개별 파일의 실패를 로그로만 남기고 계속 진행하므로, 삭제한 documentation
+// 폴더를 되살릴지 판단하려면 성공/실패 건수를 따로 들고 있어야 한다.
+let conversionSuccessCount = 0;
+const conversionFailures = [];
+
 function readJsonCached(filePath) {
   if (jsonCache.has(filePath)) {
     return jsonCache.get(filePath);
@@ -473,8 +480,10 @@ function convertFile(jsonPath) {
     if (convertedSwiftFileMap[jsonFileBase] !== undefined) {
       convertedSwiftFileMap[jsonFileBase].isConverted = true;
     }
+    conversionSuccessCount += 1;
     console.log(`✓ 변환 완료: ${mdPath}`);
   } catch (error) {
+    conversionFailures.push({ jsonPath, message: error.message });
     console.error(`✗ 변환 실패: ${jsonPath}`, error.message);
   }
 }
@@ -964,32 +973,163 @@ const doccRoot = path.join(dataRoot, 'documentation');
 // 기존 documentation 폴더를 지우기 전에 반드시 확인한다.
 // xcodebuild docbuild가 실패하면 아카이브가 없거나 비어 있는데, 그 상태로 삭제를
 // 진행하면 문서를 복구하지 못한 채 삭제만 남는다.
-if (!fs.existsSync(doccRoot) || fs.readdirSync(doccRoot).length === 0) {
-  console.error('❌ DocC 아카이브를 찾을 수 없거나 비어 있습니다.');
+//
+// "폴더가 비어 있지 않다"만 보는 것으로는 부족하다. 빌드가 중간에 끊기면 디렉터리
+// 껍데기만 남거나 JSON이 잘린 채로 남는데, walk()는 .json만 골라 처리하면서 파싱
+// 오류를 로그로만 남기고 계속 진행한다. 그래서 심볼 JSON을 실제로 하나라도 읽을 수
+// 있는지까지 확인해야 삭제만 남는 상황을 막을 수 있다.
+function inspectDoccArchive(dir) {
+  let jsonCount = 0;
+  const stack = [dir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (error) {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!entry.name.endsWith('.json')) continue;
+
+      jsonCount += 1;
+      try {
+        const parsed = JSON.parse(fs.readFileSync(full, 'utf-8'));
+        if (parsed && parsed.metadata) {
+          return { parsable: true, jsonCount };
+        }
+      } catch (error) {
+        // 잘린 JSON은 넘기고 다른 파일로 검증을 계속한다
+      }
+    }
+  }
+
+  return { parsable: false, jsonCount };
+}
+
+const archive = inspectDoccArchive(doccRoot);
+if (!fs.existsSync(doccRoot) || !archive.parsable) {
+  console.error('❌ 사용할 수 있는 DocC 아카이브가 없습니다.');
   console.error(`   경로: ${doccRoot}`);
+  if (!fs.existsSync(doccRoot)) {
+    console.error('   원인: 아카이브 경로가 존재하지 않습니다.');
+  } else if (archive.jsonCount === 0) {
+    console.error('   원인: 아카이브에 심볼 JSON이 없습니다.');
+  } else {
+    console.error(`   원인: JSON ${archive.jsonCount}개를 모두 읽을 수 없습니다 (손상 또는 잘림).`);
+  }
   console.error('   기존 documentation 폴더를 보존한 채 중단합니다.');
   console.error('   먼저 `make docc`를 실행해 아카이브를 생성하세요.');
   process.exit(1);
 }
 
 // documentation 폴더 정리
+//
+// 삭제가 아니라 .build 아래로 옮겨 둔다. 변환이 실패하거나 결과물이 없으면
+// 그대로 되돌려서, 아카이브가 불완전할 때 문서만 사라지는 일이 없게 한다.
 const documentationDir = path.join(repoRoot, 'documentation');
-if (fs.existsSync(documentationDir)) {
-  console.log('🗑️  기존 documentation 폴더 삭제 중...');
-  fs.rmSync(documentationDir, { recursive: true, force: true });
-  console.log('✓ 삭제 완료\n');
+const backupDir = path.join(repoRoot, '.build/documentation-backup');
+let previousMarkdownCount = 0;
+let backedUp = false;
+
+function countMarkdownFiles(dir) {
+  let count = 0;
+  const stack = [dir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (error) {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) stack.push(path.join(current, entry.name));
+      else if (entry.name.endsWith('.md')) count += 1;
+    }
+  }
+
+  return count;
 }
 
-console.log('📂 Swift 타입-파일 매핑 시작...');
-walkSwiftFiles(montageSrcRoot);
-console.log(`✓ Swift 타입-파일 매핑 완료 (${Object.keys(swiftFileMap).length}개 타입)\n`);
+function abortAndRestore(reason, details = []) {
+  console.error('\n' + '='.repeat(50));
+  console.error(`❌ ${reason}`);
+  details.forEach((line) => console.error(`   ${line}`));
+  if (backedUp) {
+    fs.rmSync(documentationDir, { recursive: true, force: true });
+    fs.renameSync(backupDir, documentationDir);
+    console.error('   기존 documentation 폴더를 복원했습니다.');
+  }
+  console.error('='.repeat(50));
+  process.exit(1);
+}
 
-console.log('🔎 Extended Module 인덱싱 시작...');
-collectExtendedModuleMarkdown(dataRoot);
-console.log(`✓ 인덱싱 완료 (확장 심볼 ${Object.keys(extensionMdMap).length}개)\n`);
+if (fs.existsSync(documentationDir)) {
+  console.log('🗂️  기존 documentation 폴더 임시 보관 중...');
+  previousMarkdownCount = countMarkdownFiles(documentationDir);
+  fs.rmSync(backupDir, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(backupDir), { recursive: true });
+  fs.renameSync(documentationDir, backupDir);
+  backedUp = true;
+  console.log(`✓ 보관 완료 (md ${previousMarkdownCount}개)\n`);
+}
 
-console.log('🔄 JSON → Markdown 변환 시작...');
-walk(doccRoot);
+try {
+  console.log('📂 Swift 타입-파일 매핑 시작...');
+  walkSwiftFiles(montageSrcRoot);
+  console.log(`✓ Swift 타입-파일 매핑 완료 (${Object.keys(swiftFileMap).length}개 타입)\n`);
+
+  console.log('🔎 Extended Module 인덱싱 시작...');
+  collectExtendedModuleMarkdown(dataRoot);
+  console.log(`✓ 인덱싱 완료 (확장 심볼 ${Object.keys(extensionMdMap).length}개)\n`);
+
+  console.log('🔄 JSON → Markdown 변환 시작...');
+  walk(doccRoot);
+} catch (error) {
+  abortAndRestore('변환 중 오류가 발생해 중단했습니다.', [error.message]);
+}
+
+if (conversionFailures.length > 0) {
+  abortAndRestore(
+    `${conversionFailures.length}개 파일 변환에 실패했습니다.`,
+    conversionFailures.slice(0, 10).map(({ jsonPath, message }) => `${jsonPath}: ${message}`)
+  );
+}
+
+if (conversionSuccessCount === 0) {
+  abortAndRestore('변환된 문서가 없습니다.', ['아카이브에 변환 대상 심볼이 없습니다.']);
+}
+
+// 문서 급감 감지
+//
+// 파싱 가능한 JSON이 있고 실패도 없더라도 아카이브가 반쪽일 수 있다. 이때는 삭제만
+// 정상 완료된 것처럼 보이므로, 직전 문서 수 대비 절반 미만이면 중단한다.
+// 컴포넌트를 실제로 대량 정리한 경우에는 MONTAGE_ALLOW_DOC_SHRINK=1로 통과시킨다.
+const currentMarkdownCount = countMarkdownFiles(documentationDir);
+if (
+  previousMarkdownCount > 0 &&
+  currentMarkdownCount * 2 < previousMarkdownCount &&
+  process.env.MONTAGE_ALLOW_DOC_SHRINK !== '1'
+) {
+  abortAndRestore('생성된 문서 수가 직전보다 크게 줄었습니다.', [
+    `이전: ${previousMarkdownCount}개 → 현재: ${currentMarkdownCount}개`,
+    '아카이브가 불완전할 가능성이 높습니다. `make docc`를 다시 실행하세요.',
+    '의도한 대량 삭제라면 MONTAGE_ALLOW_DOC_SHRINK=1 을 지정하세요.',
+  ]);
+}
+
+if (backedUp) {
+  fs.rmSync(backupDir, { recursive: true, force: true });
+}
 
 Object.values(convertedSwiftFileMap).forEach((item) => {
   if (!item.isConverted) {
@@ -1001,5 +1141,5 @@ Object.values(convertedSwiftFileMap).forEach((item) => {
 });
 
 console.log('\n' + '='.repeat(50));
-console.log('✅ 모든 변환 작업 완료!');
+console.log(`✅ 모든 변환 작업 완료! (md ${currentMarkdownCount}개)`);
 console.log('='.repeat(50));

--- a/scripts/docc_to_md.js
+++ b/scripts/docc_to_md.js
@@ -953,6 +953,25 @@ console.log('='.repeat(50));
 console.log('📚 DocC → Markdown 변환 시작');
 console.log('='.repeat(50));
 
+const dataRoot = path.join(
+  repoRoot,
+  '.build/derived_data/Build/Products/Debug-iphoneos/Montage.doccarchive/data'
+);
+const doccRoot = path.join(dataRoot, 'documentation');
+
+// DocC 아카이브 검증
+//
+// 기존 documentation 폴더를 지우기 전에 반드시 확인한다.
+// xcodebuild docbuild가 실패하면 아카이브가 없거나 비어 있는데, 그 상태로 삭제를
+// 진행하면 문서를 복구하지 못한 채 삭제만 남는다.
+if (!fs.existsSync(doccRoot) || fs.readdirSync(doccRoot).length === 0) {
+  console.error('❌ DocC 아카이브를 찾을 수 없거나 비어 있습니다.');
+  console.error(`   경로: ${doccRoot}`);
+  console.error('   기존 documentation 폴더를 보존한 채 중단합니다.');
+  console.error('   먼저 `make docc`를 실행해 아카이브를 생성하세요.');
+  process.exit(1);
+}
+
 // documentation 폴더 정리
 const documentationDir = path.join(repoRoot, 'documentation');
 if (fs.existsSync(documentationDir)) {
@@ -964,12 +983,6 @@ if (fs.existsSync(documentationDir)) {
 console.log('📂 Swift 타입-파일 매핑 시작...');
 walkSwiftFiles(montageSrcRoot);
 console.log(`✓ Swift 타입-파일 매핑 완료 (${Object.keys(swiftFileMap).length}개 타입)\n`);
-
-const dataRoot = path.join(
-  repoRoot,
-  '.build/derived_data/Build/Products/Debug-iphoneos/Montage.doccarchive/data'
-);
-const doccRoot = path.join(dataRoot, 'documentation');
 
 console.log('🔎 Extended Module 인덱싱 시작...');
 collectExtendedModuleMarkdown(dataRoot);

--- a/scripts/docc_to_md.js
+++ b/scripts/docc_to_md.js
@@ -1064,11 +1064,17 @@ function abortAndRestore(reason, details = []) {
   console.error('\n' + '='.repeat(50));
   console.error(`❌ ${reason}`);
   details.forEach((line) => console.error(`   ${line}`));
+
+  // 중단 시점까지 만들어진 문서는 반쪽이므로 언제나 걷어낸다. 이걸 남겨 두면
+  // 백업이 없는 첫 실행에서 부분 결과가 그대로 커밋될 수 있다.
+  fs.rmSync(documentationDir, { recursive: true, force: true });
   if (backedUp) {
-    fs.rmSync(documentationDir, { recursive: true, force: true });
     fs.renameSync(backupDir, documentationDir);
     console.error('   기존 documentation 폴더를 복원했습니다.');
+  } else {
+    console.error('   생성 중이던 documentation 폴더를 삭제했습니다.');
   }
+
   console.error('='.repeat(50));
   process.exit(1);
 }

--- a/scripts/tests/docc_to_md.test.js
+++ b/scripts/tests/docc_to_md.test.js
@@ -1,0 +1,218 @@
+// docc_to_md.js 통합 테스트
+//
+// 변환기는 top-level에서 즉시 실행되는 스크립트라 함수 단위로 불러올 수 없다.
+// 그래서 임시 디렉터리에 가짜 레포(scripts/ + Sources/Montage/ + documentation/ +
+// .doccarchive)를 만들고 스크립트를 서브프로세스로 돌려, 종료 코드와 documentation
+// 폴더의 최종 상태를 확인한다.
+//
+// 실행: node --test scripts/tests/
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT_SOURCE = path.resolve(__dirname, '../docc_to_md.js');
+const ARCHIVE_REL = '.build/derived_data/Build/Products/Debug-iphoneos/Montage.doccarchive/data/documentation';
+const EXISTING_DOC_REL = 'documentation/components/feedback/toast/ios.md';
+const EXISTING_DOC_BODY = '# 기존 문서\n';
+
+// 변환에 성공하는 최소 심볼 JSON. Toast.swift 매핑을 타고
+// documentation/components/feedback/toast/ios.md 로 나간다.
+const VALID_SYMBOL_JSON = JSON.stringify({
+  metadata: { title: 'Toast', roleHeading: 'Structure' },
+  abstract: [{ type: 'text', text: '테스트용 심볼' }],
+  identifier: { url: 'doc://Montage/documentation/Montage/Toast' },
+  primaryContentSections: [],
+  topicSections: [],
+  references: {},
+});
+
+function writeFile(repoRoot, relPath, body) {
+  const full = path.join(repoRoot, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body, 'utf-8');
+}
+
+// 가짜 레포를 만든다. archiveFiles 가 비면 아카이브 디렉터리 자체를 만들지 않는다.
+function makeRepo({ archiveFiles = {}, existingDocs = true } = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'docc-md-test-'));
+
+  fs.mkdirSync(path.join(repoRoot, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT_SOURCE, path.join(repoRoot, 'scripts/docc_to_md.js'));
+
+  writeFile(
+    repoRoot,
+    'Sources/Montage/1 Components/7 Feedback/Toast.swift',
+    'public struct Toast {}\n'
+  );
+
+  if (existingDocs) {
+    writeFile(repoRoot, EXISTING_DOC_REL, EXISTING_DOC_BODY);
+  }
+
+  for (const [name, body] of Object.entries(archiveFiles)) {
+    writeFile(repoRoot, path.join(ARCHIVE_REL, 'montage', name), body);
+  }
+
+  return repoRoot;
+}
+
+function run(repoRoot, env = {}) {
+  const result = spawnSync(process.execPath, ['scripts/docc_to_md.js'], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout || ''}${result.stderr || ''}`,
+  };
+}
+
+function countMarkdown(dir) {
+  let count = 0;
+  const stack = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (error) {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) stack.push(path.join(current, entry.name));
+      else if (entry.name.endsWith('.md')) count += 1;
+    }
+  }
+  return count;
+}
+
+// 기존 문서가 손대지 않은 그대로 남아 있는지 확인한다.
+function assertDocsPreserved(repoRoot) {
+  const docPath = path.join(repoRoot, EXISTING_DOC_REL);
+  assert.ok(fs.existsSync(docPath), '기존 documentation 파일이 사라졌다');
+  assert.equal(fs.readFileSync(docPath, 'utf-8'), EXISTING_DOC_BODY);
+  assert.equal(countMarkdown(path.join(repoRoot, 'documentation')), 1);
+  assert.equal(
+    fs.existsSync(path.join(repoRoot, '.build/documentation-backup')),
+    false,
+    '백업 폴더가 남아 있다'
+  );
+}
+
+const repos = [];
+function trackRepo(repoRoot) {
+  repos.push(repoRoot);
+  return repoRoot;
+}
+
+test.after(() => {
+  repos.forEach((repoRoot) => fs.rmSync(repoRoot, { recursive: true, force: true }));
+});
+
+test('아카이브 경로가 없으면 기존 문서를 보존하고 중단한다', () => {
+  const repoRoot = trackRepo(makeRepo());
+  const { status, output } = run(repoRoot);
+
+  assert.equal(status, 1);
+  assert.match(output, /사용할 수 있는 DocC 아카이브가 없습니다/);
+  assert.match(output, /아카이브 경로가 존재하지 않습니다/);
+  assertDocsPreserved(repoRoot);
+});
+
+test('아카이브에 심볼 JSON이 없으면 기존 문서를 보존하고 중단한다', () => {
+  const repoRoot = trackRepo(makeRepo({ archiveFiles: { 'index.html': '<html></html>' } }));
+  const { status, output } = run(repoRoot);
+
+  assert.equal(status, 1);
+  assert.match(output, /아카이브에 심볼 JSON이 없습니다/);
+  assertDocsPreserved(repoRoot);
+});
+
+test('JSON이 전부 잘려 있으면 기존 문서를 보존하고 중단한다', () => {
+  const repoRoot = trackRepo(makeRepo({
+    archiveFiles: {
+      'toast.json': '{"metadata": {"title": "Toa',
+      'button.json': 'not json at all',
+    },
+  }));
+  const { status, output } = run(repoRoot);
+
+  assert.equal(status, 1);
+  assert.match(output, /JSON 2개를 모두 읽을 수 없습니다/);
+  assertDocsPreserved(repoRoot);
+});
+
+test('변환에 실패한 파일이 있으면 기존 문서를 복원하고 중단한다', () => {
+  const repoRoot = trackRepo(makeRepo({
+    archiveFiles: {
+      'toast.json': VALID_SYMBOL_JSON,
+      // title 이 없어 convertFile 내부에서 예외가 발생한다
+      'bad.json': JSON.stringify({ metadata: { roleHeading: 'Structure' } }),
+    },
+  }));
+  const { status, output } = run(repoRoot);
+
+  assert.equal(status, 1);
+  assert.match(output, /1개 파일 변환에 실패했습니다/);
+  assertDocsPreserved(repoRoot);
+});
+
+test('문서 수가 절반 미만으로 줄면 기존 문서를 복원하고 중단한다', () => {
+  const repoRoot = trackRepo(makeRepo({ archiveFiles: { 'toast.json': VALID_SYMBOL_JSON } }));
+  // 기존 문서를 4개로 늘려 1개 생성 결과가 급감으로 걸리게 만든다
+  ['a', 'b', 'c'].forEach((name) => {
+    writeFile(repoRoot, `documentation/components/feedback/${name}/ios.md`, '# 기존 문서\n');
+  });
+
+  const { status, output } = run(repoRoot);
+
+  assert.equal(status, 1);
+  assert.match(output, /생성된 문서 수가 직전보다 크게 줄었습니다/);
+  assert.match(output, /이전: 4개 → 현재: 1개/);
+  assert.equal(countMarkdown(path.join(repoRoot, 'documentation')), 4);
+  assert.equal(fs.existsSync(path.join(repoRoot, '.build/documentation-backup')), false);
+});
+
+test('MONTAGE_ALLOW_DOC_SHRINK=1 이면 급감을 허용한다', () => {
+  const repoRoot = trackRepo(makeRepo({ archiveFiles: { 'toast.json': VALID_SYMBOL_JSON } }));
+  ['a', 'b', 'c'].forEach((name) => {
+    writeFile(repoRoot, `documentation/components/feedback/${name}/ios.md`, '# 기존 문서\n');
+  });
+
+  const { status, output } = run(repoRoot, { MONTAGE_ALLOW_DOC_SHRINK: '1' });
+
+  assert.equal(status, 0);
+  assert.match(output, /모든 변환 작업 완료/);
+  assert.equal(countMarkdown(path.join(repoRoot, 'documentation')), 1);
+});
+
+test('정상 아카이브는 문서를 새로 생성하고 백업을 남기지 않는다', () => {
+  const repoRoot = trackRepo(makeRepo({ archiveFiles: { 'toast.json': VALID_SYMBOL_JSON } }));
+  const { status, output } = run(repoRoot);
+
+  assert.equal(status, 0);
+  assert.match(output, /모든 변환 작업 완료/);
+
+  const docPath = path.join(repoRoot, EXISTING_DOC_REL);
+  assert.ok(fs.existsSync(docPath));
+  // 기존 내용이 변환 결과로 교체됐다
+  assert.notEqual(fs.readFileSync(docPath, 'utf-8'), EXISTING_DOC_BODY);
+  assert.equal(countMarkdown(path.join(repoRoot, 'documentation')), 1);
+  assert.equal(fs.existsSync(path.join(repoRoot, '.build/documentation-backup')), false);
+});
+
+test('기존 documentation 폴더가 없어도 정상 변환한다', () => {
+  const repoRoot = trackRepo(makeRepo({
+    archiveFiles: { 'toast.json': VALID_SYMBOL_JSON },
+    existingDocs: false,
+  }));
+  const { status } = run(repoRoot);
+
+  assert.equal(status, 0);
+  assert.equal(countMarkdown(path.join(repoRoot, 'documentation')), 1);
+});

--- a/scripts/tests/docc_to_md.test.js
+++ b/scripts/tests/docc_to_md.test.js
@@ -206,6 +206,25 @@ test('정상 아카이브는 문서를 새로 생성하고 백업을 남기지 �
   assert.equal(fs.existsSync(path.join(repoRoot, '.build/documentation-backup')), false);
 });
 
+test('백업이 없는 상태에서 변환이 실패하면 부분 생성물을 남기지 않는다', () => {
+  const repoRoot = trackRepo(makeRepo({
+    archiveFiles: {
+      'toast.json': VALID_SYMBOL_JSON,
+      'bad.json': JSON.stringify({ metadata: { roleHeading: 'Structure' } }),
+    },
+    existingDocs: false,
+  }));
+  const { status, output } = run(repoRoot);
+
+  assert.equal(status, 1);
+  assert.match(output, /1개 파일 변환에 실패했습니다/);
+  assert.match(output, /생성 중이던 documentation 폴더를 삭제했습니다/);
+  // toast.json 은 변환에 성공했지만 그 결과물이 남아 있으면 안 된다
+  assert.equal(countMarkdown(path.join(repoRoot, 'documentation')), 0);
+  assert.equal(fs.existsSync(path.join(repoRoot, 'documentation')), false);
+  assert.equal(fs.existsSync(path.join(repoRoot, '.build/documentation-backup')), false);
+});
+
 test('기존 documentation 폴더가 없어도 정상 변환한다', () => {
   const repoRoot = trackRepo(makeRepo({
     archiveFiles: { 'toast.json': VALID_SYMBOL_JSON },

--- a/scripts/tests/docc_to_md.test.js
+++ b/scripts/tests/docc_to_md.test.js
@@ -61,10 +61,17 @@ function makeRepo({ archiveFiles = {}, existingDocs = true } = {}) {
 }
 
 function run(repoRoot, env = {}) {
+  // 실행 셸에 MONTAGE_ALLOW_DOC_SHRINK 가 남아 있으면 급감 감지 테스트가 아무 검증도
+  // 하지 못한 채 통과한다. 테스트가 명시로 넘긴 경우만 살리고 나머지는 지운다.
+  const childEnv = { ...process.env, ...env };
+  if (!Object.prototype.hasOwnProperty.call(env, 'MONTAGE_ALLOW_DOC_SHRINK')) {
+    delete childEnv.MONTAGE_ALLOW_DOC_SHRINK;
+  }
+
   const result = spawnSync(process.execPath, ['scripts/docc_to_md.js'], {
     cwd: repoRoot,
     encoding: 'utf-8',
-    env: { ...process.env, ...env },
+    env: childEnv,
   });
   return {
     status: result.status,


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2540

`scripts/docc_to_md.js`가 DocC 아카이브 유무를 확인하기 전에 `documentation/` 폴더를 먼저 지우고 있었습니다. `xcodebuild docbuild`가 실패하면 아카이브가 없는데, 그 상태에서 삭제가 먼저 일어나고 이후 아카이브를 읽으려다 ENOENT로 죽기 때문에 문서가 복구되지 않은 채 삭제만 남습니다.

실제로 Xcode 27 베타로 문서 생성을 시도했을 때 이 경로를 밟아 문서 65개 파일 20,069줄이 삭제됐습니다.

# 수정사항

아카이브 검증을 삭제보다 앞으로 옮기고, 유효하지 않으면 아무것도 지우지 않고 `exit 1`로 중단합니다.

- `dataRoot` / `doccRoot` 경로 계산을 삭제 로직 앞으로 이동
- `doccRoot`가 없거나 비어 있으면 안내 메시지 출력 후 `process.exit(1)`
- 이때 `documentation/`은 손대지 않음

`make`는 `set -o pipefail`과 `if !` 가드로 이미 막고 있지만, 스크립트를 직접 실행하거나 파이프로 exit code가 가려지면 방어가 없었습니다. 이제 스크립트 자체가 막습니다.

# 검증

| 케이스 | 결과 |
|---|---|
| 아카이브 없음 | 문서 58개 그대로 보존, exit 1 |
| 정상 아카이브 | `generate_docc.sh` exit 0, 변환 완료, `documentation/` diff 0 |

정상 흐름에 회귀가 없음을 확인했습니다. 재생성 결과가 기존과 완전히 동일합니다.

# 미리보기
스크립트 동작 변경이라 UI 스크린샷은 해당 없습니다.

아카이브가 없을 때 출력:

```
❌ DocC 아카이브를 찾을 수 없거나 비어 있습니다.
   경로: .../Montage.doccarchive/data/documentation
   기존 documentation 폴더를 보존한 채 중단합니다.
   먼저 `make docc`를 실행해 아카이브를 생성하세요.
```