### PR TITLE
docs: 4.0 마이그레이션 가이드를 v3.15.2 기준으로 재작성

### DIFF
--- a/MIGRATION.ko.md
+++ b/MIGRATION.ko.md
@@ -4,44 +4,34 @@
 
 메이저 버전 업그레이드에 필요한 변경 사항을 정리합니다. 최신 버전이 위에 옵니다.
 
-각 항목은 **기계적 치환으로 끝나는 것**과 **구조를 다시 짜야 하는 것**, **시각 결과가 달라지는 것**으로 나눠 표시했습니다. 컴파일 에러만 없앤 뒤 화면을 확인하지 않으면 놓치는 항목이 있어서, 마지막 [시각 결과가 달라지는 변경](#시각-결과가-달라지는-변경) 절을 반드시 읽어주세요.
+**이 문서는 브레이킹 체인지만 다룹니다.** 새로 생긴 컴포넌트와 모디파이어는 [추가된 API](#추가된-api)에 이름만 모아뒀고, 자세한 내용은 [릴리즈 노트](https://github.com/wanteddev/montage-ios/releases)에 있습니다.
+
+각 메이저 절의 기준선은 **직전 메이저의 마지막 릴리즈 태그**입니다. 개발 중에 생겼다가 없어진 API는 이전 버전 사용처가 겪을 일이 없으므로 적지 않습니다.
 
 ---
 
 ## 4.0
 
-> **진행 중**입니다. `release/4.0.0`에 항목이 추가되면 이 문서를 갱신합니다.
+**기준선: v3.15.2 → 4.0.0**
 
-4.0은 네 축으로 브레이킹 체인지가 들어갑니다.
+브레이킹 체인지가 네 갈래입니다. 위에서 아래 순서로 진행하면 컴파일 에러가 가장 빨리 줄어듭니다.
 
-1. **컬러 시맨틱 토큰 재편** - 토큰 이름이 `용도 + 역할 + 변형` 규칙으로 통일됐습니다. 값은 대부분 그대로고 이름만 바뀝니다.
-2. **슬롯 기반 API 전환** - 고정 파라미터(`leadingImage:`)와 `Model` 구조체 대신 호출부가 뷰를 직접 넣습니다.
-3. **입력 컴포넌트 구조 분리** - 라벨·상태 메시지·글자수가 `TextField`/`TextArea` 안쪽에서 `FormControl` 슬롯으로 나왔습니다.
-4. **컴포넌트 스펙 리프레시** - radius·타이포·패딩·아이콘 크기가 디자인 스펙에 맞춰 재조정됐습니다. **API가 그대로여서 컴파일 에러가 나지 않는 유일한 축입니다.**
-
-### 작업 순서
-
-| 순서 | 작업 | 성격 | 시각 변화 |
+| 순서 | 절 | 성격 | 하는 일 |
 |---|---|---|---|
-| 1 | [컬러 시맨틱 토큰](#1-컬러-시맨틱-토큰) | 기계적 치환 | 없음 |
-| 2 | [Spacing · Opacity 토큰](#2-spacing--opacity-토큰) | 기계적 치환 | 없음 |
-| 3 | [전역 모디파이어](#3-전역-모디파이어) | 기계적 치환 | 없음 |
-| 4 | [입력 컴포넌트 → FormControl](#4-입력-컴포넌트--formcontrol) | 구조 재작성 | **있음** |
-| 5 | [슬롯 API 전환](#5-슬롯-api-전환) | 구조 재작성 | 대부분 없음 |
-| 6 | [단순 API 치환](#6-단순-api-치환) | 기계적 치환 | 일부 있음 |
-| 7 | [제거된 UIKit 래퍼](#7-제거된-uikit-래퍼) | 구조 재작성 | 없음 |
-| 8 | [컴포넌트 스펙 리프레시](#8-컴포넌트-스펙-리프레시) | 화면 확인 | **있음** |
-| 9 | [시각 결과가 달라지는 변경 점검](#시각-결과가-달라지는-변경) | 화면 확인 | **있음** |
+| 1 | [이름이 바뀐 것](#1-이름이-바뀐-것) | 기계적 치환 | `sed`로 끝납니다 |
+| 2 | [없어져서 다시 짜야 하는 것](#2-없어져서-다시-짜야-하는-것) | 구조 재작성 | 대체 API로 옮깁니다 |
+| 3 | [대응이 없는 것](#3-대응이-없는-것) | 직접 선택 | 사용처가 판단해야 합니다 |
+| 4 | [화면이 달라지는 것](#4-화면이-달라지는-것) | 화면 확인 | **컴파일 에러가 나지 않습니다** |
 
-**8번을 건너뛰지 마세요.** API가 그대로인데 값만 바뀐 항목이라 컴파일 에러가 나지 않습니다. 치환 작업이 끝나고 빌드가 통과했다고 마이그레이션이 끝난 게 아닙니다.
-
-토큰 치환(1~3)을 먼저 끝내면 컴파일 에러가 크게 줄어 나머지 작업을 보기 쉬워집니다.
+**4번을 건너뛰지 마세요.** API는 그대로인데 값만 바뀐 항목이라 빌드가 통과해도 화면이 달라집니다. 치환이 끝났다고 마이그레이션이 끝난 게 아닙니다.
 
 ---
 
-### 1. 컬러 시맨틱 토큰
+## 1. 이름이 바뀐 것
 
-`Color.semantic(_:)` / `UIColor.semantic(_:)`에 넘기는 토큰 이름이 전부 바뀝니다. 아래 표의 대응은 **RedOrange 계열 2건을 빼면 값이 같아서** 렌더 결과가 달라지지 않습니다. RedOrange는 4.0에 대응 토큰이 없어 직접 골라야 하고 색이 바뀝니다.
+### 1.1 컬러 시맨틱 토큰
+
+`Color.semantic(_:)` / `UIColor.semantic(_:)`에 넘기는 토큰 이름이 전부 바뀝니다. 대부분은 이름만 바뀌지만 **14건은 색값도 함께 바뀝니다.** [값이 함께 바뀌는 토큰](#값이-함께-바뀌는-토큰)을 꼭 확인해주세요.
 
 #### 새 이름 규칙
 
@@ -50,7 +40,7 @@
 
 용도   foreground  텍스트·아이콘
        background  화면 바탕
-       surface     화면 위에 올라가는 면(카드·필드·버튼)
+       surface     화면 위 요소의 배경(카드·필드·버튼)
        line        테두리·구분선
        effect      딤·투명 레이어
 
@@ -64,104 +54,126 @@
        Opaque           불투명 버전 (접미사 없는 쪽이 반투명)
 ```
 
-3.x의 `Solid` 접미사가 4.0에서 `Opaque`로 뒤집혔습니다. **`lineSolidNormal` → `lineNeutralPrimaryOpaque`**처럼 접미사 위치가 앞에서 뒤로 옮겨간다는 점만 주의하면 됩니다.
+3.x에서 이름 중간에 붙던 `Solid`가 4.0에서는 맨 뒤 `Opaque`로 갑니다. **`lineSolidNormal` → `lineNeutralPrimaryOpaque`**처럼 자리까지 바뀐다는 점만 주의하면 됩니다.
 
 #### Foreground - 텍스트·아이콘
 
-| 3.x | 4.0 |
-|---|---|
-| `.labelNormal` | `.foregroundNeutralPrimary` |
-| `.labelStrong` | `.foregroundNeutralStrong` |
-| `.labelNeutral` | `.foregroundNeutralSecondary` |
-| `.labelAlternative` | `.foregroundNeutralTertiary` |
-| `.labelAssistive` | `.foregroundNeutralQuaternary` |
-| `.inverseLabel` | `.foregroundNeutralInverse` |
-| `.labelDisable` | `.foregroundDisablePrimary` |
-| `.interactionInactive` | `.foregroundInactivePrimary` |
-| `.inversePrimary` | `.foregroundBrandInverse` |
-| `.statusPositive` | `.foregroundPositivePrimary` |
-| `.statusCautionary` | `.foregroundCautionaryPrimary` |
-| `.statusNegative` | `.foregroundNegativePrimary` |
-| `.accentForegroundBlue` | `.foregroundBrandPrimary` |
-| `.accentForegroundGreen` | `.foregroundPositivePrimary` |
-| `.accentForegroundOrange` | `.foregroundCautionaryPrimary` |
-| `.accentForegroundRed` | `.foregroundNegativeStrong` |
-| `.accentForegroundRedOrange` | **대응 없음** (아래 참고) |
-| `.accentForegroundLime` | `.foregroundAccentLime` |
-| `.accentForegroundCyan` | `.foregroundAccentCyan` |
-| `.accentForegroundLightBlue` | `.foregroundAccentLightBlue` |
-| `.accentForegroundViolet` | `.foregroundAccentViolet` |
-| `.accentForegroundPurple` | `.foregroundAccentPurple` |
-| `.accentForegroundPink` | `.foregroundAccentPink` |
+| 3.x | 4.0 | 값 |
+|---|---|---|
+| `.labelNormal` | `.foregroundNeutralPrimary` | 동일 |
+| `.labelStrong` | `.foregroundNeutralStrong` | 동일 |
+| `.labelNeutral` | `.foregroundNeutralSecondary` | 동일 |
+| `.labelAlternative` | `.foregroundNeutralTertiary` | 동일 |
+| `.labelAssistive` | `.foregroundNeutralQuaternary` | 동일 |
+| `.inverseLabel` | `.foregroundNeutralInverse` | **미세 변경** |
+| `.labelDisable` | `.foregroundDisablePrimary` | 동일 |
+| `.interactionInactive` | `.foregroundInactivePrimary` | 동일 |
+| `.inversePrimary` | `.foregroundBrandInverse` | 동일 |
+| `.statusPositive` | `.foregroundPositivePrimary` | 동일 |
+| `.statusCautionary` | `.foregroundCautionaryPrimary` | 동일 |
+| `.statusNegative` | `.foregroundNegativePrimary` | 동일 |
+| `.accentForegroundBlue` | `.foregroundBrandPrimary` | **변경** |
+| `.accentForegroundGreen` | `.foregroundPositivePrimary` | **변경** |
+| `.accentForegroundOrange` | `.foregroundCautionaryPrimary` | **변경** |
+| `.accentForegroundRed` | `.foregroundNegativeStrong` | **다크 변경** |
+| `.accentForegroundLime` | `.foregroundAccentLime` | **다크 변경** |
+| `.accentForegroundCyan` | `.foregroundAccentCyan` | **다크 변경** |
+| `.accentForegroundLightBlue` | `.foregroundAccentLightBlue` | **다크 변경** |
+| `.accentForegroundViolet` | `.foregroundAccentViolet` | **다크 변경** |
+| `.accentForegroundPurple` | `.foregroundAccentPurple` | **다크 변경** |
+| `.accentForegroundPink` | `.foregroundAccentPink` | **다크 변경** |
+| `.accentForegroundRedOrange` | 대응 없음 | [3.1](#31-redorange-토큰) 참고 |
 
-> `accentForeground{색}` 중 Blue·Green·Orange·Red는 액센트 계열에서 **의미 색(brand/positive/cautionary/negative)으로 승격**됐습니다. 이름만 옮기지 말고 그 자리가 정말 의미 색인지 확인해주세요.
+> `accentForeground{색}` 중 Blue·Green·Orange·Red는 **역할이 `Accent{색}`에서 `Brand`·`Positive`·`Cautionary`·`Negative`로 바뀌었습니다.** 이름만 옮기지 말고 그 자리가 정말 그 역할인지 확인해주세요.
 
-#### Background · Surface - 면
+#### Background · Surface - 화면 바탕과 요소 배경
 
-| 3.x | 4.0 |
-|---|---|
-| `.backgroundNormal` | `.backgroundNeutralPrimary` |
-| `.backgroundNormalAlternative` | `.backgroundNeutralSecondary` |
-| `.backgroundElevated` | `.surfaceElevatedPrimary` |
-| `.backgroundElevatedAlternative` | `.surfaceElevatedSecondary` |
-| `.fillNormal` | `.surfaceNeutralSecondary` |
-| `.fillAlternative` | `.surfaceNeutralTertiary` |
-| `.fillStrong` | `.surfaceNeutralStrong` |
-| `.fillPrimary` | `.surfaceBrandSubtle` |
-| `.fillNegative` | `.surfaceNegativeStrong` |
-| `.backgroundStatusPositive` | `.surfacePositivePrimary` |
-| `.backgroundStatusCautionary` | `.surfaceCautionaryPrimary` |
-| `.backgroundStatusNegative` | `.surfaceNegativePrimary` |
-| `.inverseBackground` | `.surfaceNeutralInverse` |
-| `.primaryNormal` | `.surfaceBrandPrimary` |
-| `.primaryStrong` | `.surfaceBrandStrong` |
-| `.primaryHeavy` | `.surfaceBrandHeavy` |
-| `.interactionDisable` | `.surfaceDisablePrimary` |
-| `.accentBackgroundLime` | `.surfaceAccentLimeOpaque` |
-| `.accentBackgroundCyan` | `.surfaceAccentCyanOpaque` |
-| `.accentBackgroundLightBlue` | `.surfaceAccentLightBlueOpaque` |
-| `.accentBackgroundViolet` | `.surfaceAccentVioletOpaque` |
-| `.accentBackgroundPink` | `.surfaceAccentPinkOpaque` |
-| `.accentBackgroundRedOrange` | **대응 없음** (아래 참고) |
+| 3.x | 4.0 | 값 |
+|---|---|---|
+| `.backgroundNormal` | `.backgroundNeutralPrimary` | 동일 |
+| `.backgroundNormalAlternative` | `.backgroundNeutralSecondary` | 동일 |
+| `.backgroundElevated` | `.surfaceElevatedPrimary` | 동일 |
+| `.backgroundElevatedAlternative` | `.surfaceElevatedSecondary` | 동일 |
+| `.fillNormal` | `.surfaceNeutralSecondary` | 동일 |
+| `.fillAlternative` | `.surfaceNeutralTertiary` | 동일 |
+| `.fillStrong` | `.surfaceNeutralStrong` | 동일 |
+| `.backgroundStatusPositive` | `.surfacePositivePrimary` | 동일 |
+| `.backgroundStatusCautionary` | `.surfaceCautionaryPrimary` | 동일 |
+| `.backgroundStatusNegative` | `.surfaceNegativePrimary` | 동일 |
+| `.inverseBackground` | `.surfaceNeutralInverse` | 동일 |
+| `.primaryNormal` | `.surfaceBrandPrimary` | 동일 |
+| `.primaryStrong` | `.surfaceBrandStrong` | 동일 |
+| `.primaryHeavy` | `.surfaceBrandHeavy` | 동일 |
+| `.interactionDisable` | `.surfaceDisablePrimary` | 동일 |
+| `.accentBackgroundLime` | `.surfaceAccentLimeOpaque` | 동일 |
+| `.accentBackgroundCyan` | `.surfaceAccentCyanOpaque` | 동일 |
+| `.accentBackgroundLightBlue` | `.surfaceAccentLightBlueOpaque` | 동일 |
+| `.accentBackgroundViolet` | `.surfaceAccentVioletOpaque` | 동일 |
+| `.accentBackgroundPurple` | `.surfaceAccentPurpleOpaque` | 동일 |
+| `.accentBackgroundPink` | `.surfaceAccentPinkOpaque` | 동일 |
+| `.accentBackgroundRedOrange` | 대응 없음 | [3.1](#31-redorange-토큰) 참고 |
 
-> `background`는 화면 바탕(Primary·Secondary) 두 종만 남았습니다. 나머지는 면 토큰이면 `surface`로, 투명 레이어인 `backgroundTransparent*`는 `effect`로 갈라졌습니다 (`backgroundTransparent` → `effectTransparentPrimary`, `backgroundTransparentAlternative` → `effectTransparentSecondary`). 값은 그대로입니다.
+> `background`는 화면 바탕(Primary·Secondary) 두 종만 남았습니다. 나머지 배경 토큰은 `surface`로, 투명 레이어인 `backgroundTransparent*`는 `effect`로 갈라졌습니다.
 >
-> `accentBackground{색}`은 기본이 **불투명(`Opaque`)** 대응입니다. 반투명 위에 겹쳐 쓰던 자리라면 접미사 없는 `.surfaceAccent{색}`을 쓰세요.
->
-> **RedOrange 계열은 4.0 시맨틱에서 없어졌습니다.** `accentForegroundRedOrange`와 `accentBackgroundRedOrange`에 대응하는 4.0 토큰이 없습니다(프리미티브 `redOrange*`는 그대로 남아 있습니다). 1:1 치환이 불가능하니 그 자리의 의도를 보고 직접 골라야 하고, 무엇을 고르든 **색이 바뀝니다.** 원티드 앱은 이 토큰을 쓰던 세 곳이 모두 텍스트·아이콘 색이어서 `.foregroundNegativePrimary`로 옮겼는데, 그 결과 `redOrange50/60`이 `red50/60`으로 바뀌었습니다. 면 색으로 쓰던 자리라면 `.surfaceNegativePrimary`나 프리미티브 `redOrange*` 직접 지정이 원래 값에 더 가깝습니다.
+> `accentBackground{색}`은 기본이 **불투명(`Opaque`)** 대응입니다. 반투명 위에 겹쳐 쓰던 자리라면 접미사 없는 `.surfaceAccent{색}`(8% 알파)을 쓰세요.
 
 #### Line - 테두리·구분선
 
-| 3.x | 4.0 |
-|---|---|
-| `.lineNormal` | `.lineNeutralPrimary` |
-| `.lineNeutral` | `.lineNeutralSecondary` |
-| `.lineAlternative` | `.lineNeutralTertiary` |
-| `.lineSolidNormal` | `.lineNeutralPrimaryOpaque` |
-| `.lineSolidNeutral` | `.lineNeutralSecondaryOpaque` |
-| `.lineSolidAlternative` | `.lineNeutralTertiaryOpaque` |
-| `.linePrimaryStrong` | `.lineBrandStrong` |
-| `.lineStatusPositiveNormal` | `.linePositivePrimary` |
-| `.lineStatusCautionaryNormal` | `.lineCautionaryPrimary` |
-| `.lineStatusNegativeStrong` | `.lineNegativeStrong` |
+| 3.x | 4.0 | 값 |
+|---|---|---|
+| `.lineNormal` | `.lineNeutralPrimary` | 동일 |
+| `.lineNeutral` | `.lineNeutralSecondary` | 동일 |
+| `.lineAlternative` | `.lineNeutralTertiary` | 동일 |
+| `.lineSolidNormal` | `.lineNeutralPrimaryOpaque` | 동일 |
+| `.lineSolidNeutral` | `.lineNeutralSecondaryOpaque` | 동일 |
+| `.lineSolidAlternative` | `.lineNeutralTertiaryOpaque` | 동일 |
+| `.linePrimaryNormal` | `.lineBrandPrimary` | 동일 |
+| `.linePrimaryStrong` | `.lineBrandStrong` | 동일 |
+| `.lineStatusPositiveNormal` | `.linePositivePrimary` | 동일 |
+| `.lineStatusCautionaryNormal` | `.lineCautionaryPrimary` | 동일 |
+| `.lineStatusNegativeNormal` | `.lineNegativePrimary` | 동일 |
+| `.lineStatusNegativeStrong` | `.lineNegativeStrong` | 동일 |
 
 #### Effect - 딤·투명 레이어
 
-| 3.x | 4.0 |
-|---|---|
-| `.materialDimmer` | `.effectDimmerPrimary` |
-| `.backgroundTransparent` | `.effectTransparentPrimary` |
-| `.backgroundTransparentAlternative` | `.effectTransparentSecondary` |
+| 3.x | 4.0 | 값 |
+|---|---|---|
+| `.materialDimmer` | `.effectDimmerPrimary` | **다크 변경** |
+| `.backgroundTransparent` | `.effectTransparentPrimary` | 동일 |
+| `.backgroundTransparentAlternative` | `.effectTransparentSecondary` | 동일 |
 
-#### 위 표에 없는 토큰
+#### 값이 함께 바뀌는 토큰
 
-4.0에서 새로 생긴 토큰(`lineBrandFocus`, `lineNegativeFocus`, `foregroundAccent*` 등)과 프리미티브 토큰(`neutral*`, `blue*`, `coolNeutral*` …)은 `Color.Semantic`에서 직접 확인해주세요. 프리미티브 이름은 변경되지 않았습니다.
+이름만 옮기면 **색이 달라집니다.** 아래 자리는 치환 후 눈으로 확인해주세요.
 
-위 표에서 못 찾은 3.x 토큰은 `Color.Semantic` 각 케이스의 doc 주석을 보면 됩니다. 리네임된 토큰에는 `/// … (구 labelNormal)`처럼 3.x 이름이 적혀 있습니다.
+| 3.x → 4.0 | 라이트 | 다크 |
+|---|---|---|
+| `accentForegroundBlue` → `foregroundBrandPrimary` | `blue45` `#005EEB` → `blue50` `#0066FF` | `blue45` → `blue60` `#3385FF` |
+| `accentForegroundGreen` → `foregroundPositivePrimary` | `green40` `#009632` → `green50` `#00BF40` | `green40` → `green60` `#1ED45A` |
+| `accentForegroundOrange` → `foregroundCautionaryPrimary` | `orange39` `#D17600` → `orange50` `#FF9200` | `orange39` → `orange60` `#FFA938` |
+| `accentForegroundRed` → `foregroundNegativeStrong` | 동일 (`red40`) | `red40` `#E52222` → `red60` `#FF6363` |
+| `accentForegroundLime` → `foregroundAccentLime` | 동일 (`lime37`) | `lime37` `#429E00` → `lime50` `#58CF04` |
+| `accentForegroundCyan` → `foregroundAccentCyan` | 동일 (`cyan40`) | `cyan40` `#0098B2` → `cyan50` `#00BDDE` |
+| `accentForegroundLightBlue` → `foregroundAccentLightBlue` | 동일 (`lightBlue40`) | `lightBlue40` `#008DCF` → `lightBlue50` `#00AEFF` |
+| `accentForegroundViolet` → `foregroundAccentViolet` | 동일 (`violet45`) | `violet45` `#5B37ED` → `violet70` `#9E86FC` |
+| `accentForegroundPurple` → `foregroundAccentPurple` | 동일 (`purple40`) | `purple40` `#AD36E3` → `purple60` `#D478FF` |
+| `accentForegroundPink` → `foregroundAccentPink` | 동일 (`pink46`) | `pink46` `#E846CD` → `pink60` `#FA73E3` |
+| `materialDimmer` → `effectDimmerPrimary` | 동일 | `coolNeutral5` `#0F0F10` → `coolNeutral10` `#171719` (딤이 약간 밝아짐) |
+| `inverseLabel` → `foregroundNeutralInverse` | `neutral99` `#F7F7F7` → `coolNeutral99` `#F7F7F8` | `neutral10` `#171717` → `coolNeutral10` `#171719` |
+
+`accentForegroundBlue`·`Green`·`Orange` 세 개는 **라이트 모드에서도 확실히 달라집니다.** 나머지 accent 계열은 다크 모드에서 한 단계 밝아지고, `inverseLabel`은 1/255 수준이라 사실상 티가 나지 않습니다.
+
+#### 표에 없는 토큰
+
+프리미티브 토큰(`neutral*`, `blue*`, `coolNeutral*` …)은 이름·값 모두 그대로입니다.
+
+4.0에서 새로 생긴 토큰(`lineBrandFocus`, `lineNegativeFocus`, `surfaceBrandSubtle`, `surfaceNegativeStrong`, `foregroundAccent*` 등)은 3.x에 대응이 없으므로 이 표에 없습니다. `Color.Semantic`에서 직접 확인해주세요.
+
+> `Color.Semantic`의 doc 주석에 `(구 …)`로 3.x 이름이 적혀 있지만, 일부는 4.0 개발 중에만 존재했던 이름(`fillPrimary`, `fillNegative`, `interactionFocus`, `interactionNegative`)입니다. **3.x에서 올라온다면 이 문서의 표를 기준으로 삼으세요.**
 
 #### 일괄 치환
 
-3.x 토큰 이름이 4.0에 남아 있는 게 없으므로 단어 경계 치환으로 안전하게 처리됩니다.
+3.x 토큰 이름이 4.0에 하나도 남지 않아서, `\b`로 끊어 치환하면 엉뚱한 데가 걸릴 일이 없습니다.
 
 ```bash
 # 확인 먼저
@@ -177,9 +189,9 @@ find . -name "*.swift" -exec sed -i '' \
 
 ---
 
-### 2. Spacing · Opacity 토큰
+### 1.2 Spacing · Opacity 토큰
 
-값이 이름에 그대로 들어가는 방식으로 평탄화됐습니다. 값 대응은 1:1이라 렌더 결과가 같습니다.
+열거형을 거쳐 함수를 부르던 게 정적 프로퍼티 하나로 합쳐지고, 값이 이름에 그대로 들어갑니다.
 
 ```swift
 // 3.x
@@ -193,7 +205,30 @@ find . -name "*.swift" -exec sed -i '' \
 
 | 3.x | 4.0 |
 |---|---|
-| `.spacing(.pt02)` … `.spacing(.pt72)` | `.spacing2` … `.spacing72` |
+| `.spacing(.pt01)` | `.spacing1` |
+| `.spacing(.pt02)` | `.spacing2` |
+| `.spacing(.pt04)` | `.spacing4` |
+| `.spacing(.pt08)` | `.spacing8` |
+| `.spacing(.pt12)` | `.spacing12` |
+| `.spacing(.pt16)` | `.spacing16` |
+| `.spacing(.pt20)` | `.spacing20` |
+| `.spacing(.pt24)` | `.spacing24` |
+| `.spacing(.pt28)` | **대응 없음** ([3.2](#32-spacing-pt28--pt36)) |
+| `.spacing(.pt32)` | `.spacing32` |
+| `.spacing(.pt36)` | **대응 없음** ([3.2](#32-spacing-pt28--pt36)) |
+| `.spacing(.pt40)` | `.spacing40` |
+| `.spacing(.pt48)` | `.spacing48` |
+| `.spacing(.pt56)` | `.spacing56` |
+| `.spacing(.pt64)` | `.spacing64` |
+| `.spacing(.pt72)` | `.spacing72` |
+| `.spacing(.pt80)` | `.spacing80` |
+
+`pt08` → `spacing8`처럼 **앞자리 `0`이 없어집니다.** `spacing08`이 아닙니다.
+
+Opacity는 16개가 1:1로 대응하고 값이 같습니다.
+
+| 3.x | 4.0 |
+|---|---|
 | `.opacity(.p000)` | `.opacity0` |
 | `.opacity(.p005)` | `.opacity5` |
 | `.opacity(.p008)` | `.opacity8` |
@@ -211,37 +246,204 @@ find . -name "*.swift" -exec sed -i '' \
 | `.opacity(.p097)` | `.opacity97` |
 | `.opacity(.p100)` | `.opacity100` |
 
-`pt08` → `spacing8`처럼 **0 패딩이 사라집니다**. `spacing08`이 아닙니다.
+Opacity 토큰의 타입이 `Double`로 바뀌었습니다. `withAlphaComponent(0)`처럼 숫자를 직접 넣던 자리도 `withAlphaComponent(.opacity0)`으로 정리할 수 있습니다.
 
-Opacity 토큰은 `Double`로 이관됐습니다. `withAlphaComponent(0)`처럼 원시 리터럴을 쓰던 자리도 `withAlphaComponent(.opacity0)`으로 정리할 수 있습니다.
+`Color.spacing(_:)` / `Color.opacity(_:)` 정적 함수는 제거됐습니다.
 
 ---
 
-### 3. 전역 모디파이어
+### 1.3 전역 모디파이어
 
 | 3.x | 4.0 | 비고 |
 |---|---|---|
 | `.disable(_:)` | `.disabled(_:)` | SwiftUI 표준 모디파이어로 흡수. 컴포넌트가 `isEnabled` 환경값을 읽습니다 |
 | `scrollStatus.scrolledToMax` | `scrollStatus.reachedEnd` | `Montage.ScrollView`의 `ScrollStatus` 프로퍼티 |
 
-`disable()` → `disabled()`는 이름만 바뀌는 게 아닙니다. 3.x는 컴포넌트가 스스로 `opacity`를 깔았고, 4.0은 SwiftUI `isEnabled`를 타고 색 토큰(`foregroundDisablePrimary` 등)으로 표현합니다. [시각 결과가 달라지는 변경](#시각-결과가-달라지는-변경)을 확인해주세요.
+`disable()` → `disabled()`는 이름만 바뀐 게 아닙니다. 3.x는 컴포넌트가 뷰 전체의 불투명도를 낮춰 흐리게 만들었고, 4.0은 SwiftUI `isEnabled` 값을 읽어 색 토큰(`foregroundDisablePrimary` 등)으로 바꿉니다. [4. 화면이 달라지는 것](#4-화면이-달라지는-것)을 확인해주세요.
 
-입력 컴포넌트에는 `autocorrectionDisabled(_:)`가 새로 생겼습니다(추가 API, 브레이킹 아님).
+`Chip`·`FilterButton`은 3.x에도 `disabled(_:)`가 있었지만 `Self`를 돌려주는 컴포넌트 자체 모디파이어였습니다. 4.0에서 이게 없어지고 SwiftUI 표준이 대신 잡히면서 반환 타입이 `some View`로 바뀝니다. **`.disabled()` 뒤에 컴포넌트 전용 모디파이어를 체이닝하던 자리는 컴파일 에러가 나니 `.disabled()`를 맨 뒤로 보내세요.**
+
+```swift
+// 3.x
+Chip(variant: variant, size: size, text: text)
+    .disabled(disable)
+    .active(active)
+
+// 4.0 - .disabled()가 Chip이 아니라 some View를 돌려준다
+Chip(variant: variant, size: size, text: text)
+    .active(active)
+    .disabled(disable)
+```
+
+상위 뷰에 걸어 둔 `.disabled(true)`도 이제 두 컴포넌트의 색까지 바꿉니다. 3.x는 자체 프로퍼티로 색을 정해서 위에서 내려온 `.disabled()`는 터치만 막고 색은 그대로였습니다.
 
 ---
 
-### 4. 입력 컴포넌트 → FormControl
+### 1.4 컴포넌트 API 리네임
 
-가장 손이 많이 가는 변경입니다. `TextField`/`TextArea`가 **입력 그 자체만** 담당하고, 라벨·상태 메시지·글자수 카운터는 `FormControl`이 필드 밖에서 배치합니다.
+#### ListCell
 
-| 3.x (필드 내부) | 4.0 (FormControl 슬롯) | 위치 |
+| 3.x | 4.0 |
+|---|---|
+| `ListCell(title:)` | `ListCell(label:)` |
+| `.titleVariant(_:)` | `.labelVariant(_:)` |
+| `.titleWeight(_:)` | `.labelWeight(_:)` |
+| `.titleColor(_:)` | `.labelColor(_:)` |
+| `.caption(_:)` | `.description(_:)` |
+| `.fillWidth(false)` | `.variant(.inset)` (기본값) |
+| `.fillWidth(true)` | `.variant(.full)` |
+
+`inset`은 인터랙션 배경만 좌우 12 확장하고 모서리 16, `full`은 셀이 좌우 여백 20을 직접 갖습니다. 3.x의 `fillWidth(false)`·`fillWidth(true)`가 쓰던 값 그대로라 이름만 바꾸면 화면은 달라지지 않습니다.
+
+슬롯 재구성은 [2.5 ListCell 슬롯](#25-listcell-슬롯)에 있습니다.
+
+#### TopNavigation 슬롯 프리셋
+
+프리셋 네임스페이스가 `컴포넌트.Resource.슬롯명` 패턴으로 통일됐습니다.
+
+| 3.x | 4.0 |
+|---|---|
+| `TopNavigation.Resource.LeadingButtonInfo` | `TopNavigation.Resource.Leading` |
+| `TopNavigation.Resource.TrailingButtonInfo` | `TopNavigation.Resource.Trailing` |
+
+```swift
+// 3.x
+TopNavigation.LeadingButton(TopNavigation.Resource.LeadingButtonInfo.back(action: { dismiss() }))
+
+// 4.0
+TopNavigation.LeadingButton(TopNavigation.Resource.Leading.back(action: { dismiss() }))
+```
+
+#### 입력 컴포넌트
+
+| 3.x | 4.0 | 대상 |
+|---|---|---|
+| `.heading(_:)` | `.label(_:required:)` | `TextField` · `TextArea` · `Select` |
+| `.requiredBadge(_:)` | `.label(_:required:)`의 `required` | `TextField` · `TextArea` · `Select` |
+| `.description(_:)` | `.message(_:)` | `TextArea` · `Select` |
+| `.inputCharacterLimit(_:)` | `.maxLength(_:)` | `TextArea` |
+| `.status(.negative(description:))` | `.status(.negative)` + `.message(_:)` | `TextField` |
+
+`TextField.Status`에서 연관값이 빠졌습니다. `.normal()` → `.normal`, `.negative(description:)` → `.negative`.
+
+구조가 바뀌는 부분은 [2.1 입력 컴포넌트의 라벨·메시지·카운터](#21-입력-컴포넌트의-라벨메시지카운터)에 있습니다.
+
+#### Button · TextButton
+
+`fill(horizontal:vertical:)`이 제거되고 `fillWidth(_:)`로 대체됐습니다.
+
+| 3.x | 4.0 |
+|---|---|
+| `.fill(horizontal: true)` | `.fillWidth(true)` |
+| `.fill(horizontal: true, vertical: false)` | `.fillWidth(true)` |
+| `.fill(horizontal: true, vertical: true)` | `.fillWidth(true)` |
+
+`vertical`은 3.x에서도 아무 일을 하지 않았습니다. 파라미터로 받기만 하고 함수 본문이 그 값을 버려서, `vertical: true`로 부르던 곳도 버튼 높이가 늘어난 적이 없습니다. 세 경우 모두 렌더 결과가 같으니 기계적으로 치환해도 됩니다.
+
+#### IconButton
+
+`normal` variant의 사이즈가 `Int`에서 `NormalSize` 열거형으로 바뀌었습니다.
+
+| 3.x | 4.0 | 아이콘 글리프 | 컨테이너 |
+|---|---|---|---|
+| `.normal(size: 16)` | `.normal(size: .small)` | 16 | 24 |
+| `.normal(size: 18)` | `.normal(size: .medium)` | 18 | 28 |
+| `.normal(size: 20)` | `.normal(size: .large)` | 20 | 32 |
+| `.normal(size: 24)` | `.normal(size: .xlarge)` | 24 | 36 |
+
+글리프 크기는 그대로고 **터치 컨테이너만 커집니다.** 배경·테두리 없는 variant라 트레일링 아이콘이 약 6pt 움직이거나 행 높이가 약 8pt 늘어나는 정도입니다.
+
+위 네 값 외의 크기는 [3.3 IconButton 비표준 크기](#33-iconbutton-비표준-크기)를 보세요.
+
+#### PushBadge
+
+| 3.x | 4.0 |
+|---|---|
+| `.new` | `.text("N")` |
+| `.number(count)` | `.maxCount(count, max: 99)` |
+
+한 글자일 때 최소 너비 + 패딩 대신 `badgeSize` 정사각(xsmall 16 / small 20 / medium 24)으로 고정됩니다. `N`처럼 좁은 글자는 픽셀 차이가 없고, 한글 한 글자나 `M`·`W`에서도 찌그러지지 않습니다.
+
+확대 상한도 생겼습니다. 3.x는 글자 크기를 접근성 단계까지 키우면 뱃지도 계속 커졌지만, 4.0은 `xxxLarge`에서 멈춥니다. 뱃지가 얹히는 아이콘·아바타는 Dynamic Type을 따라 커지지 않아서, 뱃지만 계속 커지면 대상을 덮어버리기 때문입니다.
+
+#### SegmentedControl
+
+| 3.x | 4.0 |
+|---|---|
+| `Item(image:title:)` | `Item(leadingIcon:title:)` |
+| `icon` 토글 | `.iconOnly(_:)` |
+
+`variant(_:)` 모디파이어 제거는 [3.4](#34-segmentedcontrol-outlined-variant)를 보세요.
+
+#### Accordion
+
+`trailingContent`에서 인자 없는 오버로드가 빠지고 펼침 여부(`Bool`)를 받는 오버로드만 남았습니다.
+
+```swift
+// 3.x
+.trailingContent { Chevron() }
+
+// 4.0
+.trailingContent { _ in Chevron() }
+```
+
+#### init에서 빠진 파라미터
+
+비활성 여부와 배경색이 `init` 파라미터에서 모디파이어로 옮겨갔습니다.
+
+| 3.x | 4.0 |
+|---|---|
+| `TopNavigation(scrollOffset:backgroundColor:)` | `TopNavigation(scrollOffset:)` + `.backgroundColor(_:)` |
+| `TopNavigation.TrailingIconButton(icon:disable:showPushBadge:action:)` | `(icon:showPushBadge:action:)` + `.disabled(_:)` |
+| `TopNavigation.TrailingTextButton(text:disable:action:)` | `(text:action:)` + `.disabled(_:)` |
+| `framedStyle(status:borderRadius:shadowLevel:disabled:)` | `framedStyle(status:borderRadius:shadowLevel:)` + `.disabled(_:)` |
+
+`disable:`을 넘기던 자리는 [1.3 전역 모디파이어](#13-전역-모디파이어)와 같은 방식으로 SwiftUI 표준 `.disabled(_:)`를 씁니다.
+
+#### Skeleton
+
+가변 폭 배열 대신 타이포그래피 `variant`를 받습니다. 줄 높이와 줄 수를 variant에서 자동 계산합니다.
+
+```swift
+// 3.x
+Skeleton.SkeletonView(.text(lengths: [._25, ._50, ._75]))
+
+// 4.0
+Skeleton.SkeletonView(.text(variant: .body1))
+```
+
+플레이스홀더 바 폭이 가변(25/50/75/100%)에서 균일로 바뀝니다. 여러 줄을 흉내내려면 `SkeletonView`를 여러 개 놓으세요.
+
+#### Avatar
+
+`border(color:)`의 기본값이 `.lineAlternative`에서 `.lineNeutralTertiary`로 바뀌었습니다. 같은 색을 가리키는 새 이름이라 렌더 결과는 같습니다.
+
+---
+
+## 2. 없어져서 다시 짜야 하는 것
+
+### 2.1 입력 컴포넌트의 라벨·메시지·카운터
+
+3.x는 `TextField`가 라벨과 에러 메시지까지 자기 안에서 그렸습니다. 4.0은 `TextField`·`TextArea`·`Select` 세 컴포넌트가 입력 칸만 그리고, `label`·`message`·`accessory`를 붙이면 **`FormControl`이 감싸면서 라벨과 메시지를 대신 배치합니다.**
+
+```swift
+// 4.0에서 .label()·.message()를 붙이면 내부적으로 이렇게 됩니다
+FormControl {
+    TextField(text: $email)   // 입력만 그린다
+}
+.label("이메일")               // 라벨은 필드 위에
+.message(errorMessage)         // 메시지는 필드 아래에
+```
+
+FormControl로 감싸는 건 자동이라 호출부는 모디파이어만 바꾸면 됩니다. 다만 **뷰 계층이 달라져서 필드 높이와 폼 전체 높이가 변합니다.** 이름만 바꾸는 치환이 아닙니다.
+
+| 3.x (필드 내부) | 4.0 | 위치 |
 |---|---|---|
 | `.heading("이메일")` | `.label("이메일")` | 필드 **위** |
+| `.requiredBadge(true)` | `.label("이메일", required: true)` | 라벨 옆 |
 | `.status(.negative(description: msg))` | `.status(.negative)` + `.message(msg)` | 필드 **아래** |
 | `.bottomResources(trailing: [.characterCount(limit:)])` | `.accessory { … }` | 필드 아래 **우측** |
 | `.disable(_:)` | `.disabled(_:)` | - |
-
-`TextField.Status`에서 연관값이 빠졌습니다. `.normal()` → `.normal`, `.negative(description:)` → `.negative`.
 
 #### TextField
 
@@ -254,18 +456,15 @@ Montage.TextField(text: $email)
     .disable(isDisabled)
 
 // 4.0
-FormControl { context in
-    Montage.TextField(text: $email)
-        .status(context.status.textFieldStatus)
-        .placeholder(String(localized: "이메일을 입력해주세요."))
-}
-.label(String(localized: "이메일"))
-.status(isInvalidated ? .negative : .normal)
-.message(isInvalidated ? errorMessage : nil)
-.disabled(isDisabled)
+Montage.TextField(text: $email)
+    .label(String(localized: "이메일"))
+    .placeholder(String(localized: "이메일을 입력해주세요."))
+    .status(isInvalidated ? .negative : .normal)
+    .message(isInvalidated ? errorMessage : nil)
+    .disabled(isDisabled)
 ```
 
-상태는 **`FormControl`이 소유**하고 `context.status.textFieldStatus`로 필드에 내려갑니다. 필드에 상태를 직접 주면 라벨·메시지 색이 따로 놀게 됩니다.
+라벨은 필드의 접근성 라벨로, 메시지는 접근성 힌트로 연결됩니다.
 
 #### TextArea + 글자수 카운터
 
@@ -277,44 +476,47 @@ TextArea(text: $feedback, focus: $focus)
     .bottomResources(trailing: [.characterCount(limit: 1000)])
 
 // 4.0
-FormControl { _ in
-    TextArea(text: $feedback, focus: $focus)
-        .maxLength(1000)
-        .resize(.fixed(min: 116, max: 116))
-        .placeholder(String(localized: "좋았던 점이나 아쉬운 점을 적어주세요."))
-}
-.accessory {
-    Text(verbatim: "\(feedback.count)/1000")
-        .typography(variant: .label2, weight: .medium, semantic: .foregroundNeutralTertiary)
-}
+TextArea(text: $feedback, focus: $focus)
+    .maxLength(1000)
+    .resize(.fixed(min: 116, max: 116))
+    .placeholder(String(localized: "좋았던 점이나 아쉬운 점을 적어주세요."))
+    .accessory {
+        Text(verbatim: "\(feedback.count)/1000")
+            .typography(variant: .label2, weight: .medium, semantic: .foregroundNeutralTertiary)
+    }
 ```
 
-`bottomResources`의 `.characterCount` 리소스가 제거됐습니다. 카운터는 이제 호출부가 직접 그립니다(`bottomResources` 자체는 남아 있습니다). 두 가지를 챙겨주세요.
+`.characterCount` 리소스가 제거됐습니다. 카운터는 이제 호출부가 직접 그립니다. 두 가지를 챙겨주세요.
 
 - **입력 상한은 `maxLength(_:)`로 필드에 줍니다.** 카운터 표시와 입력 제한이 분리됐습니다.
 - **`Text(verbatim:)`을 쓰세요.** `Text("\(count)/\(limit)")`는 `LocalizedStringKey` 보간을 타서 상한이 1000 이상일 때 로케일 천단위 구분자가 붙습니다(`5,000`). `verbatim:`이면 `5000`으로 나옵니다.
 
-`FormControl`의 나머지 모디파이어: `size(.large/.medium)`, `labelPlacement(.top/.leading)`, `labelWidth(_:)`, `label(_:required:)`. 여러 필드를 묶어 정렬하려면 `FormControlGroup`을 씁니다.
-
-#### 입력에 직접 붙이는 방식
-
-`FormControl`로 감싸지 않고 `TextField`·`TextArea`·`Select`에 모디파이어를 바로 붙일 수도 있습니다. 세 컴포넌트가 같은 다섯 개를 갖습니다.
+세 컴포넌트가 공통으로 갖는 모디파이어는 다섯 개입니다.
 
 `.label(_:required:)` · `.message(_:)` · `.labelPlacement(_:)` · `.labelWidth(_:)` · `.accessory { }`
 
+#### FormControl로 감싸는 경우
+
+위 모디파이어를 하나라도 붙이면 내부에서 `FormControl`로 감싸지므로, 대부분의 화면은 `FormControl`을 쓸 일이 없습니다. 직접 쓰는 게 나은 경우는 셋입니다.
+
+- 앱에서 직접 만든 입력 컴포넌트를 감쌀 때
+- 어떤 입력 컴포넌트가 들어갈지 런타임에 바뀌어 래퍼 설정을 한곳에 모아야 할 때
+- `FormControlGroup`으로 여러 필드의 라벨 폭을 맞출 때
+
 ```swift
-Montage.TextField(text: $email)
-    .placeholder(String(localized: "이메일을 입력해주세요."))
-    .label(String(localized: "이메일"), required: true)
-    .message(isInvalidated ? errorMessage : nil)
-    .status(isInvalidated ? .negative : .normal)
+FormControl { context in
+    Montage.TextField(text: $email)
+        .status(context.status.textFieldStatus)
+        .placeholder(String(localized: "이메일을 입력해주세요."))
+}
+.label(String(localized: "이메일"))
+.status(isInvalidated ? .negative : .normal)
+.message(isInvalidated ? errorMessage : nil)
 ```
 
-하나라도 붙이면 내부에서 `FormControl`로 감싸지므로 결과는 위의 `FormControl { … }` 조합과 같습니다. 라벨은 입력의 접근성 라벨로, 메시지는 접근성 힌트로 연결됩니다.
+`size`·`status`는 **컴포넌트에 직접 준 값 → `FormControl` 전파값 → 기본값**(`.large` / `.normal`) 순으로 정해집니다. 슬롯 안까지 전파되므로 보통 `FormControl`에 한 번만 주면 됩니다. 반대로 컴포넌트에 상태를 따로 주면 라벨·메시지 색이 따로 놀 수 있으니, 위 예제처럼 `context.status`로 받아 내려주세요.
 
-`size`·`status`는 **호출부 지정값 → `FormControl` 전파값 → 기본값**(`.large` / `.normal`) 순으로 결정됩니다. 입력 하나에 라벨·메시지만 붙이는 흔한 경우는 이 방식이 짧고, `FormControlGroup`으로 묶거나 입력을 조합해야 하면 `FormControl`을 직접 쓰는 편이 낫습니다.
-
----
+`FormControl`의 나머지 모디파이어: `size(.large/.medium)`, `labelPlacement(.top/.leading)`, `labelWidth(_:)`, `label(_:required:)`.
 
 #### 자체 입력 래퍼가 있다면
 
@@ -322,11 +524,49 @@ Montage.TextField(text: $email)
 
 ---
 
-### 5. 슬롯 API 전환
+### 2.2 TextArea 하단 리소스
 
-`Model` 구조체와 고정 이미지 파라미터가 사라지고 호출부가 뷰를 직접 넣습니다.
+`bottomResources`의 시그니처와 리소스 타입이 모두 바뀌었습니다.
 
-#### ActionArea
+```swift
+// 3.x - 하나의 Resource 타입을 leading/trailing 양쪽에 넘김
+public func bottomResources(
+    leading leadingResources: [Resource] = [],
+    trailing trailingResources: [Resource] = [],
+    leadingResourceSpacing: CGFloat = 4,
+    trailingResourceSpacing: CGFloat = 4
+) -> Self
+
+// 4.0 - 슬롯별로 타입이 갈림
+public func bottomResources(
+    leading: [Resource.Leading] = [],
+    trailing: [Resource.Trailing] = [],
+    leadingResourceSpacing: CGFloat? = nil,
+    trailingResourceSpacing: CGFloat? = nil
+) -> Self
+```
+
+- 인자 라벨이 `leading leadingResources:` → `leading:`으로 바뀌었습니다.
+- 리소스 간 간격 기본값이 고정 `4`에서 **사이즈별 기본값(large 8 / medium 6)**으로 바뀝니다. 명시하지 않았다면 간격이 넓어집니다.
+
+프리셋 대응은 이렇습니다.
+
+| 3.x `Resource` | 4.0 |
+|---|---|
+| `.icon` | `Resource.Leading.icon` / `Resource.Trailing.icon` |
+| `.iconButton` | `Resource.Leading.iconButton` / `Resource.Trailing.iconButton` |
+| `.characterCount` | 제거 - [2.1](#21-입력-컴포넌트의-라벨메시지카운터)의 `accessory` |
+| `.textButton` · `.chip` · `.filterButton` · `.badge` | **대응 없음** ([3.6](#36-textarea-하단-리소스-프리셋)) |
+| - | `.contentBadge` · `.segmentedControl` 신설, trailing 전용 `.button` · `.primaryIconButton` 신설 |
+| `.slot` 없음 | `Resource.Leading.slot { }` / `Resource.Trailing.slot { }` |
+
+프리셋에 없는 구성은 `slot(_:)`으로 직접 넣습니다.
+
+---
+
+### 2.3 ActionArea
+
+`Model` 구조체와 고정 파라미터가 사라지고 호출부가 뷰를 직접 넣습니다.
 
 ```swift
 // 3.x
@@ -350,7 +590,9 @@ Montage.TextField(text: $email)
 )
 ```
 
-`actionArea` 슬롯 클로저에는 `@ViewBuilder`가 **붙지 않습니다**. `if`문을 쓰면 `_ConditionalContent`가 되어 `ActionArea` 타입 제약이 깨집니다. 조건 분기는 삼항 연산자나 모디파이어 체인으로 처리하세요.
+`BottomSheet`·`Popup`의 `modalActionArea(_:)`도 `ActionArea.Model?`에서 `(() -> ActionArea)?`로 바뀌었습니다.
+
+`actionArea` 슬롯 클로저에는 `@ViewBuilder`가 **붙지 않습니다.** `if`문을 쓰면 `_ConditionalContent`가 되어 `ActionArea` 타입 제약이 깨집니다. 조건 분기는 삼항 연산자나 모디파이어 체인으로 처리하세요.
 
 ```swift
 // 안 됩니다
@@ -360,7 +602,15 @@ Montage.TextField(text: $email)
 .actionArea { ActionArea(variant: isEditing ? a : b) }
 ```
 
+#### 투명 배경 제어
+
 투명 배경을 직접 제어하던 API가 없어졌습니다. 4.0에서는 배경과 상단 그라데이션이 스크롤 하단 도달 신호(`scrollReachedEnd`) 하나로 함께 결정됩니다.
+
+| 3.x | 4.0 |
+|---|---|
+| `.transparentBackground(_:)` | 제거 |
+| `ActionArea.BackgroundTransparencyControl` (`.automatic` / `.manual`) | 제거 |
+| `actionArea(backgroundTransparency:)` | 제거 - `actionArea(scrollReachedEnd:)` |
 
 | `scrollReachedEnd` | `extra` 슬롯 | 상단 그라데이션 | 배경 |
 |---|---|---|---|
@@ -370,15 +620,7 @@ Montage.TextField(text: $email)
 
 그라데이션은 "아래에 가려진 콘텐츠가 있다"는 신호이고 0.5초에 걸쳐 켜졌다 꺼집니다.
 
-| 3.x | 4.0 |
-|---|---|
-| `.transparentBackground(_:)` | 제거 |
-| `ActionArea.BackgroundTransparencyControl` (`.automatic` / `.manual`) | 제거 |
-| `actionArea(backgroundTransparency:)` | 제거 |
-| `.gradientColor(_:)` | `.backgroundColor(_:)` (배경과 그라데이션 시작색에 함께 적용) |
-| - | `.scrollReachedEnd(_:)` 신설 |
-
-`Montage.ScrollView`를 쓰면 스크롤 바닥 도달이 자동 전달되므로 아무것도 넘기지 않아도 3.x의 `.automatic`과 동등합니다. `SwiftUI.ScrollView`/`List`처럼 신호를 올려주지 않는 컨테이너를 쓸 때만 `actionArea(scrollReachedEnd:)`로 직접 넘기세요.
+`Montage.ScrollView`를 쓰면 스크롤 바닥 도달이 자동 전달되므로 아무것도 넘기지 않아도 3.x의 `.automatic`과 같습니다. `SwiftUI.ScrollView`/`List`처럼 신호를 올려주지 않는 컨테이너를 쓸 때만 직접 넘기세요.
 
 **`.manual`로 배경을 직접 투명하게 만들던 자리는 하단 도달 신호를 직접 넘기면 됩니다.** 스크롤 컨테이너가 아예 없는 화면(팝업·시트 안의 고정 높이 콘텐츠)은 신호가 올라올 데가 없어서 ActionArea가 "아래에 가려진 콘텐츠가 있다"고 보고 그라데이션과 배경을 그립니다. `true`를 넘기면 그라데이션이 숨겨지고 배경이 비칩니다.
 
@@ -396,37 +638,41 @@ content
 })
 ```
 
-배경색 자체를 바꿔야 한다면 `backgroundColor(_:)`를 씁니다. 두 방법 중 어느 것도 맞지 않으면 그 표현이 정말 필요한지 디자이너와 다시 확인해주세요.
+배경색 자체를 바꿔야 한다면 `backgroundColor(_:)`를 씁니다(배경과 그라데이션 시작색에 함께 적용). 두 방법으로 안 되는 화면이 있으면 [이슈](https://github.com/wanteddev/montage-ios/issues)로 알려주세요.
 
-4.0에서 ActionArea 스펙도 함께 조정됐습니다.
+스펙 변경은 [4. 화면이 달라지는 것](#4-화면이-달라지는-것)에 있습니다.
 
-| 항목 | 3.x | 4.0 |
-|---|---|---|
-| `extra` 슬롯 좌우 여백 | 20 | **24** |
-| `extra` 슬롯 하단 여백 | 24 | **20** |
-| `extra` 구분선 색 | `lineNeutralSecondary` | `lineNeutralTertiary` (옅어짐) |
-| 캡션 타이포 | `label2` | `label2` + `weight: .medium` (굵어짐) |
-| 캡션 아이콘 | 없음 | `.caption(_:icon:)` 16pt 슬롯 신설 |
-| 대체(`alternative`) 액션 버튼 | `outlined` / `primary` | `outlined` / **`assistive`** |
-| `cancel` 메인 액션 버튼 | `outlined` / `assistive` | **`solid`** / `assistive` |
+---
 
-메인 버튼 행의 좌우 여백 20은 그대로입니다.
+### 2.4 View.topNavigation(...) 제거
 
-버튼 색상은 API가 그대로라 컴파일 에러가 나지 않습니다. 대체 액션은 라벨이 파란색에서 검정으로 바뀌어 주 액션과의 대비가 커지고, `cancel` variant의 메인 버튼은 테두리형에서 회색 채움으로 바뀝니다. 보조(`sub`) 액션은 변경이 없습니다.
-
-#### ScreenScaffold
-
-`TopNavigation` + 본문 + `ActionArea`를 한 화면으로 조립하는 컨테이너가 새로 생겼습니다. 화면마다 손으로 맞추던 스크롤 오프셋 전달과 하단 여백 계산을 스캐폴드가 대신합니다.
+화면 상단을 붙이던 `View.topNavigation(...)` 모디파이어 두 개가 통째로 사라졌습니다. `TopNavigation` 컴포넌트를 직접 배치하거나, 새로 생긴 `ScreenScaffold`로 화면을 조립합니다.
 
 ```swift
+// 3.x
+content
+    .topNavigation(
+        title: "설정",
+        leadingContent: { TopNavigation.LeadingButton(.back(action: { dismiss() })) },
+        withBottom: .init(variant: .neutral(main: .init(text: "저장", action: save)))
+    )
+
+// 4.0
 ScreenScaffold(
-    navigation: { TopNavigation(title: title) },
-    actionArea: { ActionArea(variant: .neutral(main: .init(text: "확인", action: submit))) }
+    navigation: {
+        TopNavigation(title: "설정")
+            .leadingContent { TopNavigation.LeadingButton(.back(action: { dismiss() })) }
+    },
+    actionArea: {
+        ActionArea(variant: .neutral(main: .init(text: "저장", action: save)))
+    }
 ) {
     content
 }
 .backgroundColor(.semantic(.backgroundNeutralPrimary))
 ```
+
+`ScreenScaffold`는 `TopNavigation` + 본문 + `ActionArea`를 한 화면으로 조립하면서 화면마다 손으로 맞추던 스크롤 오프셋 전달과 하단 여백 계산을 대신합니다.
 
 `ActionArea`를 `safeAreaInset(edge: .bottom)`으로 넣기 때문에 스크롤 컨테이너가 그만큼 콘텐츠 인셋을 잡습니다. **바닥까지 내렸을 때 마지막 요소가 버튼에 가리지 않도록 호출부가 손으로 비워 주던 여백은 지우세요.**
 
@@ -435,28 +681,24 @@ ScreenScaffold(
 | `.builtIn` (기본) | 스캐폴드가 `Montage.ScrollView`를 깔고 스크롤 상태를 직접 잼 |
 | `.custom` | `List`처럼 컨테이너를 바꿀 수 없을 때. 콘텐츠가 `reportsScrollOffset(_:)`·`reportsScrollReachedEnd(_:)`로 신호를 올려야 함 |
 
-`navigation`·`actionArea` 슬롯 클로저에도 **`@ViewBuilder`가 붙지 않습니다.** `if`문을 쓰면 `_ConditionalContent`가 되어 타입 제약이 깨지므로, 조건부로 넣을 때는 `actionArea: isEditing ? slot : nil`처럼 클로저 자체를 갈라 주세요.
+`navigation`·`actionArea` 슬롯 클로저에도 **`@ViewBuilder`가 붙지 않습니다.** 조건부로 넣을 때는 `actionArea: isEditing ? slot : nil`처럼 클로저 자체를 갈라 주세요.
 
-`BottomSheet`·`Popup` 안에는 넣지 않습니다. 두 컴포넌트가 같은 일을 하고 `ActionArea` 높이를 자기 높이 계산에 쓰므로 그쪽 `actionArea:` 인자로 넘기세요. 전체 화면 커버나 push된 목적지는 시트가 아니라 화면이므로 여기에 해당하지 않습니다.
+`BottomSheet`·`Popup` 안에는 넣지 않습니다. 두 컴포넌트가 같은 일을 하고 `ActionArea` 높이를 자기 높이 계산에 쓰므로 그쪽 `actionArea:` 인자로 넘기세요. 전체 화면 커버나 push한 화면은 시트가 아니므로 여기에 해당하지 않습니다.
 
 `List`를 쓸 때는 행 배경과 스크롤 배경을 **둘 다** 걷어내야 합니다. 하나만 처리하면 `backgroundColor(_:)`로 지정한 색이 가려지고, `ActionArea`가 바닥에서 투명해질 때 그 경계가 드러납니다.
 
 ---
 
-#### ListCell
+### 2.5 ListCell 슬롯
 
-`title*` 계열이 `label*`로, `fillWidth()`가 `variant(_:)`로, `leadingContent {}`가 `leadingResources([…])`로 바뀌었습니다.
+`leadingContent {}` / `trailingContent {}`가 프리셋 배열을 받는 네 개의 슬롯 모디파이어로 바뀌었습니다.
 
 | 3.x | 4.0 |
 |---|---|
-| `ListCell(title:)` | `ListCell(label:)` |
-| `.titleVariant(_:)` / `.titleWeight(_:)` / `.titleColor(_:)` | `.labelVariant(_:)` / `.labelWeight(_:)` / `.labelColor(_:)` |
-| `.caption(_:)` | `.description(_:)` |
-| `.fillWidth(false)` | `.variant(.inset)` (기본값) |
-| `.fillWidth(true)` | `.variant(.full)` |
 | `.leadingContent { … }` | `.leadingResources([.slot { … }])` |
-| `.interactionPadding(_:)` | 제거 - `variant`에 통합 |
-| `.verticalAlign(.bottom)` | 제거 - `.top` / `.center`만 남음 |
+| `.trailingContent { _ in … }` | `.trailingResources([.slot { … }])` |
+| `.interactionPadding(_:)` | 제거 - `variant(_:)`에 통합 |
+| `.verticalAlign(_:)`의 타입 `VerticalAlignment` | `ListCell.VerticalAlign` |
 
 ```swift
 // 3.x
@@ -474,9 +716,7 @@ ListCell(label: option.title) { onSelect() }
     }])
 ```
 
-`inset`은 인터랙션 배경만 좌우 12 확장하고 모서리 16, `full`은 셀이 좌우 여백 20을 직접 갖습니다. 기존 `fillWidth(false/true)`와 값까지 대응합니다.
-
-슬롯이 네 종으로 늘었습니다: `leadingResources`, `labelTrailingResources`, `trailingResources`, `extraResources`. 자주 쓰는 조합은 프리셋으로 있습니다.
+슬롯이 네 개로 늘었습니다: `leadingResources`, `labelTrailingResources`, `trailingResources`, `extraResources`. 자주 쓰는 조합은 프리셋으로 있습니다.
 
 ```swift
 .leadingResources([.icon(.search), .checkbox(checked: isChecked)])
@@ -486,9 +726,11 @@ ListCell(label: option.title) { onSelect() }
 .leadingResources([.slot { AnyCustomView() }])   // 프리셋에 없으면 slot
 ```
 
-`verticalPadding`에 `.custom(CGFloat)`이 추가됐습니다.
+`.verticalAlign(.bottom)`은 [3.5](#35-listcell-verticalalignbottom)를 보세요.
 
-#### Chip
+---
+
+### 2.6 Chip 이미지 슬롯
 
 이미지 파라미터가 콘텐츠 슬롯으로 바뀌었습니다.
 
@@ -517,93 +759,19 @@ Chip(text: skill.name, variant: .outlined, size: .medium)
     }
 ```
 
-#### 슬롯 프리셋 이름
-
-프리셋은 `컴포넌트.Resource.슬롯명` 패턴으로 통일됐습니다.
-
-```swift
-// 3.x
-TopNavigation.LeadingButton(TopNavigation.Resource.LeadingButtonInfo.back(action: { dismiss() }))
-
-// 4.0
-TopNavigation.LeadingButton(TopNavigation.Resource.Leading.back(action: { dismiss() }))
-```
-
 ---
 
-### 6. 단순 API 치환
+### 2.7 FallbackView 여백
 
-#### Button · TextButton
-
-`fill(horizontal:vertical:)`이 **제거**되고 `fillWidth(_:)`로 대체됐습니다. 유예 없이 4.0에서 바로 빠지니 호출부를 모두 옮기세요.
+`init`에서 `image:`와 `button:`이 빠졌습니다.
 
 | 3.x | 4.0 |
 |---|---|
-| `.fill(horizontal: true)` | `.fillWidth(true)` |
-| `.fill(horizontal: true, vertical: false)` | `.fillWidth(true)` |
-| `.fill(horizontal: true, vertical: true)` | `.fillWidth(true)` |
+| `FallbackView(image:title:description:button:)` | `FallbackView(title:description:)` |
+| `button:` 슬롯 | `buttonActionArea(_:)` |
+| `image:` 슬롯 | **대응 없음** ([3.7](#37-fallbackview-이미지-슬롯)) |
 
-`vertical`은 3.x에서도 이미 아무 동작을 하지 않았습니다. 시그니처에만 있고 함수 본문에서 쓰이지 않아, `vertical: true`로 부르던 곳도 세로 채움이 일어난 적이 없습니다. 세 경우 모두 렌더링이 그대로라 기계적으로 치환해도 됩니다.
-
-`TextButton`은 3.x에 `fillWidth(_:)`가 없었습니다. 4.0에서 `Button`과 같은 모양으로 새로 생겼습니다.
-
-#### IconButton
-
-`normal` variant의 사이즈가 `Int`에서 `NormalSize` 열거형으로 바뀌었습니다.
-
-| 3.x | 4.0 | 아이콘 글리프 | 컨테이너 |
-|---|---|---|---|
-| `.normal(size: 16)` | `.normal(size: .small)` | 16 | 24 |
-| `.normal(size: 18)` | `.normal(size: .medium)` | 18 | 28 |
-| `.normal(size: 20)` | `.normal(size: .large)` | 20 | 32 |
-| `.normal(size: 24)` | `.normal(size: .xlarge)` | 24 | 36 |
-
-글리프 크기는 그대로고 **터치 컨테이너만 커집니다**. 배경·테두리 없는 variant라 트레일링 아이콘이 약 6px 움직이거나 행 높이가 약 8px 늘어나는 정도입니다.
-
-위 네 값 외의 크기를 쓰던 자리는 `NormalSize.custom(size:)`로 옮기는데, **`size`의 의미가 아이콘 크기에서 컨테이너 크기로 바뀝니다.** 3.x의 `.normal(size: n)`은 컨테이너가 아이콘과 같은 `n`이었지만, 4.0의 `.custom(size: n)`은 `n`이 컨테이너 한 변이고 아이콘은 컨테이너의 2/3에 가장 가까운 dimension 토큰으로 도출됩니다. 컨테이너는 `[24, 64]`로 clamp됩니다.
-
-```swift
-// 3.x - n은 아이콘 크기
-IconButton(variant: .normal(size: 22), icon: .search)
-
-// 4.0 - n은 컨테이너 크기, 아이콘은 여기서 도출된다
-IconButton(variant: .normal(size: .custom(size: 32)), icon: .search)  // 아이콘 20
-```
-
-3.x 값을 그대로 넣으면 아이콘이 작아집니다. `.custom(size: 22)`는 컨테이너가 24로 clamp되어 아이콘이 16이 됩니다. **표준 4개 값 외에는 기계적 대응이 없습니다.** 원하는 아이콘 크기가 나오는 컨테이너 값을 직접 골라야 합니다.
-
-| 컨테이너 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 |
-|---|---|---|---|---|---|---|---|---|
-| 아이콘 | 16 | 18 | 20 | 24 | 28 | 32 | 36 | 40 |
-
-#### Skeleton
-
-가변 폭 배열 대신 타이포그래피 변형을 받습니다. 줄 높이·줄 수를 변형에서 자동 계산합니다.
-
-```swift
-// 3.x
-Skeleton.SkeletonView(.text(lengths: [._25, ._50, ._75]))
-
-// 4.0
-Skeleton.SkeletonView(.text(variant: .body1))
-```
-
-플레이스홀더 바 폭이 가변(25/50/75/100%)에서 균일로 바뀝니다. 여러 줄을 흉내내려면 `SkeletonView`를 여러 개 놓으세요.
-
-#### PushBadge
-
-variant가 통합됐습니다.
-
-| 3.x | 4.0 |
-|---|---|
-| `.new` | `.text("N")` |
-| `.number(count)` | `.maxCount(count, max: 99)` |
-
-한 글자일 때 최소 너비 + 패딩 대신 `badgeSize` 정사각(xsmall 16 / small 20 / medium 24)으로 고정됩니다. `N`처럼 좁은 글자는 픽셀 차이가 없고, 한글 한 글자나 `M`·`W`에서 정원이 유지됩니다. Dynamic Type은 `xxxLarge`에서 멈춥니다.
-
-#### FallbackView
-
-여백 인터페이스가 생기고 **상하 최소 여백이 컴포넌트에 내장됐습니다.**
+여백을 지정하는 `Padding` 열거형도 생기고 **상하 최소 여백이 컴포넌트에 내장됐습니다.**
 
 ```swift
 public enum Padding {
@@ -636,7 +804,7 @@ FallbackView(…)
 
 ---
 
-### 7. 제거된 UIKit 래퍼
+### 2.8 제거된 UIKit 래퍼
 
 deprecated UIKit 래퍼가 제거됐습니다. SwiftUI 컴포넌트를 `UIHostingController`로 브리징하세요.
 
@@ -645,14 +813,98 @@ deprecated UIKit 래퍼가 제거됐습니다. SwiftUI 컴포넌트를 `UIHostin
 | `Montage.Button.SolidUIButton` | `Montage.Button(variant: .solid, …)` |
 | `Montage.Button.OutlinedUIButton` | `Montage.Button(variant: .outlined, …)` |
 | `ContentBadgeUIView` | `ContentBadge(…)` |
+| `InteractionUIView` | `Interaction` 모디파이어 |
 
 스펙은 동일하므로 렌더 결과에 차이가 없습니다.
 
 ---
 
-### 8. 컴포넌트 스펙 리프레시
+## 3. 대응이 없는 것
 
-컴파일 에러가 나지 않아 놓치기 쉬운 구간입니다. **API는 그대로인데 값이 바뀐** 항목이라, 치환 작업이 끝난 뒤 화면을 봐야 드러납니다.
+기계적 대응이 없어 **사용처가 직접 골라야 하는** 항목입니다. 비슷한 걸 임의로 넣으면 결과가 달라진 걸 모르고 넘어가게 됩니다.
+
+### 3.1 RedOrange 토큰
+
+`accentForegroundRedOrange`와 `accentBackgroundRedOrange`에 대응하는 4.0 토큰이 없습니다. 프리미티브 `redOrange*`는 그대로 남아 있습니다.
+
+1:1 치환이 불가능하니 그 자리의 의도를 보고 직접 골라야 하고, **무엇을 고르든 색이 바뀝니다.**
+
+원티드 앱은 이 토큰을 쓰던 세 곳이 모두 텍스트·아이콘 색이어서 `.foregroundNegativePrimary`로 옮겼고, 그 결과 `redOrange50/60`이 `red50/60`으로 바뀌었습니다. 배경색으로 쓰던 자리라면 `.surfaceNegativePrimary`나 프리미티브 `redOrange*` 직접 지정이 원래 값에 더 가깝습니다.
+
+### 3.2 Spacing pt28 · pt36
+
+4.0 Spacing 스케일에 `28`과 `36`이 없습니다. 새 스케일은 `0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 32, 40, 48, 56, 64, 72, 80`입니다.
+
+`.spacing(.pt28)` / `.spacing(.pt36)`을 쓰던 자리는 `spacing24`·`spacing32`·`spacing40` 중에서 골라야 하고, **레이아웃이 4pt씩 움직입니다.** 스케일을 벗어난 값이 꼭 필요하면 리터럴을 씁니다. 다만 리터럴이 여러 곳에 생긴다면 그 화면의 간격 설계를 다시 볼 신호입니다.
+
+```bash
+grep -rn "spacing(\.pt28\|spacing(\.pt36" --include="*.swift" .
+```
+
+### 3.3 IconButton 비표준 크기
+
+표준 4개(16·18·20·24) 외의 크기를 쓰던 자리는 `NormalSize.custom(size:)`로 옮기는데, **`size`의 의미가 아이콘 크기에서 컨테이너 크기로 바뀝니다.**
+
+3.x의 `.normal(size: n)`은 컨테이너가 아이콘과 같은 `n`이었지만, 4.0의 `.custom(size: n)`은 `n`이 컨테이너 한 변이고 아이콘은 컨테이너의 2/3에 가장 가까운 dimension 토큰으로 정해집니다. 컨테이너는 `[24, 64]`로 clamp됩니다.
+
+```swift
+// 3.x - n은 아이콘 크기
+IconButton(variant: .normal(size: 22), icon: .search)
+
+// 4.0 - n은 컨테이너 크기, 아이콘은 여기서 도출된다
+IconButton(variant: .normal(size: .custom(size: 32)), icon: .search)  // 아이콘 20
+```
+
+3.x 값을 그대로 넣으면 아이콘이 작아집니다. `.custom(size: 22)`는 컨테이너가 24로 clamp되어 아이콘이 16이 됩니다. 원하는 아이콘 크기가 나오는 컨테이너 값을 직접 골라야 합니다.
+
+| 컨테이너 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 |
+|---|---|---|---|---|---|---|---|---|
+| 아이콘 | 16 | 18 | 20 | 24 | 28 | 32 | 36 | 40 |
+
+### 3.4 SegmentedControl outlined variant
+
+`Variant` 열거형과 `variant(_:)` 모디파이어가 통째로 제거됐습니다. `outlined`를 쓰던 자리는 `solid` 하나로 통합되고 **테두리형이 사라집니다.**
+
+### 3.5 ListCell verticalAlign(.bottom)
+
+`.top` / `.center`만 남았습니다. 하단 정렬이 필요하던 자리는 슬롯 구성을 다시 짜거나 `.top`으로 맞춰야 합니다.
+
+### 3.6 TextArea 하단 리소스 프리셋
+
+`Resource.textButton` · `.chip` · `.filterButton` · `.badge`가 제거됐습니다. `Resource.Leading.slot { }` / `Resource.Trailing.slot { }`으로 직접 그리거나, trailing이라면 새로 생긴 `.button` · `.contentBadge`가 의도에 맞는지 확인해주세요.
+
+### 3.7 FallbackView 이미지 슬롯
+
+3.x는 `image:`로 삽화를 넣을 수 있었지만 4.0 `FallbackView`에는 이미지 관련 API가 없습니다. 제목과 설명, 버튼 영역만 남았습니다.
+
+삽화가 꼭 필요하면 `FallbackView`를 쓰지 않고 호출부에서 직접 조립해야 합니다. 그대로 두면 **빈 화면에서 삽화가 사라집니다.**
+
+### 3.8 AvatarGroup variant
+
+`AvatarGroup(_:variant:size:onTap:)`에서 `variant:`가 빠지고 `.person`으로 고정됐습니다. 3.x에서 `company`·`academy`로 회사·학원 로고를 묶어 보여주던 자리는 4.0에서 **모서리가 둥근 사각형이 아니라 원형으로 바뀝니다.**
+
+컴파일 에러가 나므로 인자를 지우게 되는데, 그 자리의 렌더 결과가 달라진다는 걸 같이 확인해주세요.
+
+### 3.9 TextField 트레일링 버튼 색
+
+`TextField.TrailingButtonInfo(variant:title:disable:handler:)`에서 `variant: Button.Color`가 빠졌습니다. 4.0은 outlined 한 가지로 고정됩니다. `primary`로 강조하던 인증 버튼 등은 색이 바뀝니다.
+
+### 3.10 그 밖의 제거된 API
+
+| 제거됨 | 비고 |
+|---|---|
+| `ModalNavigation.Variant.extended` | 대응 없음 |
+| `ModalNavigation.Variant.floating(alternative:background:)` | 인자 없는 `.floating`만 남음 |
+| `Select.shadowBackgroundColor(_:)` | 대응 없음 |
+| `Skeleton.Length` (`_25`/`_50`/`_75`/`_100`) | 폭이 균일로 고정 |
+
+---
+
+## 4. 화면이 달라지는 것
+
+**컴파일은 통과하지만 화면이 달라지는 항목입니다.** API가 그대로라 치환 작업이 끝난 뒤 화면을 봐야 드러납니다.
+
+### 4.1 컴포넌트 스펙
 
 #### Button
 
@@ -661,8 +913,6 @@ deprecated UIKit 래퍼가 제거됐습니다. SwiftUI 컴포넌트를 `UIHostin
 | radius | large 12 / medium 10 / small 8 | large **14** / medium **12** / small **10** / xsmall 8 |
 | 높이 제약 | `.frame(height:)` 고정 | `.frame(minHeight:)` |
 | 아이콘 크기 | large 24 / medium 24·22 / small 20·18 | large 22 / medium 22·20 / small 20·16 / xsmall 16 |
-| 사이즈 | large · medium · small | **+ xsmall** |
-| color | primary · assistive | **+ negative** |
 | 타이포 | 사이즈별 한 단계 위 | 사이즈별 한 단계 아래로 조정 |
 
 **높이 제약이 고정에서 최소값으로 바뀐 게 파급이 가장 큽니다.** 3.x는 라벨이 길면 한 줄로 말줄임(`텍스트...`)했는데, 4.0은 **줄바꿈해서 버튼이 세로로 커집니다.** 긴 라벨을 쓰는 버튼이 있으면 주변 레이아웃이 밀립니다.
@@ -684,30 +934,34 @@ FilterButton은 radius가 커지고 패딩이 줄어 더 둥글고 작아집니�
 
 | 항목 | 3.x | 4.0 |
 |---|---|---|
-| 사이즈 | 없음 | `size(.large / .medium)` 신설 |
 | min-height | - | 증가 (필드가 높아짐) |
 | 테두리 색 | - | 옅어짐 |
-| `heading` · `requiredBadge` | 컴포넌트 내장 | 제거 - `FormControl`로 이관 |
 | 세로 정렬 | 항상 `top` | `overflow`일 때만 `top`, 그 외 `center` |
 
 세로 정렬은 Dynamic Type을 키웠을 때만 눈에 띕니다. 3.x는 항상 `top` 정렬이라 텍스트 높이가 leading 아이콘·chevron(24pt)을 넘어서면 **아이콘만 위로 치우쳐** 보였습니다. 4.0은 여러 줄로 흐르는 `overflow` 상태에서만 `top`을 쓰고 한 줄일 때는 `center`로 맞춥니다. 선택 목록의 `ListCell`도 `verticalAlign(.center)`가 붙어 라디오·체크박스가 라벨 중앙에 옵니다.
 
-#### TopNavigation · ModalNavigation
-
-스크롤 시 깔리는 배경 tint 농도가 올라갔습니다.
-
-| 항목 | 3.x·4.0 초기 | 4.0 |
-|---|---|---|
-| 스크롤 배경 tint | `backgroundOpacity * 0.7` | `backgroundOpacity * 0.88` |
-
-콘텐츠를 스크롤해 내비게이션 배경이 나타나는 구간에서 **배경이 더 진해집니다.** API 변경은 없고 값만 바뀌므로 컴파일 에러가 나지 않습니다. 내비게이션 아래로 콘텐츠가 지나가는 화면을 눈으로 확인해주세요.
-
-#### SegmentedControl
+#### ActionArea
 
 | 항목 | 3.x | 4.0 |
 |---|---|---|
-| variant | `solid` · `outlined` | **`outlined` 제거** |
-| 아이콘 | `icon` 토글 | `leadingIcon` + `iconOnly` |
+| `extra` 슬롯 좌우 여백 | 20 | **24** |
+| `extra` 슬롯 하단 여백 | 24 | **20** |
+| `extra` 구분선 색 | `lineNeutral` (= `lineNeutralSecondary`) | `lineNeutralTertiary` (옅어짐) |
+| 캡션 타이포 | `label2` | `label2` + `weight: .medium` (굵어짐) |
+| 대체(`alternative`) 액션 버튼 | `outlined` / `primary` | `outlined` / **`assistive`** |
+| `cancel` 메인 액션 버튼 | `outlined` / `assistive` | **`solid`** / `assistive` |
+
+메인 버튼 행의 좌우 여백 20은 그대로입니다.
+
+버튼 색상은 API가 그대로라 컴파일 에러가 나지 않습니다. 대체 액션은 라벨이 파란색에서 검정으로 바뀌어 주 액션과의 대비가 커지고, `cancel` variant의 메인 버튼은 테두리형에서 회색 채움으로 바뀝니다. 보조(`sub`) 액션은 변경이 없습니다.
+
+#### TopNavigation · ModalNavigation
+
+| 항목 | 3.x | 4.0 |
+|---|---|---|
+| 스크롤 배경 tint | `backgroundOpacity * 0.7` | `backgroundOpacity * 0.88` |
+
+콘텐츠를 스크롤해 내비게이션 배경이 나타나는 구간에서 **배경이 더 진해집니다.**
 
 #### Avatar · AvatarGroup
 
@@ -722,67 +976,169 @@ company·academy variant의 cornerRadius가 전 사이즈에서 **+2** 됩니다
 | `xlarge` | 14 | 16 |
 | `custom(v)` | `ceil(v * 0.25 / 2) * 2` | `ceil(v * 0.25 / 2) * 2 + 2` |
 
-테두리 기본색이 `lineAlternative`에서 `lineNeutralTertiary`로, 푸시뱃지 inset도 사이즈별로 조정됐습니다.
+이미지가 없을 때 그리는 플레이스홀더도 전용 일러스트에서 아이콘 글리프(`personFill` / `companyFill` / `graduationFill`)로 바뀌었습니다. 푸시뱃지 inset도 사이즈별로 조정됐습니다.
 
 #### 그 외
 
-`Shadow` · `Typography` · `Opacity` · `Spacing` 정의와 `Toast` · `SnackBar` · `Popup` · `Popover` · `Tooltip` · `Thumbnail` · `Accordion` · `Category` · `ProgressTracker`도 값이 조정됐습니다. 새로 생긴 `Radius` · `Dimension` · `Primitive` · `MaterialBackground`는 추가 API입니다.
+`Shadow` · `Typography` · `Opacity` · `Spacing` 정의와 `Toast` · `SnackBar` · `Popup` · `Popover` · `Tooltip` · `Thumbnail` · `Accordion` · `Category` · `ProgressTracker`도 값이 조정됐습니다.
 
----
+### 4.2 전체 목록
 
-## 시각 결과가 달라지는 변경
-
-컴파일은 통과하지만 화면이 달라지는 항목입니다. **마이그레이션 후 이 목록의 화면을 눈으로 확인해주세요.**
+**마이그레이션 후 이 목록의 화면을 눈으로 확인해주세요.**
 
 | 대상 | 무엇이 달라지나 |
 |---|---|
+| **컬러 토큰** | `accentForegroundBlue`·`Green`·`Orange`는 라이트·다크 모두, 나머지 `accentForeground*`와 `materialDimmer`는 다크에서 색이 바뀝니다. [값이 함께 바뀌는 토큰](#값이-함께-바뀌는-토큰) 참고 |
+| **RedOrange 토큰** | 대응 토큰이 없어 무엇으로 옮기든 **색이 바뀝니다.** 쓰던 자리를 전부 찾아 확인해주세요 |
+| **Spacing pt28 · pt36** | 대응 값이 없어 24/32/40 중 하나를 골라야 하고 레이아웃이 4pt씩 움직입니다 |
 | **Button** | 높이 제약이 고정에서 최소값으로 바뀌어 **긴 라벨이 말줄임 대신 줄바꿈**됩니다. 버튼이 세로로 커져 주변 레이아웃이 밀립니다. radius도 사이즈별로 +2 |
 | **Chip · FilterButton** | 타이포가 한 단계 내려가고 패딩이 줄어 **작아집니다.** 가로로 나열되는 칩·필터 바의 줄바꿈 지점이 달라집니다 |
 | **Select** | min-height가 올라가 **선택 필드가 높아집니다.** 테두리 색도 옅어집니다. Dynamic Type을 키웠을 때 leading 아이콘·chevron이 위로 치우치던 것이 중앙정렬로 정정됐습니다 |
 | **SegmentedControl** | `outlined` variant 제거. outlined를 쓰던 자리는 solid로 바뀝니다 |
 | **ActionArea** | 투명 배경이 **스크롤 하단 도달 신호에 묶입니다.** 신호를 올려주지 않는 컨테이너(`SwiftUI.ScrollView`·`List`·스크롤 없는 팝업)에서는 그라데이션과 불투명 배경이 그대로 남으므로 `scrollReachedEnd(true)`를 직접 넘겨야 합니다. 배경이 투명해지는 건 `extra` 슬롯이 비어 있을 때뿐입니다. `extra` 슬롯 좌우 여백 20→24·하단 24→20, 구분선 옅어짐, 캡션이 `medium` weight로 굵어짐. **대체 액션 버튼 라벨이 파란색에서 검정으로, `cancel` 메인 버튼이 테두리형에서 회색 채움으로 바뀝니다** |
-| **Avatar · AvatarGroup** | company·academy cornerRadius 전 사이즈 +2. 회사 로고가 조금 더 둥글어집니다 |
-| **FallbackView** | 상하 최소 여백 160 내장. 밖의 여백·고정 높이를 정리하지 않으면 이중 적용. 설명 타이포가 `body2` → `body2Reading`으로 행간이 늘어납니다 |
+| **AvatarGroup variant** | `variant:`가 `.person` 고정이라 company·academy로 묶던 그룹이 **둥근 사각형에서 원형으로** 바뀝니다 |
+| **Avatar · AvatarGroup** | company·academy cornerRadius 전 사이즈 +2. 이미지 없을 때 플레이스홀더가 일러스트에서 아이콘 글리프로 교체. 비활성 시 `opacity43` 적용 |
+| **FallbackView** | `image:` 슬롯이 없어져 **삽화가 사라집니다.** 상하 최소 여백 160 내장. 밖의 여백·고정 높이를 정리하지 않으면 이중 적용. 설명 타이포가 `body2` → `body2Reading`으로 행간이 늘어납니다 |
+| **TextField 트레일링 버튼** | `variant:`가 없어져 outlined로 고정됩니다. `primary`로 강조하던 버튼의 색이 바뀝니다 |
 | **입력 컴포넌트** | 라벨이 필드 위로, 에러가 필드 아래로, 카운터가 필드 아래 우측으로 나옵니다. 필드 높이와 폼 전체 높이가 달라집니다 |
+| **TextArea 하단 리소스** | 리소스 간 간격 기본값이 고정 4에서 사이즈별(large 8 / medium 6)로 바뀝니다 |
 | **글자수 카운터** | `Text("...")` 보간은 상한 1000 이상에서 천단위 구분자가 붙습니다(`5,000`). `Text(verbatim:)`을 쓰세요 |
-| **disabled 표현** | 컴포넌트 자체 `opacity` → `isEnabled` 기반 색 토큰. 불투명도 이중 적용이 없어져 **덜 흐려 보입니다**. ListCell 슬롯에 넣은 커스텀 뷰(회사 로고 등)는 더 이상 흐려지지 않습니다 |
-| **PlayBadge** | 배경에 `coolNeutral40` 28% 틴트 추가. 밝은 썸네일에서 뱃지가 보이게 됩니다 |
+| **비활성 상태** | 컴포넌트가 직접 낮추던 불투명도 대신 `isEnabled` 기반 색 토큰을 씁니다. 불투명도가 겹쳐 적용되지 않아 **덜 흐려 보입니다.** ListCell 슬롯에 넣은 커스텀 뷰(회사 로고 등)는 이제 흐려지지 않습니다. **상위 뷰의 `.disabled(true)`가 `Chip`·`FilterButton` 색까지 바꿉니다**(3.x는 터치만 막혔습니다) |
+| **PushBadge** | 한 글자 뱃지가 `badgeSize` 정사각으로 고정됩니다. 확대 상한이 생겨 접근성 글자 크기에서 3.x보다 작게 나옵니다 |
+| **PlayBadge** | 배경에 `coolNeutral40` 28% 틴트 추가, 재생 아이콘이 `staticWhite` 88%로. 밝은 썸네일에서도 뱃지가 묻히지 않습니다 |
 | **Toast · SnackBar** | 배경 불투명도 light 50% → 52%, dark 46% → 43% |
 | **BottomSheet** | 배경 불투명도 80% → 88% |
-| **SearchField** | solid 틴트 2겹, 비활성 outlined 배경이 `surfaceNeutralTertiary`로 |
 | **TopNavigation · ModalNavigation** | 스크롤 배경 tint 농도가 `0.7` → `0.88`로 올라가 **스크롤 시 내비게이션 배경이 더 진해집니다** |
-| **Typography `caption2`** | Dynamic Type 스케일 곡선이 `.caption2` → `.caption`. 기본 크기는 동일하고, 확대 단계에서 `caption2`가 `caption1`보다 커지던 위계 역전이 해소됩니다 |
-| **Avatar · Thumbnail** | 비활성 시 `opacity43` 적용 |
+| **Typography `caption2`** | Dynamic Type 스케일 곡선이 `.caption2` → `.caption`. 기본 크기는 그대로고, 확대했을 때 `caption2`가 `caption1`보다 커지던 문제가 없어집니다 |
+| **Thumbnail** | 비활성 시 `opacity43` 적용 |
 | **Skeleton** | 텍스트 플레이스홀더 바 폭이 가변 → 균일 (로딩 중 한정) |
-| **IconButton** | 글리프 동일, 터치 컨테이너만 확대 (약 6~8px 레이아웃 이동) |
-| **RedOrange 토큰** | `accentForegroundRedOrange`·`accentBackgroundRedOrange`에 대응 토큰이 없어 무엇으로 옮기든 **색이 바뀝니다.** 이 토큰을 쓰던 자리를 전부 찾아 확인해주세요 |
+| **IconButton** | 글리프 동일, 터치 컨테이너만 확대 (약 68pt 레이아웃 이동) |
+
+---
+
+## 추가된 API
+
+**마이그레이션에 필요 없습니다.** 4.0에서 새로 쓸 수 있게 된 것들이라 참고용으로만 적어둡니다. 자세한 사용법은 [DocC 문서](./documentation)와 Blueprint 샘플 앱에 있습니다.
+
+### 신규 컴포넌트
+
+#### ScreenScaffold
+
+`TopNavigation` + 본문 + `ActionArea`를 한 화면으로 조립합니다. 화면마다 손으로 맞추던 스크롤 오프셋 전달과 하단 여백 계산을 대신합니다. 제거된 `View.topNavigation(...)`의 대체 수단이기도 해서 마이그레이션 중에도 등장합니다([2.4](#24-viewtopnavigation-제거)).
+
+```swift
+ScreenScaffold(
+    navigation: { TopNavigation(title: "설정") },
+    actionArea: { ActionArea(variant: .neutral(main: .init(text: "저장", action: save))) }
+) {
+    content
+}
+.backgroundColor(.semantic(.backgroundNeutralPrimary))
+```
+
+#### SearchField
+
+검색어 입력 컴포넌트입니다. 왼쪽 검색 아이콘과 입력 영역으로 구성되고, 입력값이 있으면 오른쪽에 지우기 버튼이 나타납니다. 크기 체계는 `TextField`와 같습니다. `TopNavigation`의 검색 모드도 이 컴포넌트를 씁니다.
+
+```swift
+SearchField(text: $keyword)
+    .placeholder("검색어를 입력해 주세요.")
+    .onSubmit { search(keyword) }
+
+// 테두리형, medium
+SearchField(text: $keyword)
+    .variant(.outlined)
+    .size(.medium)
+```
+
+#### FormControl · FormControlGroup
+
+`FormControl`은 입력 컴포넌트의 라벨·메시지·accessory를 배치합니다. 컴포넌트에 모디파이어를 직접 붙이면 내부에서 알아서 감싸므로 직접 쓸 일은 많지 않습니다([2.1](#21-입력-컴포넌트의-라벨메시지카운터)).
+
+`FormControlGroup`은 라벨을 왼쪽에 두는 입력을 여러 개 쌓을 때 라벨 열 폭을 가장 긴 라벨에 맞춥니다. 호출부에 고정 폭을 박지 않아도 되고, Dynamic Type이나 다국어로 라벨 길이가 바뀌어도 알아서 다시 맞춥니다.
+
+```swift
+FormControlGroup {
+    TextField(text: $name)
+        .labelPlacement(.leading)
+        .label("이름")
+
+    TextField(text: $email)
+        .labelPlacement(.leading)
+        .label("이메일 주소")
+}
+// 라벨 열이 "이메일 주소" 폭으로 통일되고 두 입력의 시작 위치가 맞는다
+```
+
+### 신규 토큰 그룹
+
+`Radius` · `Dimension` · `Primitive` · `MaterialBackground`. 각각 `CGFloat` 확장으로 노출되고 `allValues` · `min` · `max`를 제공합니다.
+
+시맨틱 토큰도 새로 생긴 게 있습니다: `lineBrandFocus`, `lineNegativeFocus`, `surfaceBrandSubtle`, `surfaceNegativeStrong`, `foregroundAccent*`, `lineAccent*`, `surfaceAccent*`(반투명 8%).
+
+### 컴포넌트별 추가
+
+| 컴포넌트 | 추가된 것 |
+|---|---|
+| `Button` | 사이즈 `xsmall`, color `negative` |
+| `TextButton` | `fillWidth(_:)` |
+| `IconButton` | `disableInteraction(_:)`, `interactionColor(_:)` |
+| `ActionArea` | `caption(_:icon:)`의 아이콘 슬롯(16pt), `scrollReachedEnd(_:)`, `backgroundColor(_:)` |
+| `TopNavigation` | `backgroundColor(_:)` |
+| `Chip` | `borderColor(_:)` |
+| `Category` | `itemDisabled(_:)` |
+| `PushBadge` | `outlineBorder(_:color:)` |
+| `ListCell` | `verticalPadding(.custom(_:))`, 슬롯 4개(`leading` · `labelTrailing` · `trailing` · `extra`) |
+| `Select` | `size(.large/.medium)` |
+| `TextField` · `TextArea` | `autocorrectionDisabled(_:)`, `onTextChange(_:)`, `size(_:)` |
+| `Shadow` | `shadow(_:) -> some ShapeStyle` |
+| `UIColor` | Montage 토큰 확장 |
 
 ---
 
 ## 체크리스트
 
-- [ ] 컬러 시맨틱 토큰 치환 후 `grep -rn "\.label\(Normal\|Alternative\|Assistive\|Strong\|Neutral\|Disable\)\b"`로 잔존 확인
-- [ ] `spacing(.pt` · `opacity(.p` 잔존 확인
-- [ ] `.disable(` 잔존 확인 (`.disabled(`가 맞습니다)
-- [ ] 모든 `TextField`/`TextArea`가 `FormControl`로 감싸졌는지
+### 치환
+
+- [ ] 컬러 시맨틱 토큰 치환 후 `grep -rn "\.label\(Normal\|Alternative\|Assistive\|Strong\|Neutral\|Disable\)\b"`로 남은 곳 확인
+- [ ] `spacing(.pt` · `opacity(.p` 남은 곳 확인
+- [ ] `grep -rn "spacing(\.pt28\|spacing(\.pt36"` - 대응 없는 값
+- [ ] `.disable(` 남은 곳 확인 (`.disabled(`가 맞습니다)
+- [ ] `Chip`·`FilterButton`의 `.disabled()` 뒤에 컴포넌트 전용 모디파이어를 체이닝한 자리가 없는지
+- [ ] `.topNavigation(` 남은 곳 확인
+- [ ] `accentForegroundRedOrange` · `accentBackgroundRedOrange` 사용처 전수 확인
+- [ ] `FallbackView(image:` · `AvatarGroup(` 의 `variant:` · `TrailingButtonInfo(variant:` 사용처 확인
+
+### 구조
+
+- [ ] 3.x의 `heading`·`requiredBadge`·`description`을 `label`·`message`로 옮겼는지
 - [ ] 글자수 카운터가 `Text(verbatim:)`인지 - 상한 1000 이상 자리 우선
 - [ ] `FallbackView` 사용처의 외부 `padding(.vertical,)` · `frame(height:)` 제거
-- [ ] `.actionArea {}` 슬롯 안에 `if`문이 없는지
+- [ ] `.actionArea {}` · `ScreenScaffold` 슬롯 안에 `if`문이 없는지
 - [ ] Chip 슬롯 아이콘의 크기·색을 사용처에서 지정했는지
-- [ ] 긴 라벨을 쓰는 버튼이 줄바꿈되면서 높아진 만큼 주변 레이아웃이 밀려도 괜찮은지
 - [ ] `transparentBackground`를 `.manual`로 쓰던 자리에 `scrollReachedEnd(_:)`를 넘겼는지
-- [ ] 스크롤 컨테이너가 없는 팝업·시트의 ActionArea 배경이 의도대로 보이는지
-- [ ] `alternative` 액션과 `.cancel` variant를 쓰는 ActionArea의 버튼 색이 의도대로 보이는지
-- [ ] [컴포넌트 스펙 리프레시](#8-컴포넌트-스펙-리프레시)·[시각 결과가 달라지는 변경](#시각-결과가-달라지는-변경) 목록의 화면을 실기기/시뮬레이터에서 확인
 
-> 스펙 변경은 Blueprint를 두 버전으로 빌드해 대조하면 가장 빠르게 확인됩니다.
->
-> ```bash
-> git worktree add --detach ../baseline v3.15.2   # 올라오기 전 버전
-> xcodebuild -workspace ../baseline/Montage.xcworkspace -scheme Blueprint \
->   -configuration Debug -destination 'id=<simulator udid>' \
->   -derivedDataPath /tmp/dd-before build
-> ```
+### 화면 확인
+
+- [ ] `accentForeground{Blue,Green,Orange}`를 쓰던 화면의 색 (라이트·다크 둘 다)
+- [ ] 나머지 `accentForeground*` · `materialDimmer` 다크 모드
+- [ ] 긴 라벨을 쓰는 버튼이 줄바꿈되면서 높아진 만큼 주변 레이아웃이 밀려도 괜찮은지
+- [ ] 스크롤 컨테이너가 없는 팝업·시트의 ActionArea 배경
+- [ ] `alternative` 액션과 `.cancel` variant를 쓰는 ActionArea의 버튼 색
+- [ ] 이미지 없는 Avatar의 플레이스홀더
+- [ ] 삽화를 쓰던 `FallbackView` 화면과 company·academy `AvatarGroup`
+- [ ] [4. 화면이 달라지는 것](#4-화면이-달라지는-것) 목록의 화면을 실기기/시뮬레이터에서 확인
+
+스펙 변경은 Blueprint를 두 버전으로 빌드해 대조하는 게 가장 빠릅니다. `UDID`에는 `xcrun simctl list devices`로 확인한 값을 넣습니다.
+
+```bash
+UDID=... # xcrun simctl list devices
+
+git worktree add --detach ../baseline v3.15.2
+xcodebuild -workspace ../baseline/Montage.xcworkspace -scheme Blueprint \
+  -configuration Debug -destination "id=$UDID" \
+  -derivedDataPath /tmp/dd-before build
+```
 
 ---
 

--- a/MIGRATION.ko.md
+++ b/MIGRATION.ko.md
@@ -18,12 +18,14 @@
 
 | 순서 | 절 | 성격 | 하는 일 |
 |---|---|---|---|
-| 1 | [이름이 바뀐 것](#1-이름이-바뀐-것) | 기계적 치환 | `sed`로 끝납니다 |
+| 1 | [이름이 바뀐 것](#1-이름이-바뀐-것) | 기계적 치환 | 대부분 `sed`로 끝납니다 |
 | 2 | [없어져서 다시 짜야 하는 것](#2-없어져서-다시-짜야-하는-것) | 구조 재작성 | 대체 API로 옮깁니다 |
 | 3 | [대응이 없는 것](#3-대응이-없는-것) | 직접 선택 | 사용처가 판단해야 합니다 |
 | 4 | [화면이 달라지는 것](#4-화면이-달라지는-것) | 화면 확인 | **컴파일 에러가 나지 않습니다** |
 
 **4번을 건너뛰지 마세요.** API는 그대로인데 값만 바뀐 항목이라 빌드가 통과해도 화면이 달라집니다. 치환이 끝났다고 마이그레이션이 끝난 게 아닙니다.
+
+1번도 전부 `sed`로 끝나지는 않습니다. 컬러 토큰 12건은 이름과 함께 색값까지 바뀌고([값이 함께 바뀌는 토큰](#값이-함께-바뀌는-토큰)), `\b` 치환은 Swift 문법을 모르기 때문에 주석이나 문자열 리터럴에 들어간 같은 이름도 함께 바꿉니다. 치환 뒤 diff를 한 번 훑어주세요.
 
 ---
 
@@ -1012,7 +1014,7 @@ company·academy variant의 cornerRadius가 전 사이즈에서 **+2** 됩니다
 | **Typography `caption2`** | Dynamic Type 스케일 곡선이 `.caption2` → `.caption`. 기본 크기는 그대로고, 확대했을 때 `caption2`가 `caption1`보다 커지던 문제가 없어집니다 |
 | **Thumbnail** | 비활성 시 `opacity43` 적용 |
 | **Skeleton** | 텍스트 플레이스홀더 바 폭이 가변 → 균일 (로딩 중 한정) |
-| **IconButton** | 글리프 동일, 터치 컨테이너만 확대 (약 68pt 레이아웃 이동) |
+| **IconButton** | 글리프 동일, 터치 컨테이너만 확대 (약 6\~8pt 레이아웃 이동) |
 
 ---
 
@@ -1088,7 +1090,7 @@ FormControlGroup {
 | `Chip` | `borderColor(_:)` |
 | `Category` | `itemDisabled(_:)` |
 | `PushBadge` | `outlineBorder(_:color:)` |
-| `ListCell` | `verticalPadding(.custom(_:))`, 슬롯 4개(`leading` · `labelTrailing` · `trailing` · `extra`) |
+| `ListCell` | `verticalPadding(.custom(_:))`, 슬롯 모디파이어 4개(`leadingResources(_:)` · `labelTrailingResources(_:)` · `trailingResources(_:)` · `extraResources(_:)`) |
 | `Select` | `size(.large/.medium)` |
 | `TextField` · `TextArea` | `autocorrectionDisabled(_:)`, `onTextChange(_:)`, `size(_:)` |
 | `Shadow` | `shadow(_:) -> some ShapeStyle` |
@@ -1134,11 +1136,19 @@ FormControlGroup {
 ```bash
 UDID=... # xcrun simctl list devices
 
+# 올라오기 전 버전
 git worktree add --detach ../baseline v3.15.2
 xcodebuild -workspace ../baseline/Montage.xcworkspace -scheme Blueprint \
   -configuration Debug -destination "id=$UDID" \
   -derivedDataPath /tmp/dd-before build
+
+# 올라갈 버전
+xcodebuild -workspace Montage.xcworkspace -scheme Blueprint \
+  -configuration Debug -destination "id=$UDID" \
+  -derivedDataPath /tmp/dd-after build
 ```
+
+두 빌드를 같은 시뮬레이터에 번갈아 설치해 [4. 화면이 달라지는 것](#4-화면이-달라지는-것) 목록의 컴포넌트를 나란히 놓고 봅니다. 목록에 없는데 달라 보이는 게 있으면 문서가 빠뜨린 것이니 알려주세요.
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,172 +2,184 @@
 
 [English](./MIGRATION.md) | [한국어](./MIGRATION.ko.md)
 
-Changes required when upgrading across a major version. The newest version comes first.
+Changes required to move between major versions. Newest first.
 
-Every item is marked as one of three kinds: **a mechanical replacement**, **something you have to restructure**, or **something that changes what you see**. Some items are easy to miss if you only clear the compile errors and never look at the screen, so please read the final [Changes that alter what you see](#changes-that-alter-what-you-see) section.
+**This document covers breaking changes only.** New components and modifiers are listed by name under [Added APIs](#added-apis); see the [release notes](https://github.com/wanteddev/montage-ios/releases) for details.
+
+Each major section is written against the **last release tag of the previous major**. APIs that appeared and disappeared during development are not listed, since nobody upgrading from the previous release ever saw them.
 
 ---
 
 ## 4.0
 
-> **In progress.** This document is updated as items land on `release/4.0.0`.
+**Baseline: v3.15.2 → 4.0.0**
 
-4.0 brings breaking changes along four axes.
+Breaking changes fall into four groups. Working top to bottom clears compile errors fastest.
 
-1. **Color semantic tokens reorganized** - token names now follow a `usage + role + variant` rule. Most values stay the same; only the names change.
-2. **Slot-based APIs** - instead of fixed parameters (`leadingImage:`) and `Model` structs, the call site passes views directly.
-3. **Input components split apart** - labels, status messages, and character counts moved out of `TextField`/`TextArea` and into `FormControl` slots.
-4. **Component spec refresh** - radius, typography, padding, and icon sizes were retuned to match the design spec. **This is the only axis where the API is unchanged, so nothing fails to compile.**
-
-### Order of work
-
-| Step | Task | Kind | Visual change |
+| Order | Section | Kind | What you do |
 |---|---|---|---|
-| 1 | [Color semantic tokens](#1-color-semantic-tokens) | Mechanical | None |
-| 2 | [Spacing and Opacity tokens](#2-spacing-and-opacity-tokens) | Mechanical | None |
-| 3 | [Global modifiers](#3-global-modifiers) | Mechanical | None |
-| 4 | [Input components to FormControl](#4-input-components-to-formcontrol) | Restructure | **Yes** |
-| 5 | [Slot-based APIs](#5-slot-based-apis) | Restructure | Mostly none |
-| 6 | [Straight API replacements](#6-straight-api-replacements) | Mechanical | Some |
-| 7 | [Removed UIKit wrappers](#7-removed-uikit-wrappers) | Restructure | None |
-| 8 | [Component spec refresh](#8-component-spec-refresh) | Check the screen | **Yes** |
-| 9 | [Review changes that alter what you see](#changes-that-alter-what-you-see) | Check the screen | **Yes** |
+| 1 | [Renamed](#1-renamed) | Mechanical | `sed` handles it |
+| 2 | [Removed, needs rework](#2-removed-needs-rework) | Restructure | Move to the replacement API |
+| 3 | [No replacement](#3-no-replacement) | Judgement call | You have to choose |
+| 4 | [Visual changes](#4-visual-changes) | Eyeball it | **No compile errors** |
 
-**Do not skip step 8.** Those items keep the same API and only change values, so nothing fails to compile. A green build after the replacements does not mean the migration is done.
-
-Finishing the token replacements (1 through 3) first removes most of the compile errors and makes the rest of the work easier to see.
+**Do not skip section 4.** Those entries keep the same API and change only values, so the build passes while the screen changes. A clean build does not mean the migration is done.
 
 ---
 
-### 1. Color semantic tokens
+## 1. Renamed
 
-Every token name passed to `Color.semantic(_:)` / `UIColor.semantic(_:)` changes. **Except for two RedOrange entries**, the mappings below keep the same value, so rendering does not change. RedOrange has no 4.0 counterpart, so you have to pick one yourself and the color will change.
+### 1.1 Semantic color tokens
 
-#### The new naming rule
+Every token name passed to `Color.semantic(_:)` / `UIColor.semantic(_:)` changes. Most are pure renames, but **14 also change the rendered color.** Check [Tokens whose value also changes](#tokens-whose-value-also-changes).
+
+#### Naming rule
 
 ```
-usage + role + variant
+purpose + role + variant
 
-usage    foreground  text and icons
-         background  the page beneath everything
-         surface     surfaces that sit on the page (cards, fields, buttons)
+purpose  foreground  text and icons
+         background  page background
+         surface     backgrounds of elements on the page (cards, fields, buttons)
          line        borders and dividers
-         effect      dimming and transparent layers
+         effect      dim and translucent layers
 
 role     Neutral  Brand  Positive  Cautionary  Negative  Disable  Inactive  Accent{Color}
 
 variant  Primary → Secondary → Tertiary → Quaternary  (decreasing contrast)
          Strong / Heavy   darker
          Subtle           lighter
-         Inverse          for use on an inverted background
+         Inverse          for use on inverted backgrounds
          Focus            focus ring
-         Opaque           the opaque version (the suffix-less one is translucent)
+         Opaque           opaque version (the suffix-less one is translucent)
 ```
 
-The `Solid` suffix from 3.x is inverted to `Opaque` in 4.0. The only thing to watch is that the suffix moves from the front to the back, as in **`lineSolidNormal` → `lineNeutralPrimaryOpaque`**.
+The 3.x `Solid` prefix became the `Opaque` suffix in 4.0. The only thing to watch is that the marker moves from front to back: **`lineSolidNormal` → `lineNeutralPrimaryOpaque`**.
 
 #### Foreground - text and icons
 
-| 3.x | 4.0 |
-|---|---|
-| `.labelNormal` | `.foregroundNeutralPrimary` |
-| `.labelStrong` | `.foregroundNeutralStrong` |
-| `.labelNeutral` | `.foregroundNeutralSecondary` |
-| `.labelAlternative` | `.foregroundNeutralTertiary` |
-| `.labelAssistive` | `.foregroundNeutralQuaternary` |
-| `.inverseLabel` | `.foregroundNeutralInverse` |
-| `.labelDisable` | `.foregroundDisablePrimary` |
-| `.interactionInactive` | `.foregroundInactivePrimary` |
-| `.inversePrimary` | `.foregroundBrandInverse` |
-| `.statusPositive` | `.foregroundPositivePrimary` |
-| `.statusCautionary` | `.foregroundCautionaryPrimary` |
-| `.statusNegative` | `.foregroundNegativePrimary` |
-| `.accentForegroundBlue` | `.foregroundBrandPrimary` |
-| `.accentForegroundGreen` | `.foregroundPositivePrimary` |
-| `.accentForegroundOrange` | `.foregroundCautionaryPrimary` |
-| `.accentForegroundRed` | `.foregroundNegativeStrong` |
-| `.accentForegroundRedOrange` | **No counterpart** (see below) |
-| `.accentForegroundLime` | `.foregroundAccentLime` |
-| `.accentForegroundCyan` | `.foregroundAccentCyan` |
-| `.accentForegroundLightBlue` | `.foregroundAccentLightBlue` |
-| `.accentForegroundViolet` | `.foregroundAccentViolet` |
-| `.accentForegroundPurple` | `.foregroundAccentPurple` |
-| `.accentForegroundPink` | `.foregroundAccentPink` |
+| 3.x | 4.0 | Value |
+|---|---|---|
+| `.labelNormal` | `.foregroundNeutralPrimary` | same |
+| `.labelStrong` | `.foregroundNeutralStrong` | same |
+| `.labelNeutral` | `.foregroundNeutralSecondary` | same |
+| `.labelAlternative` | `.foregroundNeutralTertiary` | same |
+| `.labelAssistive` | `.foregroundNeutralQuaternary` | same |
+| `.inverseLabel` | `.foregroundNeutralInverse` | **slightly different** |
+| `.labelDisable` | `.foregroundDisablePrimary` | same |
+| `.interactionInactive` | `.foregroundInactivePrimary` | same |
+| `.inversePrimary` | `.foregroundBrandInverse` | same |
+| `.statusPositive` | `.foregroundPositivePrimary` | same |
+| `.statusCautionary` | `.foregroundCautionaryPrimary` | same |
+| `.statusNegative` | `.foregroundNegativePrimary` | same |
+| `.accentForegroundBlue` | `.foregroundBrandPrimary` | **changed** |
+| `.accentForegroundGreen` | `.foregroundPositivePrimary` | **changed** |
+| `.accentForegroundOrange` | `.foregroundCautionaryPrimary` | **changed** |
+| `.accentForegroundRed` | `.foregroundNegativeStrong` | **dark changed** |
+| `.accentForegroundLime` | `.foregroundAccentLime` | **dark changed** |
+| `.accentForegroundCyan` | `.foregroundAccentCyan` | **dark changed** |
+| `.accentForegroundLightBlue` | `.foregroundAccentLightBlue` | **dark changed** |
+| `.accentForegroundViolet` | `.foregroundAccentViolet` | **dark changed** |
+| `.accentForegroundPurple` | `.foregroundAccentPurple` | **dark changed** |
+| `.accentForegroundPink` | `.foregroundAccentPink` | **dark changed** |
+| `.accentForegroundRedOrange` | none | see [3.1](#31-redorange-tokens) |
 
-> Among `accentForeground{Color}`, Blue, Green, Orange, and Red were **promoted from the accent family to semantic colors** (brand/positive/cautionary/negative). Do not just rename them; check that the spot really calls for a semantic color.
+> Among `accentForeground{Color}`, Blue, Green, Orange, and Red **changed role from `Accent{Color}` to `Brand`, `Positive`, `Cautionary`, and `Negative`.** Do not just swap the name - confirm the spot really carries that role.
 
-#### Background and Surface
+#### Background · Surface - page and element backgrounds
 
-| 3.x | 4.0 |
-|---|---|
-| `.backgroundNormal` | `.backgroundNeutralPrimary` |
-| `.backgroundNormalAlternative` | `.backgroundNeutralSecondary` |
-| `.backgroundElevated` | `.surfaceElevatedPrimary` |
-| `.backgroundElevatedAlternative` | `.surfaceElevatedSecondary` |
-| `.fillNormal` | `.surfaceNeutralSecondary` |
-| `.fillAlternative` | `.surfaceNeutralTertiary` |
-| `.fillStrong` | `.surfaceNeutralStrong` |
-| `.fillPrimary` | `.surfaceBrandSubtle` |
-| `.fillNegative` | `.surfaceNegativeStrong` |
-| `.backgroundStatusPositive` | `.surfacePositivePrimary` |
-| `.backgroundStatusCautionary` | `.surfaceCautionaryPrimary` |
-| `.backgroundStatusNegative` | `.surfaceNegativePrimary` |
-| `.inverseBackground` | `.surfaceNeutralInverse` |
-| `.primaryNormal` | `.surfaceBrandPrimary` |
-| `.primaryStrong` | `.surfaceBrandStrong` |
-| `.primaryHeavy` | `.surfaceBrandHeavy` |
-| `.interactionDisable` | `.surfaceDisablePrimary` |
-| `.accentBackgroundLime` | `.surfaceAccentLimeOpaque` |
-| `.accentBackgroundCyan` | `.surfaceAccentCyanOpaque` |
-| `.accentBackgroundLightBlue` | `.surfaceAccentLightBlueOpaque` |
-| `.accentBackgroundViolet` | `.surfaceAccentVioletOpaque` |
-| `.accentBackgroundPink` | `.surfaceAccentPinkOpaque` |
-| `.accentBackgroundRedOrange` | **No counterpart** (see below) |
+| 3.x | 4.0 | Value |
+|---|---|---|
+| `.backgroundNormal` | `.backgroundNeutralPrimary` | same |
+| `.backgroundNormalAlternative` | `.backgroundNeutralSecondary` | same |
+| `.backgroundElevated` | `.surfaceElevatedPrimary` | same |
+| `.backgroundElevatedAlternative` | `.surfaceElevatedSecondary` | same |
+| `.fillNormal` | `.surfaceNeutralSecondary` | same |
+| `.fillAlternative` | `.surfaceNeutralTertiary` | same |
+| `.fillStrong` | `.surfaceNeutralStrong` | same |
+| `.backgroundStatusPositive` | `.surfacePositivePrimary` | same |
+| `.backgroundStatusCautionary` | `.surfaceCautionaryPrimary` | same |
+| `.backgroundStatusNegative` | `.surfaceNegativePrimary` | same |
+| `.inverseBackground` | `.surfaceNeutralInverse` | same |
+| `.primaryNormal` | `.surfaceBrandPrimary` | same |
+| `.primaryStrong` | `.surfaceBrandStrong` | same |
+| `.primaryHeavy` | `.surfaceBrandHeavy` | same |
+| `.interactionDisable` | `.surfaceDisablePrimary` | same |
+| `.accentBackgroundLime` | `.surfaceAccentLimeOpaque` | same |
+| `.accentBackgroundCyan` | `.surfaceAccentCyanOpaque` | same |
+| `.accentBackgroundLightBlue` | `.surfaceAccentLightBlueOpaque` | same |
+| `.accentBackgroundViolet` | `.surfaceAccentVioletOpaque` | same |
+| `.accentBackgroundPurple` | `.surfaceAccentPurpleOpaque` | same |
+| `.accentBackgroundPink` | `.surfaceAccentPinkOpaque` | same |
+| `.accentBackgroundRedOrange` | none | see [3.1](#31-redorange-tokens) |
 
-> Only two `background` tokens remain, for the page itself (Primary and Secondary). Everything else split off: surfaces became `surface`, and the transparent layers `backgroundTransparent*` became `effect` (`backgroundTransparent` → `effectTransparentPrimary`, `backgroundTransparentAlternative` → `effectTransparentSecondary`). The values are unchanged.
+> Only two `background` tokens remain (Primary and Secondary) for the page background. The rest moved to `surface`, and the translucent `backgroundTransparent*` pair moved to `effect`.
 >
-> `accentBackground{Color}` maps to the **opaque** (`Opaque`) token by default. If the spot was layering a translucent color over something, use the suffix-less `.surfaceAccent{Color}`.
->
-> **The RedOrange family is gone from the 4.0 semantics.** There is no 4.0 token matching `accentForegroundRedOrange` or `accentBackgroundRedOrange` (the primitive `redOrange*` tokens are still there). A 1:1 replacement is not possible, so look at what the spot was for and choose deliberately - and whatever you choose, **the color will change.** In the Wanted app all three usages were text or icon colors, so they moved to `.foregroundNegativePrimary`, which turned `redOrange50/60` into `red50/60`. If the spot was a surface color, `.surfaceNegativePrimary` or a direct primitive `redOrange*` will be closer to the original value.
+> `accentBackground{Color}` maps to the **opaque** variant by default. If you were layering it over something translucent, use the suffix-less `.surfaceAccent{Color}` (8% alpha).
 
 #### Line - borders and dividers
 
-| 3.x | 4.0 |
-|---|---|
-| `.lineNormal` | `.lineNeutralPrimary` |
-| `.lineNeutral` | `.lineNeutralSecondary` |
-| `.lineAlternative` | `.lineNeutralTertiary` |
-| `.lineSolidNormal` | `.lineNeutralPrimaryOpaque` |
-| `.lineSolidNeutral` | `.lineNeutralSecondaryOpaque` |
-| `.lineSolidAlternative` | `.lineNeutralTertiaryOpaque` |
-| `.linePrimaryStrong` | `.lineBrandStrong` |
-| `.lineStatusPositiveNormal` | `.linePositivePrimary` |
-| `.lineStatusCautionaryNormal` | `.lineCautionaryPrimary` |
-| `.lineStatusNegativeStrong` | `.lineNegativeStrong` |
+| 3.x | 4.0 | Value |
+|---|---|---|
+| `.lineNormal` | `.lineNeutralPrimary` | same |
+| `.lineNeutral` | `.lineNeutralSecondary` | same |
+| `.lineAlternative` | `.lineNeutralTertiary` | same |
+| `.lineSolidNormal` | `.lineNeutralPrimaryOpaque` | same |
+| `.lineSolidNeutral` | `.lineNeutralSecondaryOpaque` | same |
+| `.lineSolidAlternative` | `.lineNeutralTertiaryOpaque` | same |
+| `.linePrimaryNormal` | `.lineBrandPrimary` | same |
+| `.linePrimaryStrong` | `.lineBrandStrong` | same |
+| `.lineStatusPositiveNormal` | `.linePositivePrimary` | same |
+| `.lineStatusCautionaryNormal` | `.lineCautionaryPrimary` | same |
+| `.lineStatusNegativeNormal` | `.lineNegativePrimary` | same |
+| `.lineStatusNegativeStrong` | `.lineNegativeStrong` | same |
 
-#### Effect - dimming and transparent layers
+#### Effect - dim and translucent layers
 
-| 3.x | 4.0 |
-|---|---|
-| `.materialDimmer` | `.effectDimmerPrimary` |
-| `.backgroundTransparent` | `.effectTransparentPrimary` |
-| `.backgroundTransparentAlternative` | `.effectTransparentSecondary` |
+| 3.x | 4.0 | Value |
+|---|---|---|
+| `.materialDimmer` | `.effectDimmerPrimary` | **dark changed** |
+| `.backgroundTransparent` | `.effectTransparentPrimary` | same |
+| `.backgroundTransparentAlternative` | `.effectTransparentSecondary` | same |
 
-#### Tokens not in the tables above
+#### Tokens whose value also changes
 
-For tokens introduced in 4.0 (`lineBrandFocus`, `lineNegativeFocus`, `foregroundAccent*`, and so on) and for primitive tokens (`neutral*`, `blue*`, `coolNeutral*`, …), check `Color.Semantic` directly. Primitive names did not change.
+Renaming these **changes the color.** Look at these spots after the substitution.
 
-If you cannot find a 3.x token in the tables, look at the doc comment on each `Color.Semantic` case. Renamed tokens carry their 3.x name after `구` ("former"), as in `/// 기본 전경 색상 (구 labelNormal)`.
+| 3.x → 4.0 | Light | Dark |
+|---|---|---|
+| `accentForegroundBlue` → `foregroundBrandPrimary` | `blue45` `#005EEB` → `blue50` `#0066FF` | `blue45` → `blue60` `#3385FF` |
+| `accentForegroundGreen` → `foregroundPositivePrimary` | `green40` `#009632` → `green50` `#00BF40` | `green40` → `green60` `#1ED45A` |
+| `accentForegroundOrange` → `foregroundCautionaryPrimary` | `orange39` `#D17600` → `orange50` `#FF9200` | `orange39` → `orange60` `#FFA938` |
+| `accentForegroundRed` → `foregroundNegativeStrong` | same (`red40`) | `red40` `#E52222` → `red60` `#FF6363` |
+| `accentForegroundLime` → `foregroundAccentLime` | same (`lime37`) | `lime37` `#429E00` → `lime50` `#58CF04` |
+| `accentForegroundCyan` → `foregroundAccentCyan` | same (`cyan40`) | `cyan40` `#0098B2` → `cyan50` `#00BDDE` |
+| `accentForegroundLightBlue` → `foregroundAccentLightBlue` | same (`lightBlue40`) | `lightBlue40` `#008DCF` → `lightBlue50` `#00AEFF` |
+| `accentForegroundViolet` → `foregroundAccentViolet` | same (`violet45`) | `violet45` `#5B37ED` → `violet70` `#9E86FC` |
+| `accentForegroundPurple` → `foregroundAccentPurple` | same (`purple40`) | `purple40` `#AD36E3` → `purple60` `#D478FF` |
+| `accentForegroundPink` → `foregroundAccentPink` | same (`pink46`) | `pink46` `#E846CD` → `pink60` `#FA73E3` |
+| `materialDimmer` → `effectDimmerPrimary` | same | `coolNeutral5` `#0F0F10` → `coolNeutral10` `#171719` (dim gets slightly lighter) |
+| `inverseLabel` → `foregroundNeutralInverse` | `neutral99` `#F7F7F7` → `coolNeutral99` `#F7F7F8` | `neutral10` `#171717` → `coolNeutral10` `#171719` |
 
-#### Bulk replacement
+`accentForegroundBlue`, `Green`, and `Orange` **change in light mode too.** The other accent tokens move one step brighter in dark mode, and `inverseLabel` shifts by about 1/255, which is invisible in practice.
 
-No 3.x token name survives into 4.0, so a word-boundary replacement is safe.
+#### Tokens not in the tables
+
+Primitive tokens (`neutral*`, `blue*`, `coolNeutral*`, …) keep both their names and their values.
+
+Tokens introduced in 4.0 (`lineBrandFocus`, `lineNegativeFocus`, `surfaceBrandSubtle`, `surfaceNegativeStrong`, `foregroundAccent*`, …) have no 3.x counterpart, so they are absent from these tables. Look them up in `Color.Semantic`.
+
+> The doc comments on `Color.Semantic` carry the old name as `(구 …)`, but a few of those names only ever existed during 4.0 development (`fillPrimary`, `fillNegative`, `interactionFocus`, `interactionNegative`). **If you are coming from 3.x, trust the tables in this document.**
+
+#### Bulk substitution
+
+No 3.x token name survives into 4.0, so anchoring on `\b` is enough to keep the substitution from hitting anything it shouldn't.
 
 ```bash
 # check first
 grep -rn "\.labelNormal\b" --include="*.swift" .
 
-# replace
+# substitute
 find . -name "*.swift" -exec sed -i '' \
   -e 's/\.labelNormal\b/.foregroundNeutralPrimary/g' \
   -e 's/\.labelAlternative\b/.foregroundNeutralTertiary/g' \
@@ -177,9 +189,9 @@ find . -name "*.swift" -exec sed -i '' \
 
 ---
 
-### 2. Spacing and Opacity tokens
+### 1.2 Spacing and Opacity tokens
 
-These were flattened so the value appears directly in the name. The mapping is 1:1, so rendering is identical.
+The enum plus lookup function collapsed into a single static property, and the value now appears directly in the name.
 
 ```swift
 // 3.x
@@ -193,7 +205,30 @@ These were flattened so the value appears directly in the name. The mapping is 1
 
 | 3.x | 4.0 |
 |---|---|
-| `.spacing(.pt02)` … `.spacing(.pt72)` | `.spacing2` … `.spacing72` |
+| `.spacing(.pt01)` | `.spacing1` |
+| `.spacing(.pt02)` | `.spacing2` |
+| `.spacing(.pt04)` | `.spacing4` |
+| `.spacing(.pt08)` | `.spacing8` |
+| `.spacing(.pt12)` | `.spacing12` |
+| `.spacing(.pt16)` | `.spacing16` |
+| `.spacing(.pt20)` | `.spacing20` |
+| `.spacing(.pt24)` | `.spacing24` |
+| `.spacing(.pt28)` | **none** (see [3.2](#32-spacing-pt28-and-pt36)) |
+| `.spacing(.pt32)` | `.spacing32` |
+| `.spacing(.pt36)` | **none** (see [3.2](#32-spacing-pt28-and-pt36)) |
+| `.spacing(.pt40)` | `.spacing40` |
+| `.spacing(.pt48)` | `.spacing48` |
+| `.spacing(.pt56)` | `.spacing56` |
+| `.spacing(.pt64)` | `.spacing64` |
+| `.spacing(.pt72)` | `.spacing72` |
+| `.spacing(.pt80)` | `.spacing80` |
+
+Note that **the leading zero disappears**: `pt08` becomes `spacing8`, not `spacing08`.
+
+All 16 opacity tokens map one to one with identical values.
+
+| 3.x | 4.0 |
+|---|---|
 | `.opacity(.p000)` | `.opacity0` |
 | `.opacity(.p005)` | `.opacity5` |
 | `.opacity(.p008)` | `.opacity8` |
@@ -211,37 +246,204 @@ These were flattened so the value appears directly in the name. The mapping is 1
 | `.opacity(.p097)` | `.opacity97` |
 | `.opacity(.p100)` | `.opacity100` |
 
-**The zero padding disappears**, as in `pt08` → `spacing8`. It is not `spacing08`.
+Opacity tokens are now `Double`. Spots that used raw literals like `withAlphaComponent(0)` can be tidied to `withAlphaComponent(.opacity0)`.
 
-Opacity tokens moved to `Double`. Spots that used a raw literal like `withAlphaComponent(0)` can be tidied up to `withAlphaComponent(.opacity0)`.
-
----
-
-### 3. Global modifiers
-
-| 3.x | 4.0 | Notes |
-|---|---|---|
-| `.disable(_:)` | `.disabled(_:)` | Absorbed into the standard SwiftUI modifier. Components read the `isEnabled` environment value |
-| `scrollStatus.scrolledToMax` | `scrollStatus.reachedEnd` | A `ScrollStatus` property on `Montage.ScrollView` |
-
-`disable()` → `disabled()` is more than a rename. In 3.x the component applied its own `opacity`; in 4.0 it follows SwiftUI's `isEnabled` and expresses the state through color tokens (`foregroundDisablePrimary` and friends). See [Changes that alter what you see](#changes-that-alter-what-you-see).
-
-Input components gained `autocorrectionDisabled(_:)` (an addition, not a breaking change).
+The `Color.spacing(_:)` and `Color.opacity(_:)` static functions were removed.
 
 ---
 
-### 4. Input components to FormControl
+### 1.3 Global modifiers
 
-This is the change that takes the most work. `TextField`/`TextArea` now handle **only the input itself**, and `FormControl` places the label, status message, and character counter outside the field.
-
-| 3.x (inside the field) | 4.0 (FormControl slot) | Position |
+| 3.x | 4.0 | Note |
 |---|---|---|
-| `.heading("Email")` | `.label("Email")` | **Above** the field |
-| `.status(.negative(description: msg))` | `.status(.negative)` + `.message(msg)` | **Below** the field |
-| `.bottomResources(trailing: [.characterCount(limit:)])` | `.accessory { … }` | Below the field, **trailing** |
-| `.disable(_:)` | `.disabled(_:)` | - |
+| `.disable(_:)` | `.disabled(_:)` | Absorbed into the standard SwiftUI modifier; components read the `isEnabled` environment value |
+| `scrollStatus.scrolledToMax` | `scrollStatus.reachedEnd` | `ScrollStatus` property on `Montage.ScrollView` |
+
+`disable()` → `disabled()` is more than a rename. In 3.x components dimmed the whole view by lowering its opacity; in 4.0 they read SwiftUI's `isEnabled` and swap in color tokens such as `foregroundDisablePrimary`. See [4. Visual changes](#4-visual-changes).
+
+`Chip` and `FilterButton` already spelled it `disabled(_:)` in 3.x, but that was their own modifier returning `Self`. In 4.0 it is gone and the standard modifier takes over, which returns `some View`. **Chaining a component-specific modifier after `.disabled()` no longer compiles, so move `.disabled()` to the end of the chain.**
+
+```swift
+// 3.x
+Chip(variant: variant, size: size, text: text)
+    .disabled(disable)
+    .active(active)
+
+// 4.0 - .disabled() returns some View, not Chip
+Chip(variant: variant, size: size, text: text)
+    .active(active)
+    .disabled(disable)
+```
+
+A `.disabled(true)` set on an ancestor view now changes the colors of both components too. In 3.x they picked colors from their own property, so an inherited `.disabled()` blocked touches but left the colors alone.
+
+---
+
+### 1.4 Component renames
+
+#### ListCell
+
+| 3.x | 4.0 |
+|---|---|
+| `ListCell(title:)` | `ListCell(label:)` |
+| `.titleVariant(_:)` | `.labelVariant(_:)` |
+| `.titleWeight(_:)` | `.labelWeight(_:)` |
+| `.titleColor(_:)` | `.labelColor(_:)` |
+| `.caption(_:)` | `.description(_:)` |
+| `.fillWidth(false)` | `.variant(.inset)` (default) |
+| `.fillWidth(true)` | `.variant(.full)` |
+
+`inset` extends only the interaction background by 12 on each side with a corner radius of 16; `full` gives the cell its own horizontal padding of 20. These are the same values 3.x used for `fillWidth(false)` and `fillWidth(true)`, so renaming alone leaves the screen unchanged.
+
+Slot changes are in [2.5 ListCell slots](#25-listcell-slots).
+
+#### TopNavigation slot presets
+
+Preset namespaces were unified to `Component.Resource.SlotName`.
+
+| 3.x | 4.0 |
+|---|---|
+| `TopNavigation.Resource.LeadingButtonInfo` | `TopNavigation.Resource.Leading` |
+| `TopNavigation.Resource.TrailingButtonInfo` | `TopNavigation.Resource.Trailing` |
+
+```swift
+// 3.x
+TopNavigation.LeadingButton(TopNavigation.Resource.LeadingButtonInfo.back(action: { dismiss() }))
+
+// 4.0
+TopNavigation.LeadingButton(TopNavigation.Resource.Leading.back(action: { dismiss() }))
+```
+
+#### Input components
+
+| 3.x | 4.0 | Applies to |
+|---|---|---|
+| `.heading(_:)` | `.label(_:required:)` | `TextField`, `TextArea`, `Select` |
+| `.requiredBadge(_:)` | the `required` argument of `.label(_:required:)` | `TextField`, `TextArea`, `Select` |
+| `.description(_:)` | `.message(_:)` | `TextArea`, `Select` |
+| `.inputCharacterLimit(_:)` | `.maxLength(_:)` | `TextArea` |
+| `.status(.negative(description:))` | `.status(.negative)` + `.message(_:)` | `TextField` |
 
 `TextField.Status` lost its associated values: `.normal()` → `.normal`, `.negative(description:)` → `.negative`.
+
+The structural part of this change is in [2.1 Input labels, messages, and counters](#21-input-labels-messages-and-counters).
+
+#### Button and TextButton
+
+`fill(horizontal:vertical:)` was removed in favour of `fillWidth(_:)`.
+
+| 3.x | 4.0 |
+|---|---|
+| `.fill(horizontal: true)` | `.fillWidth(true)` |
+| `.fill(horizontal: true, vertical: false)` | `.fillWidth(true)` |
+| `.fill(horizontal: true, vertical: true)` | `.fillWidth(true)` |
+
+`vertical` never did anything in 3.x either. The function took the parameter and threw it away, so even `vertical: true` call sites never got a taller button. All three cases render identically, so the substitution is purely mechanical.
+
+#### IconButton
+
+The size of the `normal` variant moved from `Int` to the `NormalSize` enum.
+
+| 3.x | 4.0 | Icon glyph | Container |
+|---|---|---|---|
+| `.normal(size: 16)` | `.normal(size: .small)` | 16 | 24 |
+| `.normal(size: 18)` | `.normal(size: .medium)` | 18 | 28 |
+| `.normal(size: 20)` | `.normal(size: .large)` | 20 | 32 |
+| `.normal(size: 24)` | `.normal(size: .xlarge)` | 24 | 36 |
+
+The glyph stays the same size and **only the touch container grows.** Since this variant has no background or border, the visible effect is a trailing icon shifting by about 6pt or a row growing by about 8pt.
+
+For any other size, see [3.3 IconButton non-standard sizes](#33-iconbutton-non-standard-sizes).
+
+#### PushBadge
+
+| 3.x | 4.0 |
+|---|---|
+| `.new` | `.text("N")` |
+| `.number(count)` | `.maxCount(count, max: 99)` |
+
+Instead of a minimum width plus padding for a single character, the badge is now a `badgeSize` square (xsmall 16 / small 20 / medium 24). Narrow glyphs like `N` are pixel-identical, and a single wide character (CJK, `M`, `W`) no longer squashes the badge.
+
+There is also a scaling cap. In 3.x the badge kept growing all the way into the accessibility text sizes; 4.0 stops it at `xxxLarge`. The icon or avatar underneath does not scale with Dynamic Type, so a badge that kept growing would cover it.
+
+#### SegmentedControl
+
+| 3.x | 4.0 |
+|---|---|
+| `Item(image:title:)` | `Item(leadingIcon:title:)` |
+| `icon` toggle | `.iconOnly(_:)` |
+
+For the removal of `variant(_:)`, see [3.4](#34-segmentedcontrol-outlined-variant).
+
+#### Accordion
+
+The no-argument `trailingContent` overload is gone; only the one taking the expanded flag (`Bool`) remains.
+
+```swift
+// 3.x
+.trailingContent { Chevron() }
+
+// 4.0
+.trailingContent { _ in Chevron() }
+```
+
+#### Parameters dropped from init
+
+Disabled state and background color moved out of `init` into modifiers.
+
+| 3.x | 4.0 |
+|---|---|
+| `TopNavigation(scrollOffset:backgroundColor:)` | `TopNavigation(scrollOffset:)` + `.backgroundColor(_:)` |
+| `TopNavigation.TrailingIconButton(icon:disable:showPushBadge:action:)` | `(icon:showPushBadge:action:)` + `.disabled(_:)` |
+| `TopNavigation.TrailingTextButton(text:disable:action:)` | `(text:action:)` + `.disabled(_:)` |
+| `framedStyle(status:borderRadius:shadowLevel:disabled:)` | `framedStyle(status:borderRadius:shadowLevel:)` + `.disabled(_:)` |
+
+Anywhere you passed `disable:`, use the standard SwiftUI `.disabled(_:)` the same way as in [1.3 Global modifiers](#13-global-modifiers).
+
+#### Skeleton
+
+It now takes a typography variant instead of an array of widths, deriving line height and line count from the variant.
+
+```swift
+// 3.x
+Skeleton.SkeletonView(.text(lengths: [._25, ._50, ._75]))
+
+// 4.0
+Skeleton.SkeletonView(.text(variant: .body1))
+```
+
+Placeholder bar widths change from variable (25/50/75/100%) to uniform. To mimic multiple lines, place several `SkeletonView`s.
+
+#### Avatar
+
+The default for `border(color:)` changed from `.lineAlternative` to `.lineNeutralTertiary`. That is the new name for the same color, so nothing renders differently.
+
+---
+
+## 2. Removed, needs rework
+
+### 2.1 Input labels, messages, and counters
+
+In 3.x the `TextField` drew its own label and error message. In 4.0 `TextField`, `TextArea`, and `Select` draw just the input field, and attaching `label`, `message`, or `accessory` **wraps it in a `FormControl` that places the label and message instead.**
+
+```swift
+// what .label() / .message() build for you in 4.0
+FormControl {
+    TextField(text: $email)   // draws the input only
+}
+.label("Email")               // label goes above the field
+.message(errorMessage)        // message goes below it
+```
+
+The wrapping is automatic, so call sites only swap modifiers. But **the view hierarchy changes, so field height and overall form height change with it.** This is not a rename-and-done substitution.
+
+| 3.x (inside the field) | 4.0 | Position |
+|---|---|---|
+| `.heading("Email")` | `.label("Email")` | **above** the field |
+| `.requiredBadge(true)` | `.label("Email", required: true)` | next to the label |
+| `.status(.negative(description: msg))` | `.status(.negative)` + `.message(msg)` | **below** the field |
+| `.bottomResources(trailing: [.characterCount(limit:)])` | `.accessory { … }` | below the field, **trailing** |
+| `.disable(_:)` | `.disabled(_:)` | - |
 
 #### TextField
 
@@ -254,6 +456,54 @@ Montage.TextField(text: $email)
     .disable(isDisabled)
 
 // 4.0
+Montage.TextField(text: $email)
+    .label(String(localized: "Email"))
+    .placeholder(String(localized: "Enter your email."))
+    .status(isInvalidated ? .negative : .normal)
+    .message(isInvalidated ? errorMessage : nil)
+    .disabled(isDisabled)
+```
+
+The label becomes the input's accessibility label and the message its accessibility hint.
+
+#### TextArea with a character counter
+
+```swift
+// 3.x
+TextArea(text: $feedback, focus: $focus)
+    .resize(.fixed(min: 116, max: 116))
+    .placeholder("Tell us what worked and what didn't.")
+    .bottomResources(trailing: [.characterCount(limit: 1000)])
+
+// 4.0
+TextArea(text: $feedback, focus: $focus)
+    .maxLength(1000)
+    .resize(.fixed(min: 116, max: 116))
+    .placeholder(String(localized: "Tell us what worked and what didn't."))
+    .accessory {
+        Text(verbatim: "\(feedback.count)/1000")
+            .typography(variant: .label2, weight: .medium, semantic: .foregroundNeutralTertiary)
+    }
+```
+
+The `.characterCount` resource was removed - the call site now draws the counter. Two things to watch:
+
+- **Set the input limit on the field with `maxLength(_:)`.** Displaying the counter and enforcing the limit are now separate.
+- **Use `Text(verbatim:)`.** `Text("\(count)/\(limit)")` goes through `LocalizedStringKey` interpolation, which adds a locale thousands separator once the limit reaches 1000 (`5,000`). With `verbatim:` you get `5000`.
+
+All three share the same five modifiers:
+
+`.label(_:required:)` · `.message(_:)` · `.labelPlacement(_:)` · `.labelWidth(_:)` · `.accessory { }`
+
+#### When to wrap in FormControl
+
+Using any one of those modifiers wraps the input in a `FormControl` internally, so most screens never need to write one. Reach for it directly in three cases:
+
+- wrapping an input component you built yourself
+- which input component goes in changes at runtime and you want the wrapper settings in one place
+- aligning label widths across several fields with `FormControlGroup`
+
+```swift
 FormControl { context in
     Montage.TextField(text: $email)
         .status(context.status.textFieldStatus)
@@ -262,71 +512,61 @@ FormControl { context in
 .label(String(localized: "Email"))
 .status(isInvalidated ? .negative : .normal)
 .message(isInvalidated ? errorMessage : nil)
-.disabled(isDisabled)
 ```
 
-**`FormControl` owns the status** and passes it down to the field through `context.status.textFieldStatus`. If you set the status on the field directly, the label and message colors will drift out of sync.
+`size` and `status` resolve in this order: **value set on the component → value propagated from `FormControl` → default** (`.large` / `.normal`). They propagate into the slot, so setting them once on the `FormControl` is usually enough. Setting the status separately on the component can leave the label and message colors out of sync, so pass it down through `context.status` as shown above.
 
-#### TextArea and the character counter
-
-```swift
-// 3.x
-TextArea(text: $feedback, focus: $focus)
-    .resize(.fixed(min: 116, max: 116))
-    .placeholder("Tell us what you liked or what fell short.")
-    .bottomResources(trailing: [.characterCount(limit: 1000)])
-
-// 4.0
-FormControl { _ in
-    TextArea(text: $feedback, focus: $focus)
-        .maxLength(1000)
-        .resize(.fixed(min: 116, max: 116))
-        .placeholder(String(localized: "Tell us what you liked or what fell short."))
-}
-.accessory {
-    Text(verbatim: "\(feedback.count)/1000")
-        .typography(variant: .label2, weight: .medium, semantic: .foregroundNeutralTertiary)
-}
-```
-
-The `.characterCount` resource was removed from `bottomResources`. The call site now draws the counter itself (`bottomResources` itself is still there). Two things to keep in mind.
-
-- **The input limit goes on the field via `maxLength(_:)`.** Displaying the count and enforcing the limit are now separate.
-- **Use `Text(verbatim:)`.** `Text("\(count)/\(limit)")` goes through `LocalizedStringKey` interpolation, which adds a locale thousands separator once the limit reaches 1000 (`5,000`). With `verbatim:` you get `5000`.
-
-The remaining `FormControl` modifiers: `size(.large/.medium)`, `labelPlacement(.top/.leading)`, `labelWidth(_:)`, `label(_:required:)`. To align several fields together, use `FormControlGroup`.
-
-#### Attaching directly to the input
-
-You can also skip the `FormControl` wrapper and put the modifiers straight on `TextField`, `TextArea`, or `Select`. All three have the same five.
-
-`.label(_:required:)` · `.message(_:)` · `.labelPlacement(_:)` · `.labelWidth(_:)` · `.accessory { }`
-
-```swift
-Montage.TextField(text: $email)
-    .placeholder(String(localized: "Enter your email."))
-    .label(String(localized: "Email"), required: true)
-    .message(isInvalidated ? errorMessage : nil)
-    .status(isInvalidated ? .negative : .normal)
-```
-
-Using any one of them wraps the input in a `FormControl` internally, so the result is the same as the `FormControl { … }` form above. The label is wired up as the input's accessibility label and the message as its accessibility hint.
-
-`size` and `status` resolve in this order: **the value set at the call site, then the value propagated from `FormControl`, then the default** (`.large` / `.normal`). For the common case of one input with just a label and a message, this form is shorter; when you need `FormControlGroup` or have to compose several inputs, reach for `FormControl` directly.
-
----
+The remaining `FormControl` modifiers: `size(.large/.medium)`, `labelPlacement(.top/.leading)`, `labelWidth(_:)`, `label(_:required:)`.
 
 #### If you have your own input wrapper
 
-For a wrapper that contains a `TextField` internally, such as `AutoCompleteTextInput`, it is better to **wrap the wrapper itself in a `FormControl`** and expose the status and message as parameters on the wrapper's interface. Putting `FormControl` inside the wrapper makes it hard to supply the label from outside.
+For a wrapper like `AutoCompleteTextInput` that hides a `TextField` inside, **wrap the wrapper in a `FormControl`** and expose status and message through the wrapper's own interface. Putting `FormControl` inside the wrapper makes it hard to supply the label from outside.
 
 ---
 
-### 5. Slot-based APIs
+### 2.2 TextArea bottom resources
 
-`Model` structs and fixed image parameters are gone; the call site passes views directly.
+Both the signature and the resource types of `bottomResources` changed.
 
-#### ActionArea
+```swift
+// 3.x - one Resource type for both slots
+public func bottomResources(
+    leading leadingResources: [Resource] = [],
+    trailing trailingResources: [Resource] = [],
+    leadingResourceSpacing: CGFloat = 4,
+    trailingResourceSpacing: CGFloat = 4
+) -> Self
+
+// 4.0 - the type differs per slot
+public func bottomResources(
+    leading: [Resource.Leading] = [],
+    trailing: [Resource.Trailing] = [],
+    leadingResourceSpacing: CGFloat? = nil,
+    trailingResourceSpacing: CGFloat? = nil
+) -> Self
+```
+
+- The argument label changed from `leading leadingResources:` to `leading:`.
+- The default spacing between resources moved from a fixed `4` to **a size-dependent default (large 8 / medium 6)**. If you never passed it explicitly, the gap widens.
+
+Preset mapping:
+
+| 3.x `Resource` | 4.0 |
+|---|---|
+| `.icon` | `Resource.Leading.icon` / `Resource.Trailing.icon` |
+| `.iconButton` | `Resource.Leading.iconButton` / `Resource.Trailing.iconButton` |
+| `.characterCount` | removed - use `accessory` from [2.1](#21-input-labels-messages-and-counters) |
+| `.textButton`, `.chip`, `.filterButton`, `.badge` | **no replacement** (see [3.6](#36-textarea-bottom-resource-presets)) |
+| - | `.contentBadge` and `.segmentedControl` added; `.button` and `.primaryIconButton` added for trailing only |
+| no `.slot` | `Resource.Leading.slot { }` / `Resource.Trailing.slot { }` |
+
+Anything without a preset goes through `slot(_:)`.
+
+---
+
+### 2.3 ActionArea
+
+The `Model` struct and the fixed parameters are gone; the call site supplies the view.
 
 ```swift
 // 3.x
@@ -350,113 +590,115 @@ For a wrapper that contains a `TextField` internally, such as `AutoCompleteTextI
 )
 ```
 
-The `actionArea` slot closure is **not** annotated with `@ViewBuilder`. An `if` statement turns it into `_ConditionalContent`, which breaks the `ActionArea` type constraint. Handle branching with a ternary or a modifier chain.
+`modalActionArea(_:)` on `BottomSheet` and `Popup` also changed from `ActionArea.Model?` to `(() -> ActionArea)?`.
+
+The `actionArea` slot closure is **not** `@ViewBuilder`. An `if` statement produces `_ConditionalContent` and breaks the `ActionArea` type constraint. Use a ternary or a modifier chain instead.
 
 ```swift
 // does not work
 .actionArea { if isEditing { ActionArea(variant: a) } else { ActionArea(variant: b) } }
 
-// do this instead
+// do this
 .actionArea { ActionArea(variant: isEditing ? a : b) }
 ```
 
-The API for controlling background transparency directly is gone. In 4.0 the background and the top gradient are both driven by a single signal - whether the scroll has reached the bottom (`scrollReachedEnd`).
+#### Transparent background control
 
-| `scrollReachedEnd` | `extra` slot | Top gradient | Background |
-|---|---|---|---|
-| not passed, or `false` | either | shown | opaque |
-| `true` | empty | hidden | **transparent** |
-| `true` | filled | hidden | opaque |
-
-The gradient means "there is content hidden below", and it fades in and out over 0.5 seconds.
+The API for driving the transparent background directly is gone. In 4.0 the background and the top gradient are both derived from one signal: whether the scroll view reached its end (`scrollReachedEnd`).
 
 | 3.x | 4.0 |
 |---|---|
-| `.transparentBackground(_:)` | Removed |
-| `ActionArea.BackgroundTransparencyControl` (`.automatic` / `.manual`) | Removed |
-| `actionArea(backgroundTransparency:)` | Removed |
-| `.gradientColor(_:)` | `.backgroundColor(_:)` (applies to both the background and the gradient's start color) |
-| - | `.scrollReachedEnd(_:)` added |
+| `.transparentBackground(_:)` | removed |
+| `ActionArea.BackgroundTransparencyControl` (`.automatic` / `.manual`) | removed |
+| `actionArea(backgroundTransparency:)` | removed - use `actionArea(scrollReachedEnd:)` |
 
-With `Montage.ScrollView`, reaching the bottom is reported automatically, so passing nothing is equivalent to 3.x's `.automatic`. Only when you use a container that does not report it, such as `SwiftUI.ScrollView` or `List`, do you need to pass it yourself via `actionArea(scrollReachedEnd:)`.
+| `scrollReachedEnd` | `extra` slot | Top gradient | Background |
+|---|---|---|---|
+| not passed, or `false` | any | shown | opaque |
+| `true` | empty | hidden | **transparent** |
+| `true` | non-empty | hidden | opaque |
 
-**Wherever you used `.manual` to force a transparent background, pass the bottom-reached signal instead.** A screen with no scroll container at all (fixed-height content inside a popup or sheet) has nothing to raise the signal, so ActionArea assumes there is hidden content below and draws the gradient and background. Passing `true` hides the gradient and lets the background show through.
+The gradient signals "there is content hidden below" and fades in and out over 0.5 seconds.
+
+With `Montage.ScrollView` the reached-end signal propagates automatically, so passing nothing is equivalent to 3.x's `.automatic`. Pass it yourself only for containers that do not report it, such as `SwiftUI.ScrollView` or `List`.
+
+**Where you used `.manual` to force a transparent background, pass the reached-end signal directly.** A screen with no scroll container at all (fixed-height content inside a popup or sheet) has nothing to report, so the ActionArea assumes content is hidden below and draws the gradient and background. Passing `true` hides the gradient and lets the background show through.
 
 There are two places to pass it.
 
 ```swift
-// as a modifier on a view
+// as a view modifier
 content
     .actionArea(scrollReachedEnd: true) { ActionArea(variant: …) }
 
-// when passing through an actionArea: argument, as with BottomSheet and Popup - chain it on ActionArea itself
+// via an actionArea: argument, as on BottomSheet and Popup - chain it on the ActionArea itself
 .popup(isPresented: $isPresented, actionArea: {
     ActionArea(variant: …)
         .scrollReachedEnd(true)
 })
 ```
 
-To change the background color itself, use `backgroundColor(_:)`. If neither approach fits, check with your designer whether that treatment is really needed.
+To change the background color itself, use `backgroundColor(_:)` (it applies to both the background and the gradient's start color). If neither approach covers your screen, [open an issue](https://github.com/wanteddev/montage-ios/issues).
 
-The ActionArea spec was retuned in 4.0 as well.
+Spec changes are in [4. Visual changes](#4-visual-changes).
 
-| Item | 3.x | 4.0 |
-|---|---|---|
-| `extra` slot horizontal padding | 20 | **24** |
-| `extra` slot bottom padding | 24 | **20** |
-| `extra` divider color | `lineNeutralSecondary` | `lineNeutralTertiary` (lighter) |
-| Caption typography | `label2` | `label2` + `weight: .medium` (heavier) |
-| Caption icon | None | New 16pt slot via `.caption(_:icon:)` |
-| Alternative (`alternative`) action button | `outlined` / `primary` | `outlined` / **`assistive`** |
-| `cancel` main action button | `outlined` / `assistive` | **`solid`** / `assistive` |
+---
 
-The horizontal padding of 20 on the main button row is unchanged.
+### 2.4 View.topNavigation(...) removed
 
-The button colors compile fine, since the API is unchanged. The alternative action's label goes from blue to black, widening the contrast against the primary action, and the `cancel` variant's main button goes from outlined to a grey fill. The `sub` action is unchanged.
-
-#### ScreenScaffold
-
-A new container assembles `TopNavigation`, the body, and `ActionArea` into one screen. The scroll-offset plumbing and bottom-inset math you used to hand-tune per screen are handled by the scaffold.
+Both `View.topNavigation(...)` modifiers were removed. Place the `TopNavigation` component yourself, or assemble the screen with the new `ScreenScaffold`.
 
 ```swift
+// 3.x
+content
+    .topNavigation(
+        title: "Settings",
+        leadingContent: { TopNavigation.LeadingButton(.back(action: { dismiss() })) },
+        withBottom: .init(variant: .neutral(main: .init(text: "Save", action: save)))
+    )
+
+// 4.0
 ScreenScaffold(
-    navigation: { TopNavigation(title: title) },
-    actionArea: { ActionArea(variant: .neutral(main: .init(text: "OK", action: submit))) }
+    navigation: {
+        TopNavigation(title: "Settings")
+            .leadingContent { TopNavigation.LeadingButton(.back(action: { dismiss() })) }
+    },
+    actionArea: {
+        ActionArea(variant: .neutral(main: .init(text: "Save", action: save)))
+    }
 ) {
     content
 }
 .backgroundColor(.semantic(.backgroundNeutralPrimary))
 ```
 
-`ActionArea` goes in through `safeAreaInset(edge: .bottom)`, so the scroll container reserves that much content inset. **Remove the padding you used to add by hand to keep the last element from hiding under the button when scrolled to the bottom.**
+`ScreenScaffold` assembles `TopNavigation` + content + `ActionArea` into one screen and takes over the scroll-offset plumbing and bottom-inset math you used to wire up per screen.
+
+It inserts the `ActionArea` with `safeAreaInset(edge: .bottom)`, so the scroll container reserves that much content inset. **Remove any manual bottom padding you added so the last row would clear the buttons.**
 
 | `scrollContainer` | When |
 |---|---|
 | `.builtIn` (default) | The scaffold lays down a `Montage.ScrollView` and measures scroll state itself |
-| `.custom` | When you cannot swap the container, as with `List`. The content has to raise signals via `reportsScrollOffset(_:)` and `reportsScrollReachedEnd(_:)` |
+| `.custom` | When the container cannot be swapped, e.g. `List`. The content must report through `reportsScrollOffset(_:)` and `reportsScrollReachedEnd(_:)` |
 
-The `navigation` and `actionArea` slot closures are **also not annotated with `@ViewBuilder`.** An `if` statement turns them into `_ConditionalContent` and breaks the type constraint, so to include one conditionally, branch on the closure itself, as in `actionArea: isEditing ? slot : nil`.
+The `navigation` and `actionArea` slot closures are **not `@ViewBuilder` either.** To include one conditionally, split the closure itself: `actionArea: isEditing ? slot : nil`.
 
-Do not put it inside `BottomSheet` or `Popup`. Those two do the same job and use the `ActionArea` height in their own height calculation, so pass it to their `actionArea:` argument instead. A full-screen cover or a pushed destination is a screen rather than a sheet, so it does not fall under this.
+Do not put it inside `BottomSheet` or `Popup`. Those do the same job and use the `ActionArea` height in their own height calculation, so pass it through their `actionArea:` argument instead. A full-screen cover or a pushed destination is a screen, not a sheet, so this does not apply there.
 
-With `List`, you have to clear **both** the row background and the scroll background. Clearing only one hides the color you set with `backgroundColor(_:)`, and the seam shows when `ActionArea` goes transparent at the bottom.
+With `List`, strip **both** the row background and the scroll background. Handling only one hides the color set via `backgroundColor(_:)`, and the seam shows once the `ActionArea` turns transparent at the bottom.
 
 ---
 
-#### ListCell
+### 2.5 ListCell slots
 
-The `title*` family became `label*`, `fillWidth()` became `variant(_:)`, and `leadingContent {}` became `leadingResources([…])`.
+`leadingContent {}` and `trailingContent {}` were replaced by four slot modifiers taking preset arrays.
 
 | 3.x | 4.0 |
 |---|---|
-| `ListCell(title:)` | `ListCell(label:)` |
-| `.titleVariant(_:)` / `.titleWeight(_:)` / `.titleColor(_:)` | `.labelVariant(_:)` / `.labelWeight(_:)` / `.labelColor(_:)` |
-| `.caption(_:)` | `.description(_:)` |
-| `.fillWidth(false)` | `.variant(.inset)` (default) |
-| `.fillWidth(true)` | `.variant(.full)` |
 | `.leadingContent { … }` | `.leadingResources([.slot { … }])` |
-| `.interactionPadding(_:)` | Removed - folded into `variant` |
-| `.verticalAlign(.bottom)` | Removed - only `.top` and `.center` remain |
+| `.trailingContent { _ in … }` | `.trailingResources([.slot { … }])` |
+| `.interactionPadding(_:)` | removed - folded into `variant(_:)` |
+| `.verticalAlign(_:)` taking `VerticalAlignment` | `ListCell.VerticalAlign` |
 
 ```swift
 // 3.x
@@ -474,8 +716,6 @@ ListCell(label: option.title) { onSelect() }
     }])
 ```
 
-`inset` extends only the interaction background by 12 on each side with a corner radius of 16; `full` gives the cell its own horizontal padding of 20. The values line up with the old `fillWidth(false/true)`.
-
 There are now four slots: `leadingResources`, `labelTrailingResources`, `trailingResources`, and `extraResources`. Common combinations ship as presets.
 
 ```swift
@@ -483,27 +723,29 @@ There are now four slots: `leadingResources`, `labelTrailingResources`, `trailin
 .leadingResources([.radio(checked: isSelected)])
 .leadingResources([.avatar(url, variant: .company)])
 .leadingResources([.thumbnail(url)])
-.leadingResources([.slot { AnyCustomView() }])   // use slot when there is no preset
+.leadingResources([.slot { AnyCustomView() }])   // slot when no preset fits
 ```
 
-`verticalPadding` gained `.custom(CGFloat)`.
+For `.verticalAlign(.bottom)`, see [3.5](#35-listcell-verticalalignbottom).
 
-#### Chip
+---
 
-The image parameters became content slots.
+### 2.6 Chip image slots
+
+Image parameters became content slots.
 
 | 3.x | 4.0 |
 |---|---|
 | `leadingImage:` / `trailingImage:` | `.leadingContent { … }` / `.trailingContent { … }` |
-| `.imageColor(_:)` | Set it inside the slot |
-| `.iconOnly(_:)` | Removed - just fill `leadingContent` |
+| `.imageColor(_:)` | set it inside the slot |
+| `.iconOnly(_:)` | removed - just fill `leadingContent` |
 
-The component no longer decides the icon size and color, so **the call site has to supply them.** Here is what 3.x used per size.
+The component no longer decides the icon size and color, so **the call site has to supply them.** These are the values 3.x applied per size.
 
 | Chip size | Icon size |
 |---|---|
 | `.large` | 16 |
-| `.medium` · `.small` | 14 |
+| `.medium`, `.small` | 14 |
 | `.xsmall` | 12 |
 
 ```swift
@@ -517,93 +759,19 @@ Chip(text: skill.name, variant: .outlined, size: .medium)
     }
 ```
 
-#### Slot preset names
-
-Presets now follow a consistent `Component.Resource.SlotName` pattern.
-
-```swift
-// 3.x
-TopNavigation.LeadingButton(TopNavigation.Resource.LeadingButtonInfo.back(action: { dismiss() }))
-
-// 4.0
-TopNavigation.LeadingButton(TopNavigation.Resource.Leading.back(action: { dismiss() }))
-```
-
 ---
 
-### 6. Straight API replacements
+### 2.7 FallbackView padding
 
-#### Button · TextButton
-
-`fill(horizontal:vertical:)` was **removed** and replaced by `fillWidth(_:)`. There is no deprecation period; it is gone in 4.0, so move every call site.
+`image:` and `button:` were dropped from `init`.
 
 | 3.x | 4.0 |
 |---|---|
-| `.fill(horizontal: true)` | `.fillWidth(true)` |
-| `.fill(horizontal: true, vertical: false)` | `.fillWidth(true)` |
-| `.fill(horizontal: true, vertical: true)` | `.fillWidth(true)` |
+| `FallbackView(image:title:description:button:)` | `FallbackView(title:description:)` |
+| the `button:` slot | `buttonActionArea(_:)` |
+| the `image:` slot | **no replacement** ([3.7](#37-fallbackview-image-slot)) |
 
-`vertical` already did nothing in 3.x. It existed only in the signature and was never used in the function body, so even the spots calling it with `vertical: true` never filled vertically. All three cases render the same, so a mechanical replacement is safe.
-
-`TextButton` had no `fillWidth(_:)` in 3.x. It was added in 4.0, matching `Button`.
-
-#### IconButton
-
-The size of the `normal` variant changed from `Int` to a `NormalSize` enum.
-
-| 3.x | 4.0 | Icon glyph | Container |
-|---|---|---|---|
-| `.normal(size: 16)` | `.normal(size: .small)` | 16 | 24 |
-| `.normal(size: 18)` | `.normal(size: .medium)` | 18 | 28 |
-| `.normal(size: 20)` | `.normal(size: .large)` | 20 | 32 |
-| `.normal(size: 24)` | `.normal(size: .xlarge)` | 24 | 36 |
-
-The glyph size is unchanged and **only the touch container grows**. Since this variant has no background or border, the effect is roughly a trailing icon shifting about 6px or a row growing about 8px taller.
-
-For any size other than those four, use `NormalSize.custom(size:)` - but **what `size` means changed from the icon to the container.** In 3.x, `.normal(size: n)` made the container the same `n` as the icon. In 4.0, `.custom(size: n)` takes `n` as one side of the container and derives the icon from it: the dimension token nearest to two thirds of the container. The container is clamped to `[24, 64]`.
-
-```swift
-// 3.x - n is the icon size
-IconButton(variant: .normal(size: 22), icon: .search)
-
-// 4.0 - n is the container size, and the icon is derived from it
-IconButton(variant: .normal(size: .custom(size: 32)), icon: .search)  // icon 20
-```
-
-Passing the 3.x value straight through shrinks the icon: `.custom(size: 22)` clamps the container to 24 and gives you a 16 icon. **Outside the four standard sizes there is no mechanical replacement** - pick the container that yields the icon size you want.
-
-| Container | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 |
-|---|---|---|---|---|---|---|---|---|
-| Icon | 16 | 18 | 20 | 24 | 28 | 32 | 36 | 40 |
-
-#### Skeleton
-
-It takes a typography variant instead of an array of variable widths. Line height and line count are derived from the variant.
-
-```swift
-// 3.x
-Skeleton.SkeletonView(.text(lengths: [._25, ._50, ._75]))
-
-// 4.0
-Skeleton.SkeletonView(.text(variant: .body1))
-```
-
-Placeholder bar widths go from variable (25/50/75/100%) to uniform. To suggest multiple lines, place several `SkeletonView`s.
-
-#### PushBadge
-
-The variants were consolidated.
-
-| 3.x | 4.0 |
-|---|---|
-| `.new` | `.text("N")` |
-| `.number(count)` | `.maxCount(count, max: 99)` |
-
-Instead of a minimum width plus padding for a single character, it is now a fixed `badgeSize` square (xsmall 16 / small 20 / medium 24). Narrow glyphs like `N` are pixel-identical, and a single CJK character or an `M`/`W` now keeps the circle round. Dynamic Type stops at `xxxLarge`.
-
-#### FallbackView
-
-It gained a padding interface, and **the minimum vertical padding is now built into the component.**
+A `Padding` enum was also added, and **the minimum vertical padding is now built into the component.**
 
 ```swift
 public enum Padding {
@@ -613,30 +781,30 @@ public enum Padding {
 ```
 
 ```swift
-// 3.x - the padding came from outside
+// 3.x - padding came from outside
 FallbackView(…)
     .padding(.vertical, 80)
 
-// 4.0 - leave it to the component
+// 4.0 - the component owns it
 FallbackView(…)
     .padding(.compact)
 ```
 
-**Be sure to clear the padding and fixed heights you were applying from outside.** Leaving them in place double-applies them. In particular, `frame(height:)` overflows because the content does not fit within the minimum padding of 160 (or 80).
+**Remove the outer padding and any fixed height.** Leaving them in place doubles the padding. A `frame(height:)` in particular will overflow, since the content no longer fits inside the built-in 160 (or 80) minimum.
 
 | 3.x | 4.0 |
 |---|---|
-| `.padding(.vertical, 160)` | Remove (the default `.normal` is 160) |
-| `.padding(.vertical, 120)` | Remove |
+| `.padding(.vertical, 160)` | remove (default `.normal` = 160) |
+| `.padding(.vertical, 120)` | remove |
 | `.padding(.vertical, 80)` | `.padding(.compact)` |
 | `.padding(.vertical, 48)` | `.padding(.compact)` |
-| `.frame(height: 200)` | `.padding(.compact)` and remove the fixed height |
+| `.frame(height: 200)` | `.padding(.compact)` and drop the fixed height |
 
 The button area goes through `buttonActionArea(_:)` (`.single` / `.horizontal` / `.vertical`).
 
 ---
 
-### 7. Removed UIKit wrappers
+### 2.8 Removed UIKit wrappers
 
 The deprecated UIKit wrappers were removed. Bridge the SwiftUI components with `UIHostingController`.
 
@@ -645,31 +813,113 @@ The deprecated UIKit wrappers were removed. Bridge the SwiftUI components with `
 | `Montage.Button.SolidUIButton` | `Montage.Button(variant: .solid, …)` |
 | `Montage.Button.OutlinedUIButton` | `Montage.Button(variant: .outlined, …)` |
 | `ContentBadgeUIView` | `ContentBadge(…)` |
+| `InteractionUIView` | the `Interaction` modifier |
 
-The specs are identical, so there is no difference in what gets rendered.
+The specs are identical, so nothing renders differently.
 
 ---
 
-### 8. Component spec refresh
+## 3. No replacement
 
-This is the section that is easy to miss because nothing fails to compile. **The API is unchanged and only the values moved**, so it only shows up when you look at the screen after the replacements are done.
+There is no mechanical equivalent for these, so **you have to choose.** Substituting something that looks close will hide the fact that the result changed.
+
+### 3.1 RedOrange tokens
+
+There is no 4.0 token for `accentForegroundRedOrange` or `accentBackgroundRedOrange`. The `redOrange*` primitives are still there.
+
+A one-to-one substitution is impossible, so look at what the spot meant and pick deliberately - and **whatever you pick, the color changes.**
+
+In the Wanted app all three usages were text or icon colors, so they moved to `.foregroundNegativePrimary`, turning `redOrange50/60` into `red50/60`. If you used it as a surface color, `.surfaceNegativePrimary` or the `redOrange*` primitive directly stays closer to the original value.
+
+### 3.2 Spacing pt28 and pt36
+
+The 4.0 spacing scale has no `28` or `36`. The new scale is `0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 32, 40, 48, 56, 64, 72, 80`.
+
+Anywhere you used `.spacing(.pt28)` or `.spacing(.pt36)` you have to pick between `spacing24`, `spacing32`, and `spacing40`, and **the layout shifts by 4pt.** If you truly need an off-scale value, use a literal. But literals piling up across a screen is a sign its spacing needs another look.
+
+```bash
+grep -rn "spacing(\.pt28\|spacing(\.pt36" --include="*.swift" .
+```
+
+### 3.3 IconButton non-standard sizes
+
+Sizes other than the four standard ones (16, 18, 20, 24) move to `NormalSize.custom(size:)`, where **`size` changes meaning from icon size to container size.**
+
+In 3.x `.normal(size: n)` made the container the same `n` as the icon. In 4.0 `.custom(size: n)` treats `n` as the container edge and derives the icon from the dimension token nearest to two thirds of it. The container is clamped to `[24, 64]`.
+
+```swift
+// 3.x - n is the icon size
+IconButton(variant: .normal(size: 22), icon: .search)
+
+// 4.0 - n is the container size and the icon is derived from it
+IconButton(variant: .normal(size: .custom(size: 32)), icon: .search)  // icon 20
+```
+
+Reusing the 3.x number shrinks the icon: `.custom(size: 22)` clamps the container to 24, giving a 16pt icon. Pick the container value that yields the icon size you want.
+
+| Container | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 |
+|---|---|---|---|---|---|---|---|---|
+| Icon | 16 | 18 | 20 | 24 | 28 | 32 | 36 | 40 |
+
+### 3.4 SegmentedControl outlined variant
+
+The `Variant` enum and the `variant(_:)` modifier were removed entirely. Everything collapses to `solid`, so **the outlined appearance is gone.**
+
+### 3.5 ListCell verticalAlign(.bottom)
+
+Only `.top` and `.center` remain. Anywhere that needed bottom alignment has to be restructured or settle for `.top`.
+
+### 3.6 TextArea bottom resource presets
+
+`Resource.textButton`, `.chip`, `.filterButton`, and `.badge` were removed. Draw them yourself with `Resource.Leading.slot { }` / `Resource.Trailing.slot { }`, or check whether the new `.button` and `.contentBadge` (trailing) match your intent.
+
+### 3.7 FallbackView image slot
+
+3.x let you pass an illustration through `image:`, but 4.0's `FallbackView` has no image API at all. Only the title, description, and button area remain.
+
+If you need the illustration, assemble the empty state yourself instead of using `FallbackView`. Leave it as is and **the illustration disappears from those screens.**
+
+### 3.8 AvatarGroup variant
+
+`variant:` was dropped from `AvatarGroup(_:variant:size:onTap:)`, which is now fixed to `.person`. Anywhere 3.x grouped company or academy logos with `company` / `academy`, 4.0 renders **circles instead of rounded rectangles.**
+
+You will delete the argument to fix the compile error - check what that spot renders while you are there.
+
+### 3.9 TextField trailing button color
+
+`variant: Button.Color` was dropped from `TextField.TrailingButtonInfo(variant:title:disable:handler:)`. 4.0 fixes the button to outlined, so a verification button you had emphasised with `primary` changes color.
+
+### 3.10 Other removals
+
+| Removed | Note |
+|---|---|
+| `ModalNavigation.Variant.extended` | no replacement |
+| `ModalNavigation.Variant.floating(alternative:background:)` | only the argument-less `.floating` remains |
+| `Select.shadowBackgroundColor(_:)` | no replacement |
+| `Skeleton.Length` (`_25`/`_50`/`_75`/`_100`) | widths are now uniform |
+
+---
+
+## 4. Visual changes
+
+**These compile cleanly but change the screen.** The API is unchanged, so they only surface once you look at the result of the migration.
+
+### 4.1 Component specs
 
 #### Button
 
 | Item | 3.x | 4.0 |
 |---|---|---|
 | radius | large 12 / medium 10 / small 8 | large **14** / medium **12** / small **10** / xsmall 8 |
-| Height constraint | fixed `.frame(height:)` | `.frame(minHeight:)` |
-| Icon size | large 24 / medium 24·22 / small 20·18 | large 22 / medium 22·20 / small 20·16 / xsmall 16 |
-| Sizes | large · medium · small | **+ xsmall** |
-| color | primary · assistive | **+ negative** |
-| Typography | one step up per size | adjusted one step down per size |
+| height constraint | fixed `.frame(height:)` | `.frame(minHeight:)` |
+| icon size | large 24 / medium 24·22 / small 20·18 | large 22 / medium 22·20 / small 20·16 / xsmall 16 |
+| typography | one step up per size | adjusted one step down per size |
 
-**The height constraint going from fixed to a minimum has the widest impact.** In 3.x a long label was truncated onto one line (`Text...`); in 4.0 it **wraps and the button grows taller.** If you have buttons with long labels, the surrounding layout will shift.
+**The height constraint moving from fixed to minimum has the widest blast radius.** 3.x truncated a long label to one line (`Some text...`); 4.0 **wraps it and the button grows taller.** Any button with a long label will push the surrounding layout.
 
-#### Chip · FilterButton
+#### Chip and FilterButton
 
-Typography drops one step per size and padding was reduced, so **chips get smaller overall.**
+Typography drops one step per size and padding shrinks, so **chips get smaller overall.**
 
 | Chip size | 3.x typography | 4.0 typography |
 |---|---|---|
@@ -678,38 +928,42 @@ Typography drops one step per size and padding was reduced, so **chips get small
 | `small` | `label1` | `caption1` |
 | `xsmall` | `caption1` | `caption2` |
 
-FilterButton gets a larger radius and less padding, so it ends up rounder and smaller.
+FilterButton gets a larger radius and less padding, making it rounder and smaller.
 
 #### Select
 
 | Item | 3.x | 4.0 |
 |---|---|---|
-| Sizes | None | New `size(.large / .medium)` |
-| min-height | - | Increased (the field gets taller) |
-| Border color | - | Lighter |
-| `heading` · `requiredBadge` | Built into the component | Removed - moved to `FormControl` |
-| Vertical alignment | Always `top` | `top` only on `overflow`, `center` otherwise |
+| min-height | - | increased (the field gets taller) |
+| border color | - | lighter |
+| vertical alignment | always `top` | `top` only on `overflow`, `center` otherwise |
 
-The alignment change is only noticeable at larger Dynamic Type sizes. Because 3.x always aligned to `top`, once the text grew taller than the leading icon and chevron (24pt), **only the icons appeared pushed up.** 4.0 uses `top` only in the `overflow` state where text wraps onto multiple lines, and centers it on a single line. The `ListCell` in the option list also got `verticalAlign(.center)`, so radios and checkboxes sit centered against the label.
+The alignment change is only visible at larger Dynamic Type sizes. 3.x always aligned to the top, so once the text grew past the leading icon and chevron (24pt), **the icons looked stuck to the top.** 4.0 uses `top` only when the text overflows onto multiple lines and centers it otherwise. The `ListCell`s in the option list also got `verticalAlign(.center)`, so radios and checkboxes sit centered on the label.
 
-#### TopNavigation · ModalNavigation
-
-The background tint that appears while scrolling got denser.
-
-| Item | 3.x and early 4.0 | 4.0 |
-|---|---|---|
-| Scroll background tint | `backgroundOpacity * 0.7` | `backgroundOpacity * 0.88` |
-
-**The background gets darker** in the range where scrolling brings the navigation background in. There is no API change, only a value change, so nothing fails to compile. Please eyeball the screens where content passes under the navigation.
-
-#### SegmentedControl
+#### ActionArea
 
 | Item | 3.x | 4.0 |
 |---|---|---|
-| variant | `solid` · `outlined` | **`outlined` removed** |
-| Icon | `icon` toggle | `leadingIcon` + `iconOnly` |
+| `extra` slot horizontal padding | 20 | **24** |
+| `extra` slot bottom padding | 24 | **20** |
+| `extra` divider color | `lineNeutral` (= `lineNeutralSecondary`) | `lineNeutralTertiary` (lighter) |
+| caption typography | `label2` | `label2` with `weight: .medium` (bolder) |
+| `alternative` action button | `outlined` / `primary` | `outlined` / **`assistive`** |
+| `cancel` main action button | `outlined` / `assistive` | **`solid`** / `assistive` |
 
-#### Avatar · AvatarGroup
+The main button row keeps its horizontal padding of 20.
+
+The button colors are an API-compatible change, so nothing fails to compile. The alternative action's label goes from blue to black, increasing contrast against the primary action, and the `cancel` variant's main button goes from outlined to a grey fill. The `sub` action is unchanged.
+
+#### TopNavigation and ModalNavigation
+
+| Item | 3.x | 4.0 |
+|---|---|---|
+| scroll background tint | `backgroundOpacity * 0.7` | `backgroundOpacity * 0.88` |
+
+**The navigation background gets darker** in the range where scrolling reveals it.
+
+#### Avatar and AvatarGroup
 
 The cornerRadius of the company and academy variants goes up by **2** at every size.
 
@@ -722,70 +976,172 @@ The cornerRadius of the company and academy variants goes up by **2** at every s
 | `xlarge` | 14 | 16 |
 | `custom(v)` | `ceil(v * 0.25 / 2) * 2` | `ceil(v * 0.25 / 2) * 2 + 2` |
 
-The default border color moved from `lineAlternative` to `lineNeutralTertiary`, and the push-badge inset was retuned per size.
+The placeholder drawn when there is no image also changed from a dedicated illustration to an icon glyph (`personFill` / `companyFill` / `graduationFill`). Push badge insets were adjusted per size as well.
 
 #### Everything else
 
-The `Shadow`, `Typography`, `Opacity`, and `Spacing` definitions were adjusted, as were `Toast`, `SnackBar`, `Popup`, `Popover`, `Tooltip`, `Thumbnail`, `Accordion`, `Category`, and `ProgressTracker`. The new `Radius`, `Dimension`, `Primitive`, and `MaterialBackground` are additions.
+`Shadow`, `Typography`, `Opacity`, and `Spacing` definitions were adjusted, as were `Toast`, `SnackBar`, `Popup`, `Popover`, `Tooltip`, `Thumbnail`, `Accordion`, `Category`, and `ProgressTracker`.
 
----
+### 4.2 Full list
 
-## Changes that alter what you see
-
-These compile fine but change the screen. **After migrating, please look at the screens in this list.**
+**Walk through these screens after migrating.**
 
 | Target | What changes |
 |---|---|
-| **Button** | The height constraint went from fixed to a minimum, so **long labels wrap instead of truncating.** The button grows taller and pushes the surrounding layout. radius is also +2 per size |
-| **Chip · FilterButton** | Typography drops one step and padding shrinks, so they **get smaller.** Wrap points change for chips and filter bars laid out horizontally |
-| **Select** | min-height went up, so **the field gets taller.** The border also gets lighter. At larger Dynamic Type sizes, the leading icon and chevron that used to sit high are now centered |
-| **SegmentedControl** | The `outlined` variant was removed. Places that used outlined become solid |
-| **ActionArea** | The transparent background is now **tied to the scroll-reached-bottom signal.** In containers that do not raise it (`SwiftUI.ScrollView`, `List`, a popup with no scrolling), the gradient and the opaque background stay put, so you have to pass `scrollReachedEnd(true)` yourself. The background only goes transparent when the `extra` slot is empty. The `extra` slot's horizontal padding went 20→24 and bottom 24→20, the divider got lighter, and the caption is heavier at `medium` weight. **The alternative action button's label goes from blue to black, and the `cancel` main button goes from outlined to a grey fill** |
-| **Avatar · AvatarGroup** | company and academy cornerRadius +2 at every size. Company logos get slightly rounder |
-| **FallbackView** | A minimum vertical padding of 160 is built in. Not clearing the outer padding and fixed height double-applies them. The description typography goes from `body2` to `body2Reading`, increasing line spacing |
-| **Input components** | The label moves above the field, errors below it, and the counter below and trailing. Field height and overall form height change |
-| **Character counter** | `Text("...")` interpolation adds a thousands separator at limits of 1000 and up (`5,000`). Use `Text(verbatim:)` |
-| **disabled appearance** | The component's own `opacity` gave way to `isEnabled`-based color tokens. The double-applied opacity is gone, so it **looks less faded**. Custom views placed in ListCell slots (company logos and the like) no longer fade |
-| **PlayBadge** | A 28% `coolNeutral40` tint was added to the background. The badge stays visible on bright thumbnails |
-| **Toast · SnackBar** | Background opacity light 50% → 52%, dark 46% → 43% |
+| **Color tokens** | `accentForegroundBlue`, `Green`, and `Orange` change in both light and dark; the other `accentForeground*` tokens and `materialDimmer` change in dark. See [Tokens whose value also changes](#tokens-whose-value-also-changes) |
+| **RedOrange tokens** | No matching token, so **the color changes whatever you pick.** Find every usage |
+| **Spacing pt28 / pt36** | No matching value, so you pick from 24/32/40 and the layout shifts by 4pt |
+| **Button** | The height constraint moved from fixed to minimum, so **long labels wrap instead of truncating.** The button grows taller and pushes the surrounding layout. radius also +2 per size |
+| **Chip / FilterButton** | Typography drops a step and padding shrinks, so **they get smaller.** Wrap points change in horizontal chip and filter rows |
+| **Select** | min-height goes up, so **the field gets taller.** The border also gets lighter. At large Dynamic Type sizes the leading icon and chevron no longer stick to the top |
+| **SegmentedControl** | `outlined` variant removed; those spots fall back to solid |
+| **ActionArea** | The transparent background is now **tied to the scroll reached-end signal.** Containers that do not report it (`SwiftUI.ScrollView`, `List`, non-scrolling popups) keep the gradient and the opaque background, so pass `scrollReachedEnd(true)` yourself. The background only turns transparent when the `extra` slot is empty. `extra` slot horizontal padding 20→24, bottom 24→20, lighter divider, caption bolder at `medium` weight. **The alternative action's label goes from blue to black and the `cancel` main button from outlined to a grey fill** |
+| **AvatarGroup variant** | `variant:` is fixed to `.person`, so groups that used company or academy render **as circles instead of rounded rectangles** |
+| **Avatar / AvatarGroup** | company and academy cornerRadius +2 at every size. The no-image placeholder changed from an illustration to an icon glyph. `opacity43` when disabled |
+| **FallbackView** | The `image:` slot is gone, so **the illustration disappears.** 160 minimum vertical padding is built in; outer padding and fixed heights double up if you leave them. The description typography moved from `body2` to `body2Reading`, increasing line spacing |
+| **TextField trailing button** | `variant:` is gone and the button is fixed to outlined, changing the color of buttons you had emphasised with `primary` |
+| **Input components** | The label moves above the field, the error below it, and the counter below and to the right. Field height and overall form height change |
+| **TextArea bottom resources** | The default gap between resources moves from a fixed 4 to size-dependent values (large 8 / medium 6) |
+| **Character counter** | `Text("...")` interpolation adds a thousands separator at limits of 1000 or more (`5,000`). Use `Text(verbatim:)` |
+| **Disabled state** | Instead of each component lowering its own opacity, colors now come from `isEnabled`-driven tokens. Opacity no longer stacks, so things **look less faded.** Custom views placed in `ListCell` slots (company logos and so on) are no longer dimmed. **A `.disabled(true)` on an ancestor now changes `Chip` and `FilterButton` colors too** (in 3.x it only blocked touches) |
+| **PushBadge** | A single-character badge is now a fixed `badgeSize` square. It also stops scaling at `xxxLarge`, so it comes out smaller than 3.x at accessibility text sizes |
+| **PlayBadge** | A `coolNeutral40` 28% tint was added to the background and the play icon is now `staticWhite` at 88%. The badge stays visible on bright thumbnails |
+| **Toast / SnackBar** | Background opacity light 50% → 52%, dark 46% → 43% |
 | **BottomSheet** | Background opacity 80% → 88% |
-| **SearchField** | Two layers of solid tint; the inactive outlined background becomes `surfaceNeutralTertiary` |
-| **TopNavigation · ModalNavigation** | The scroll background tint went from `0.7` to `0.88`, so **the navigation background gets darker while scrolling** |
-| **Typography `caption2`** | The Dynamic Type scale curve moved from `.caption2` to `.caption`. The base size is unchanged, and the inversion where `caption2` grew larger than `caption1` at bigger sizes is resolved |
-| **Avatar · Thumbnail** | `opacity43` is applied when disabled |
-| **Skeleton** | Text placeholder bar widths go from variable to uniform (only while loading) |
-| **IconButton** | Same glyph, larger touch container (about 6\~8px of layout shift) |
-| **RedOrange tokens** | There is no counterpart for `accentForegroundRedOrange` and `accentBackgroundRedOrange`, so **the color changes** no matter what you move to. Find and check every spot that used them |
+| **TopNavigation / ModalNavigation** | The scroll background tint goes from `0.7` to `0.88`, so **the navigation background gets darker while scrolling** |
+| **Typography `caption2`** | The Dynamic Type scale curve moved from `.caption2` to `.caption`. The base size is unchanged, and `caption2` no longer overtakes `caption1` at larger sizes |
+| **Thumbnail** | `opacity43` when disabled |
+| **Skeleton** | Text placeholder bar widths go from variable to uniform (while loading only) |
+| **IconButton** | Same glyph, larger touch container (roughly 6\~8pt of layout shift) |
+
+---
+
+## Added APIs
+
+**Not needed for the migration.** These are new in 4.0 and listed here for reference only. See the [DocC documentation](./documentation) and the Blueprint sample app for usage.
+
+### New components
+
+#### ScreenScaffold
+
+Assembles `TopNavigation` + content + `ActionArea` into one screen, taking over the scroll-offset plumbing and bottom-inset math you used to wire up per screen. It is also the replacement for the removed `View.topNavigation(...)`, so it shows up during the migration too ([2.4](#24-viewtopnavigation-removed)).
+
+```swift
+ScreenScaffold(
+    navigation: { TopNavigation(title: "Settings") },
+    actionArea: { ActionArea(variant: .neutral(main: .init(text: "Save", action: save))) }
+) {
+    content
+}
+.backgroundColor(.semantic(.backgroundNeutralPrimary))
+```
+
+#### SearchField
+
+A search input. It pairs a leading search icon with a single-line input, and a clear button appears on the right once there is text. Sizing follows the same system as `TextField`. `TopNavigation`'s search mode uses this component too.
+
+```swift
+SearchField(text: $keyword)
+    .placeholder("Search")
+    .onSubmit { search(keyword) }
+
+// outlined, medium
+SearchField(text: $keyword)
+    .variant(.outlined)
+    .size(.medium)
+```
+
+#### FormControl · FormControlGroup
+
+`FormControl` places the label, message, and accessory around an input component. Attaching those modifiers to the component wraps one automatically, so you rarely write it yourself ([2.1](#21-input-labels-messages-and-counters)).
+
+`FormControlGroup` aligns the label column across stacked inputs that put their label on the leading side, sizing it to the longest label. No fixed width in the call site, and it re-measures when Dynamic Type or localization changes the label lengths.
+
+```swift
+FormControlGroup {
+    TextField(text: $name)
+        .labelPlacement(.leading)
+        .label("Name")
+
+    TextField(text: $email)
+        .labelPlacement(.leading)
+        .label("Email address")
+}
+// the label column settles on the width of "Email address" and both inputs line up
+```
+
+### New token groups
+
+`Radius`, `Dimension`, `Primitive`, and `MaterialBackground`. Each is exposed as a `CGFloat` extension and provides `allValues`, `min`, and `max`.
+
+New semantic tokens were added too: `lineBrandFocus`, `lineNegativeFocus`, `surfaceBrandSubtle`, `surfaceNegativeStrong`, `foregroundAccent*`, `lineAccent*`, and `surfaceAccent*` (translucent 8%).
+
+### Per-component additions
+
+| Component | Added |
+|---|---|
+| `Button` | `xsmall` size, `negative` color |
+| `TextButton` | `fillWidth(_:)` |
+| `IconButton` | `disableInteraction(_:)`, `interactionColor(_:)` |
+| `ActionArea` | the icon slot (16pt) on `caption(_:icon:)`, `scrollReachedEnd(_:)`, `backgroundColor(_:)` |
+| `TopNavigation` | `backgroundColor(_:)` |
+| `Chip` | `borderColor(_:)` |
+| `Category` | `itemDisabled(_:)` |
+| `PushBadge` | `outlineBorder(_:color:)` |
+| `ListCell` | `verticalPadding(.custom(_:))`, four slots (`leading`, `labelTrailing`, `trailing`, `extra`) |
+| `Select` | `size(.large/.medium)` |
+| `TextField`, `TextArea` | `autocorrectionDisabled(_:)`, `onTextChange(_:)`, `size(_:)` |
+| `Shadow` | `shadow(_:) -> some ShapeStyle` |
+| `UIColor` | Montage token extensions |
 
 ---
 
 ## Checklist
 
-- [ ] After replacing color semantic tokens, check for leftovers with `grep -rn "\.label\(Normal\|Alternative\|Assistive\|Strong\|Neutral\|Disable\)\b"`
-- [ ] Check for leftover `spacing(.pt` and `opacity(.p`
-- [ ] Check for leftover `.disable(` (`.disabled(` is the correct one)
-- [ ] Every `TextField`/`TextArea` is wrapped in a `FormControl`
-- [ ] Character counters use `Text(verbatim:)` - prioritize spots with a limit of 1000 or more
-- [ ] Outer `padding(.vertical,)` and `frame(height:)` removed wherever `FallbackView` is used
-- [ ] No `if` statements inside `.actionArea {}` slots
-- [ ] Chip slot icons have their size and color set at the call site
-- [ ] Buttons with long labels now wrap - check that the taller button and the layout it pushes are acceptable
-- [ ] Wherever `transparentBackground` was used with `.manual`, `scrollReachedEnd(_:)` is passed
-- [ ] The ActionArea background looks as intended in popups and sheets with no scroll container
-- [ ] The button colors look as intended in every ActionArea that uses an `alternative` action or the `.cancel` variant
-- [ ] Check the screens listed in [Component spec refresh](#8-component-spec-refresh) and [Changes that alter what you see](#changes-that-alter-what-you-see) on a device or simulator
+### Substitution
 
-> The fastest way to verify spec changes is to build Blueprint at both versions and compare.
->
-> ```bash
-> git worktree add --detach ../baseline v3.15.2   # the version you are coming from
-> xcodebuild -workspace ../baseline/Montage.xcworkspace -scheme Blueprint \
->   -configuration Debug -destination 'id=<simulator udid>' \
->   -derivedDataPath /tmp/dd-before build
-> ```
+- [ ] After substituting semantic color tokens, check for leftovers with `grep -rn "\.label\(Normal\|Alternative\|Assistive\|Strong\|Neutral\|Disable\)\b"`
+- [ ] Check for leftover `spacing(.pt` and `opacity(.p`
+- [ ] `grep -rn "spacing(\.pt28\|spacing(\.pt36"` - values with no replacement
+- [ ] Check for leftover `.disable(` (it should be `.disabled(`)
+- [ ] No component-specific modifier chained after `.disabled()` on `Chip` or `FilterButton`
+- [ ] Check for leftover `.topNavigation(`
+- [ ] Audit every use of `accentForegroundRedOrange` and `accentBackgroundRedOrange`
+- [ ] Audit `FallbackView(image:`, `variant:` on `AvatarGroup(`, and `TrailingButtonInfo(variant:`
+
+### Restructuring
+
+- [ ] 3.x `heading`, `requiredBadge`, and `description` moved to `label` and `message`
+- [ ] Character counters use `Text(verbatim:)` - prioritise limits of 1000 or more
+- [ ] Outer `padding(.vertical,)` and `frame(height:)` removed from `FallbackView` call sites
+- [ ] No `if` statements inside `.actionArea {}` or `ScreenScaffold` slots
+- [ ] Icon size and color set at the call site for Chip slots
+- [ ] `scrollReachedEnd(_:)` passed wherever `transparentBackground` was used with `.manual`
+
+### Visual review
+
+- [ ] Screens using `accentForeground{Blue,Green,Orange}`, in both light and dark
+- [ ] The remaining `accentForeground*` and `materialDimmer`, in dark mode
+- [ ] Buttons with long labels - confirm the surrounding layout can absorb the extra height
+- [ ] ActionArea background in popups and sheets with no scroll container
+- [ ] Button colors in ActionAreas using the `alternative` action or the `.cancel` variant
+- [ ] Avatar placeholders where no image is provided
+- [ ] `FallbackView` screens that had an illustration, and company/academy `AvatarGroup`s
+- [ ] Every screen in [4. Visual changes](#4-visual-changes), on device or in the simulator
+
+The fastest way to review spec changes is to build Blueprint at both versions and compare. Set `UDID` to a value from `xcrun simctl list devices`.
+
+```bash
+UDID=... # xcrun simctl list devices
+
+git worktree add --detach ../baseline v3.15.2
+xcodebuild -workspace ../baseline/Montage.xcworkspace -scheme Blueprint \
+  -configuration Debug -destination "id=$UDID" \
+  -derivedDataPath /tmp/dd-before build
+```
 
 ---
 
 ## 3.0
 
-If you are coming from a version older than 3.0, see the [release notes](https://github.com/wanteddev/montage-ios/releases).
+If you are upgrading from a version older than 3.0, see the [release notes](https://github.com/wanteddev/montage-ios/releases).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,12 +18,14 @@ Breaking changes fall into four groups. Working top to bottom clears compile err
 
 | Order | Section | Kind | What you do |
 |---|---|---|---|
-| 1 | [Renamed](#1-renamed) | Mechanical | `sed` handles it |
+| 1 | [Renamed](#1-renamed) | Mechanical | mostly `sed` |
 | 2 | [Removed, needs rework](#2-removed-needs-rework) | Restructure | Move to the replacement API |
 | 3 | [No replacement](#3-no-replacement) | Judgement call | You have to choose |
 | 4 | [Visual changes](#4-visual-changes) | Eyeball it | **No compile errors** |
 
 **Do not skip section 4.** Those entries keep the same API and change only values, so the build passes while the screen changes. A clean build does not mean the migration is done.
+
+Section 1 is not entirely `sed` either. Twelve color tokens change their value along with their name ([Tokens whose value also changes](#tokens-whose-value-also-changes)), and a `\b` substitution is not Swift-syntax aware, so it also rewrites the same name inside comments and string literals. Skim the diff once you are done substituting.
 
 ---
 
@@ -1088,7 +1090,7 @@ New semantic tokens were added too: `lineBrandFocus`, `lineNegativeFocus`, `surf
 | `Chip` | `borderColor(_:)` |
 | `Category` | `itemDisabled(_:)` |
 | `PushBadge` | `outlineBorder(_:color:)` |
-| `ListCell` | `verticalPadding(.custom(_:))`, four slots (`leading`, `labelTrailing`, `trailing`, `extra`) |
+| `ListCell` | `verticalPadding(.custom(_:))`, four slot modifiers (`leadingResources(_:)`, `labelTrailingResources(_:)`, `trailingResources(_:)`, `extraResources(_:)`) |
 | `Select` | `size(.large/.medium)` |
 | `TextField`, `TextArea` | `autocorrectionDisabled(_:)`, `onTextChange(_:)`, `size(_:)` |
 | `Shadow` | `shadow(_:) -> some ShapeStyle` |
@@ -1134,11 +1136,19 @@ The fastest way to review spec changes is to build Blueprint at both versions an
 ```bash
 UDID=... # xcrun simctl list devices
 
+# the version you are coming from
 git worktree add --detach ../baseline v3.15.2
 xcodebuild -workspace ../baseline/Montage.xcworkspace -scheme Blueprint \
   -configuration Debug -destination "id=$UDID" \
   -derivedDataPath /tmp/dd-before build
+
+# the version you are moving to
+xcodebuild -workspace Montage.xcworkspace -scheme Blueprint \
+  -configuration Debug -destination "id=$UDID" \
+  -derivedDataPath /tmp/dd-after build
 ```
+
+Install both on the same simulator, switch between them, and put the components from [4. Visual changes](#4-visual-changes) side by side. If something looks different that is not on that list, the document missed it - please let us know.
 
 ---
 


### PR DESCRIPTION
# 개요
- 이슈 링크 :

4.0 마이그레이션 가이드가 **v3.15.2 대비 넷 디프**가 아니라 4.0 개발 중 작업분이 섞인 상태였습니다. 기준선을 직전 릴리즈 태그로 못 박고 전면 재작성했습니다.

두 리비전의 `public` 선언과 enum case를 전수 추출해 대조하는 방식으로 검증했습니다.

# 수정사항

## 1. 기준선 정정 - 4.0 내부 작업이 "3.x → 4.0"으로 적혀 있던 항목 제거

| 삭제한 항목 | 이유 |
|---|---|
| `.fillPrimary` → `.surfaceBrandSubtle` | `fillPrimary`는 v3.x에 존재한 적 없음. 4.0 중 생겼다 없어짐 |
| `.fillNegative` → `.surfaceNegativeStrong` | 위와 동일 |
| `.gradientColor(_:)` → `.backgroundColor(_:)` | v3.15.2 다음날 4.0 브랜치에서 추가됐다가 개명 |
| 시각 변화 표의 `SearchField` 행 | 4.0 신규 컴포넌트. 3.x에 없어서 "변경"이 성립 안 함 |

## 2. 누락됐던 breaking change 추가

`public init(` 첫 줄만 비교하면 여러 줄 시그니처 변경을 놓칩니다. 괄호 균형으로 시그니처 전체를 파싱해 다시 검증했습니다.

- `View.topNavigation(...)` 오버로드 2개 완전 제거
- `FallbackView.init`에서 `image:` 제거 (**대응 없음**), `button:` → `buttonActionArea(_:)`
- `AvatarGroup.init`에서 `variant:` 제거 → `.person` 고정 (**대응 없음**)
- `TextField.TrailingButtonInfo`에서 `variant:` 제거 → outlined 고정 (**대응 없음**)
- `TopNavigation` init의 `backgroundColor:`, `TrailingIconButton`/`TrailingTextButton`의 `disable:` 제거
- `framedStyle(...)`의 `disabled:` 제거
- `TextArea.bottomResources` 시그니처·간격 기본값 변경 (고정 4 → 사이즈별 8/6)
- `Spacing.pt28` · `pt36` **대응 없음** (4.0 스케일에 28·36 부재)
- 컬러 매핑 3건 추가: `accentBackgroundPurple`, `linePrimaryNormal`, `lineStatusNegativeNormal`
- `ModalNavigation.extended` / `.floating(alternative:background:)`, `Select.description`/`shadowBackgroundColor`, `ListCell.trailingContent`, `Accordion.trailingContent` 오버로드, `BottomSheet`/`Popup.modalActionArea` 시그니처
- Avatar 플레이스홀더 일러스트 → 아이콘 글리프 교체, PlayBadge 아이콘 `staticWhite` 88%

## 3. 컬러 토큰 "값 동일" 주장 정정

기존 문서는 "RedOrange 2건 빼면 값이 같다"고 했지만, `Color.swift`의 3.x/4.0 switch를 전수 대조한 결과 **12건이 실제로 색이 바뀝니다.**

- 라이트·다크 모두 변경: `accentForegroundBlue`(`#005EEB`→`#0066FF`), `Green`(`#009632`→`#00BF40`), `Orange`(`#D17600`→`#FF9200`)
- 다크만 변경: `accentForegroundRed`/`Lime`/`Cyan`/`LightBlue`/`Violet`/`Purple`/`Pink`, `materialDimmer`
- 미세: `inverseLabel` (`neutral` → `coolNeutral`)

hex까지 표에 넣고 표마다 `값` 열을 추가했습니다.

## 4. 구조 재편 - breaking change / 추가 / 제거 분리

업계 관례(React 19 Upgrade Guide 등)를 따라 마이그레이션 가이드는 브레이킹 체인지만 담고, 신규 API는 별도 절로 뺐습니다.

```
1. 이름이 바뀐 것        기계적 치환
2. 없어져서 다시 짜야 하는 것   구조 재작성
3. 대응이 없는 것        직접 선택
4. 화면이 달라지는 것     화면 확인 (컴파일 에러 없음)
추가된 API              마이그레이션 불필요
```

`ScreenScaffold`·`SearchField`·`FormControlGroup`은 `추가된 API`로 옮기고 예시 코드를 붙였습니다. 대응 수단으로 등장할 때만 본문에서 링크합니다.

## 5. 그 밖

- 입력 컴포넌트 절을 `FormControl` 우선에서 **입력에 직접 붙이는 방식** 우선으로 뒤집었습니다. `FormControl.swift` 주석이 "단일 입력은 직접 붙이는 쪽이 간결"이라고 명시하는데 문서가 반대로 안내하고 있었습니다.
- 외부 사용자가 실행할 수 없는 안내("디자이너와 확인") 2건을 이슈 링크·판단 기준으로 교체했습니다.
- 번역투·직역 20여 건 교정 (`평탄화`, `단어 경계 치환`, `의미 색`, `면 토큰`, `세로 채움` 등).
- 문서 첫머리에 기준선 원칙을 명시해 다음 메이저에서 같은 혼입이 생기지 않게 했습니다.

# 미리보기

문서만 변경되어 스크린샷이 없습니다. 렌더 결과는 GitHub의 Files changed 탭에서 확인할 수 있습니다.

## 후속

`ListCell` 슬롯 모디파이어 네이밍 정리는 별도 티켓으로 발행했습니다: WRP-2583
