### PR TITLE
refactor: fill(horizontal:vertical:) 제거하고 fillWidth로 일원화

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -519,6 +519,20 @@ TopNavigation.LeadingButton(TopNavigation.Resource.Leading.back(action: { dismis
 
 ### 6. 단순 API 치환
 
+#### Button · TextButton
+
+`fill(horizontal:vertical:)`이 **제거**되고 `fillWidth(_:)`로 대체됐습니다. 유예 없이 4.0에서 바로 빠지니 호출부를 모두 옮기세요.
+
+| 3.x | 4.0 |
+|---|---|
+| `.fill(horizontal: true)` | `.fillWidth(true)` |
+| `.fill(horizontal: true, vertical: false)` | `.fillWidth(true)` |
+| `.fill(horizontal: true, vertical: true)` | `.fillWidth(true)` |
+
+`vertical`은 3.x에서도 이미 아무 동작을 하지 않았습니다. 시그니처에만 있고 함수 본문에서 쓰이지 않아, `vertical: true`로 부르던 곳도 세로 채움이 일어난 적이 없습니다. 세 경우 모두 렌더링이 그대로라 기계적으로 치환해도 됩니다.
+
+`TextButton`은 3.x에 `fillWidth(_:)`가 없었습니다. 4.0에서 `Button`과 같은 모양으로 새로 생겼습니다.
+
 #### IconButton
 
 `normal` variant의 사이즈가 `Int`에서 `NormalSize` 열거형으로 바뀌었습니다.

--- a/Sources/Blueprint/Sources/Scene/Previews/TextButtonPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextButtonPreview.swift
@@ -23,6 +23,7 @@ struct TextButtonPreview: View {
     @State private var fontVariant = false
     @State private var fontWeight = false
     @State private var loading = false
+    @State private var fillWidth = false
 
     private let colors: [TextButton.Color] = [.primary, .assistive]
     private let sizes: [TextButton.Size] = [.small, .medium]
@@ -44,6 +45,7 @@ struct TextButtonPreview: View {
             .fontVariant(fontVariant ? .heading1 : nil)
             .fontWeight(fontWeight ? .regular : nil)
             .loading(loading)
+            .fillWidth(fillWidth)
             .padding(.vertical, 4)
             .disabled(disable)
         } options: {
@@ -52,6 +54,7 @@ struct TextButtonPreview: View {
             HStack {
                 ToggleOption("disable", isOn: $disable)
                 ToggleOption("loading", isOn: $loading)
+                ToggleOption("fillWidth", isOn: $fillWidth)
             }
             HStack {
                 ToggleOption("leadingIcon", isOn: $leadingIcon)

--- a/Sources/Montage/1 Components/2 Actions/ActionArea.swift
+++ b/Sources/Montage/1 Components/2 Actions/ActionArea.swift
@@ -232,7 +232,7 @@ extension ActionArea {
         ///
         /// - Parameter custom: 커스텀 버튼 뷰를 생성하는 클로저
         /// - Returns: 커스텀 뷰가 포함된 ButtonInfo 인스턴스
-        /// - Note: 버튼 크기가 가능한 한 최대 크기가 되도록 하려면 fill(horizontal:vertical:) 모디파이어를 사용하세요.
+        /// - Note: 버튼 크기가 가능한 한 최대 크기가 되도록 하려면 fillWidth(_:) 모디파이어를 사용하세요.
         public static func custom<V: View>(@ViewBuilder _ custom: @escaping () -> V) -> Self {
             var zelf = self.init(text: "", action: {})
             zelf.custom = { AnyView(custom()) }
@@ -392,7 +392,7 @@ extension ActionArea {
                     text: buttonInfo.text,
                     handler: buttonInfo.action
                 )
-                .fill(horizontal: true, vertical: false)
+                .fillWidth(true)
             }
         }
 
@@ -405,7 +405,7 @@ extension ActionArea {
                     text: buttonInfo.text,
                     handler: buttonInfo.action
                 )
-                .fill(horizontal: true, vertical: false)
+                .fillWidth(true)
             }
         }
 
@@ -419,7 +419,7 @@ extension ActionArea {
                     handler: buttonInfo.action
                 )
                 .if(fillWidth) {
-                    $0.fill(horizontal: true, vertical: false)
+                    $0.fillWidth(true)
                 }
             }
         }

--- a/Sources/Montage/1 Components/2 Actions/Button.swift
+++ b/Sources/Montage/1 Components/2 Actions/Button.swift
@@ -284,32 +284,9 @@ public struct Button: View {
         return zelf
     }
     
-    /// 버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.
+    /// 버튼이 수평으로 공간을 채우도록 설정합니다.
     ///
     /// 버튼의 크기를 조절하여 컨테이너 뷰의 공간을 효율적으로 활용할 때 사용합니다.
-    ///
-    /// ```swift
-    /// // 부모 뷰의 가로 너비를 모두 채우는 버튼
-    /// Button(text: "전체 확인")
-    ///     .fill(horizontal: true)
-    ///
-    /// // 가로, 세로 모두 채우는 버튼
-    /// Button(variant: .outlined, text: "영역 전체 채우기")
-    ///     .fill(horizontal: true, vertical: true)
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - fillHorizontal: 수평 방향 채우기 여부, 생략하면 기본값으로 `false` 적용
-    ///   - fillVertical: 수직 방향 채우기 여부, 생략하면 기본값으로 `false` 적용
-    /// - Returns: 수정된 버튼 인스턴스
-    @available(*, deprecated, message: "`fillWidth(_:Bool)`을 사용하세요. 참고: `vertical` 파라미터는 더 이상 지원되지 않습니다.")
-    public func fill(horizontal fillHorizontal: Bool = false, vertical fillVertical: Bool = false) -> Self {
-        var zelf = self
-        zelf.fillWidth = fillHorizontal
-        return zelf
-    }
-    
-    /// 버튼이 수평으로 공간을 채우도록 설정합니다.
     ///
     /// ```swift
     /// // 부모 뷰의 가로 너비를 모두 채우는 버튼

--- a/Sources/Montage/1 Components/2 Actions/TextButton.swift
+++ b/Sources/Montage/1 Components/2 Actions/TextButton.swift
@@ -146,28 +146,21 @@ public struct TextButton: View {
         .init(base: base.loading(loading))
     }
 
-    /// 버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.
+    /// 버튼이 수평으로 공간을 채우도록 설정합니다.
     ///
     /// 버튼의 크기를 조절하여 컨테이너 뷰의 공간을 효율적으로 활용할 때 사용합니다.
     ///
     /// ```swift
     /// // 부모 뷰의 가로 너비를 모두 채우는 버튼
     /// TextButton(text: "전체 확인")
-    ///     .fill(horizontal: true)
-    ///
-    /// // 가로, 세로 모두 채우는 버튼
-    /// TextButton(text: "영역 전체 채우기")
-    ///     .fill(horizontal: true, vertical: true)
+    ///     .fillWidth(true)
     /// ```
     ///
     /// - Parameters:
-    ///   - fillHorizontal: 수평 방향 채우기 여부, 생략하면 기본값으로 `false` 적용
-    ///   - fillVertical: 수직 방향 채우기 여부, 생략하면 기본값으로 `false` 적용
+    ///   - fillWidth: 채우기 여부, 생략하면 기본값으로 `true` 적용
     /// - Returns: 수정된 버튼 인스턴스
-    public func fill(horizontal fillHorizontal: Bool = false, vertical fillVertical: Bool = false)
-        -> Self
-    {
-        .init(base: base.fill(horizontal: fillHorizontal, vertical: fillVertical))
+    public func fillWidth(_ fillWidth: Bool = true) -> Self {
+        .init(base: base.fillWidth(fillWidth))
     }
 
     /// 뷰의 내용과 동작을 정의합니다.

--- a/documentation/components/actions/actionarea/ios.md
+++ b/documentation/components/actions/actionarea/ios.md
@@ -90,7 +90,7 @@ ActionArea에 표시될 버튼 정보를 정의하는 구조체입니다.
 - **Discussion**
   > **Note**
   >
-  > 버튼 크기가 가능한 한 최대 크기가 되도록 하려면 fill(horizontal:vertical:) 모디파이어를 사용하세요.
+  > 버튼 크기가 가능한 한 최대 크기가 되도록 하려면 fillWidth(_:) 모디파이어를 사용하세요.
 
 </details>
 

--- a/documentation/components/actions/button/ios.md
+++ b/documentation/components/actions/button/ios.md
@@ -184,42 +184,6 @@ Button(text: "저장")
 </details>
 <details>
 
-<summary>~~``func fill(horizontal: Bool, vertical: Bool) -> Button``~~</summary>
-
-
-버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.
-> **Deprecated**
->
-> `fillWidth(_:Bool)`을 사용하세요. 참고: `vertical` 파라미터는 더 이상 지원되지 않습니다.
-
-
-- **Parameters**
-
-  | Parameter | Description |
-  | --- | --- |
-  | `fillHorizontal` | 수평 방향 채우기 여부, 생략하면 기본값으로 `false` 적용 |
-  | `fillVertical` | 수직 방향 채우기 여부, 생략하면 기본값으로 `false` 적용 |
-
-- **Return Value**
-
-  수정된 버튼 인스턴스
-- **Discussion**
-
-  버튼의 크기를 조절하여 컨테이너 뷰의 공간을 효율적으로 활용할 때 사용합니다.
-
-  ```swift
-  // 부모 뷰의 가로 너비를 모두 채우는 버튼
-  Button(text: "전체 확인")
-      .fill(horizontal: true)
-  
-  // 가로, 세로 모두 채우는 버튼
-  Button(variant: .outlined, text: "영역 전체 채우기")
-      .fill(horizontal: true, vertical: true)
-  ```
-
-</details>
-<details>
-
 <summary>``func fillWidth(Bool) -> Button``</summary>
 
 
@@ -235,6 +199,8 @@ Button(text: "저장")
 
   수정된 버튼 인스턴스
 - **Discussion**
+
+  버튼의 크기를 조절하여 컨테이너 뷰의 공간을 효율적으로 활용할 때 사용합니다.
 
   ```swift
   // 부모 뷰의 가로 너비를 모두 채우는 버튼

--- a/documentation/components/actions/textbutton/ios.md
+++ b/documentation/components/actions/textbutton/ios.md
@@ -86,17 +86,16 @@ Text 스타일의 버튼을 생성합니다.
 </details>
 <details>
 
-<summary>``func fill(horizontal: Bool, vertical: Bool) -> TextButton``</summary>
+<summary>``func fillWidth(Bool) -> TextButton``</summary>
 
 
-버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.
+버튼이 수평으로 공간을 채우도록 설정합니다.
 
 - **Parameters**
 
   | Parameter | Description |
   | --- | --- |
-  | `fillHorizontal` | 수평 방향 채우기 여부, 생략하면 기본값으로 `false` 적용 |
-  | `fillVertical` | 수직 방향 채우기 여부, 생략하면 기본값으로 `false` 적용 |
+  | `fillWidth` | 채우기 여부, 생략하면 기본값으로 `true` 적용 |
 
 - **Return Value**
 
@@ -108,11 +107,7 @@ Text 스타일의 버튼을 생성합니다.
   ```swift
   // 부모 뷰의 가로 너비를 모두 채우는 버튼
   TextButton(text: "전체 확인")
-      .fill(horizontal: true)
-  
-  // 가로, 세로 모두 채우는 버튼
-  TextButton(text: "영역 전체 채우기")
-      .fill(horizontal: true, vertical: true)
+      .fillWidth(true)
   ```
 
 </details>

--- a/packages/montage-mcp/data/components.json
+++ b/packages/montage-mcp/data/components.json
@@ -375,12 +375,6 @@
           "kind": "method"
         },
         {
-          "name": "fill(horizontal:vertical:)",
-          "signature": "func fill(horizontal: Bool, vertical: Bool) -> Button",
-          "summary": "버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.",
-          "kind": "method"
-        },
-        {
           "name": "fillWidth(_:)",
           "signature": "func fillWidth(Bool) -> Button",
           "summary": "버튼이 수평으로 공간을 채우도록 설정합니다.",
@@ -3139,9 +3133,9 @@
           "kind": "method"
         },
         {
-          "name": "fill(horizontal:vertical:)",
-          "signature": "func fill(horizontal: Bool, vertical: Bool) -> TextButton",
-          "summary": "버튼이 수평 또는 수직 방향으로 공간을 채우도록 설정합니다.",
+          "name": "fillWidth(_:)",
+          "signature": "func fillWidth(Bool) -> TextButton",
+          "summary": "버튼이 수평으로 공간을 채우도록 설정합니다.",
           "kind": "method"
         },
         {


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2503

`Button`·`TextButton`의 `fill(horizontal:vertical:)`을 제거하고 `fillWidth(_:)`로 일원화했습니다. 4.0 메이저이므로 deprecated 유예를 두지 않고 바로 걷어냈습니다. 이 PR로 4.0의 deprecated public API가 0개가 됩니다.

## ⚠️ 머지 순서

상위 앱 PR [wanteddev/ios#8729](https://github.com/wanteddev/ios/pull/8729)가 **먼저 머지돼야 합니다.** 앱에 `fill(horizontal:)` 호출이 122곳 있었고 그 PR에서 `fillWidth(_:)`로 옮겼습니다. 순서가 뒤바뀌면 상위 앱이 컴파일되지 않습니다.

# 수정사항

## `fill(horizontal:vertical:)` 제거

| 컴포넌트 | 변경 전 | 변경 후 |
|---|---|---|
| `Button` | `fill(horizontal:vertical:)` (deprecated) + `fillWidth(_:)` | `fillWidth(_:)` |
| `TextButton` | `fill(horizontal:vertical:)` | `fillWidth(_:)` |

`TextButton`에는 `fillWidth(_:)`가 없었습니다. 이번에 `Button`과 같은 모양으로 새로 넣었습니다. 3.x에도 없던 API라 마이그레이션 문서에 따로 적어 뒀습니다.

`vertical` 파라미터는 3.x에서도 이미 아무 동작을 하지 않았습니다. `fillVertical`이 시그니처에만 있고 함수 본문에서 참조되지 않아, `vertical: true`로 부르던 곳도 세로 채움이 일어난 적이 없습니다. 그래서 제거해도 렌더링이 달라지지 않습니다.

## 내부 호출부 정리

`ActionArea`가 자기 deprecated API를 내부에서 부르고 있었습니다. 3곳을 `fillWidth(true)`로 옮겼습니다.

`ButtonInfo.custom(_:)`의 Note가 없어질 API를 안내하고 있어 함께 고쳤습니다.

```diff
- /// - Note: 버튼 크기가 가능한 한 최대 크기가 되도록 하려면 fill(horizontal:vertical:) 모디파이어를 사용하세요.
+ /// - Note: 버튼 크기가 가능한 한 최대 크기가 되도록 하려면 fillWidth(_:) 모디파이어를 사용하세요.
```

## 문서

`MIGRATION.md` 6절에 `Button · TextButton` 항목을 새로 넣었습니다. 기존에는 `fill` → `fillWidth` 안내가 아예 없었습니다.

`TextButtonPreview`에 `fillWidth` 토글을 추가했습니다.

# 미리보기

렌더링 변화 없음. `vertical`이 원래 동작하지 않던 파라미터라 제거해도 결과가 같고, `fillWidth`는 기존 `horizontal` 값을 그대로 이어받습니다.

## 검증

- `Blueprint` 스킴 빌드 성공, 에러 0건 / deprecated 경고 0건
- 레포 전체에 `fill(horizontal:` 잔여 0건 (docstring 포함)
- `make` 실행해 DocC 문서와 MCP 데이터 갱신 반영
- 상위 앱: `Wanted` 스킴 Dev 설정 빌드 성공, 에러 0건 (#8729)
