### PR TITLE
fix: Thumbnail이 urlString 변경 시 이미지를 다시 로드하지 않는 문제 수정

### DIFF
--- a/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
+++ b/Sources/Montage/1 Components/4 Contents/Thumbnail.swift
@@ -205,8 +205,10 @@ public struct Thumbnail: View {
         .if (thumbnailWidth > 0) {
             $0.frame(width: thumbnailWidth, height: thumbnailWidth * ratio.rawValue)
         }
-        .onAppear { loadIfNeeded() }
-        .onChange(of: urlString) { _ in loadIfNeeded() }
+        .onAppear { loadIfNeeded(urlString) }
+        // onChange 핸들러는 값이 바뀌기 전 뷰 인스턴스에 캡처되므로 self.urlString은 이전 값을 가리킨다.
+        // 전달받은 새 값을 그대로 넘겨야 URL 교체가 로드로 이어진다.
+        .onChange(of: urlString) { newValue in loadIfNeeded(newValue) }
         .onDisappear {
             // 화면에서 사라지면 진행 중인 다운로드를 즉시 취소해 네트워크 슬롯이 점유되지 않도록 한다.
             // loadedURL을 함께 비워, 같은 셀이 동일 URL로 재진입했을 때 loadIfNeeded()가 재요청을 수행하게 한다.
@@ -231,7 +233,7 @@ public struct Thumbnail: View {
         }
     }
 
-    private func loadIfNeeded() {
+    private func loadIfNeeded(_ urlString: String) {
         let url = URL(string: urlString)
         guard loadedURL != url else { return }
         loadedURL = url


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2698

`Thumbnail`이 부모로부터 받은 `urlString`이 바뀌어도 이미지를 새로 로드하지 않는 문제를 수정합니다.

스켈레톤 더미(빈 URL)를 실제 데이터로 교체하는 화면에서 썸네일이 회색으로 고착되고, 스크롤로 셀이 화면 밖에 나갔다 재진입해 `onAppear`를 다시 받을 때에야 뒤늦게 로드되는 증상으로 드러났습니다. 앱 이슈 [LIVE-1364](https://wantedlab.atlassian.net/browse/LIVE-1364)의 원인입니다.

# 수정사항

## 원인

```swift
.onChange(of: urlString) { _ in loadIfNeeded() }
```

`onChange(of:perform:)`의 클로저는 값이 바뀌기 **전** 뷰 인스턴스에 캡처됩니다. 새 값은 클로저 파라미터로만 전달되는데 이를 `_`로 버리고 `self.urlString` 프로퍼티를 읽으니, 핸들러는 계속 이전 URL을 봅니다. 그 결과 `loadIfNeeded()`에서 `URL(string: "") == nil`, `loadedURL == nil`이 되어 가드에 걸리고 로드가 시작조차 되지 않습니다.

오염되는 건 **부모가 주입하는 `let` 프로퍼티뿐**입니다. `loadedURL`(`@State`)과 `imageManager`(`@StateObject`)는 값이 뷰 struct가 아니라 SwiftUI가 관리하는 저장소에 있어서, 옛 인스턴스를 통해 접근해도 최신 값에 도달합니다. 그래서 `urlString`만 새 값으로 갈아끼우면 됩니다.

## 도입 시점

`bab85f38`(2026-05-11)에서 `WebImage` → `ImageManager` 직접 소유로 전환하며 URL 변경 처리를 `onChange`로 직접 구현할 때 유입됐습니다. 그 전 `WebImage`는 URL 변경을 자체 처리했습니다. 앱 기준 v26.521.0부터 영향.

## 검증

Blueprint에 문제 구조(`Montage.ScrollView` > `LazyVGrid` > `ForEach(id: \.offset)` + 스켈레톤 더미 10개 → 실데이터 20개 교체)를 옮긴 최소 재현 씬으로 확인했습니다.

수정 전 - `onChange`가 8회 발화하지만 전달된 URL이 전부 이전 값(빈 문자열)이라 로드가 스킵됨

```
TB 947ms onChange [<empty>]
TB 947ms   skip(sameURL) [<empty>]
```

수정 후 - 정상적으로 로드 시작

```
TB 880ms onChange [88426839-4]
TB 880ms   LOAD [88426839-4]
```

## 같은 패턴 전수 확인

Montage 내 `onChange(of:) { _ in }` 사용처 11곳을 확인했습니다. `Thumbnail` 외 10곳은 관찰 대상이 전부 `@State`/`@Binding`/computed라 프로퍼티 래퍼가 최신 값을 돌려주므로 영향이 없습니다. 부모 주입 `let`을 관찰하는 건 `Thumbnail`이 유일합니다.

# 미리보기
작업 전|작업 후
---|---
카드 텍스트는 실데이터인데 썸네일만 전부 회색(`fillAlternative`)으로 고착. 스크롤 후에야 로드됨|화면 진입 즉시 썸네일 정상 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011T2rb5zUBDWoDmiyaeGBFt

[LIVE-1364]: https://wantedlab.atlassian.net/browse/LIVE-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ