### PR TITLE
refactor: BottomSheet detent 높이 주석 정리 및 Select 미사용 코드 제거

### DIFF
--- a/Sources/Montage/1 Components/3 Selection And Input/Select.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/Select.swift
@@ -290,8 +290,6 @@ public struct Select: View {
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.colorScheme) private var colorScheme
     @State private var defaultMenuPresented = false
-    @State private var bottomSheetContentHeight: CGFloat = .zero
-    @State private var pureBottomSheetHeight: CGFloat = .zero
 
     private var isDisabled: Bool { isEnabled == false }
 
@@ -525,14 +523,6 @@ public struct Select: View {
 
     private var menuPresented: Binding<Bool> {
         customMenuPresented ?? $defaultMenuPresented
-    }
-
-    private var bottomSheetMaxHeight: CGFloat {
-        pureBottomSheetHeight + bottomSheetContentHeight
-    }
-
-    private var maxDetentValue: CGFloat {
-        (UIApplication.keyWindow?.safeAreaSize.height ?? 0) - 10
     }
 
     private var menu: some View {

--- a/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
+++ b/Sources/Montage/1 Components/8 Presentation/BottomSheet.swift
@@ -263,15 +263,19 @@ public struct BottomSheet: View {
         )
     }
     
+    /// detent가 가질 수 있는 최대 높이입니다.
+    ///
+    /// 기준값은 키 윈도우에서 세이프 에어리어 상하를 제외한 높이라, 시트가 화면 최상단까지
+    /// 올라가지는 않는다. 상태 표시줄·홈 인디케이터 영역만큼 아래에서 시작한다.
     private var maxDetentHeight: CGFloat {
+        let safeAreaHeight = UIApplication.keyWindow?.safeAreaSize.height ?? 0
         if #available(iOS 26, *) {
-            // iOS 26 부터는 stacked sheet로 자동 변경되지 않으므로 보정값 제거
-            // 단, 스크린 높이 - 10.2 보다 커지면 자동으로 불투명해지고 edge가 스크린 끝에 붙음
-            (UIApplication.keyWindow?.safeAreaSize.height ?? 0)
+            // iOS 26부터는 최대 높이에 도달해도 stacked sheet로 자동 전환되지 않으므로 보정하지 않는다.
+            return safeAreaHeight
         } else {
-            // 최대 높이에 도달할 경우 자동으로 stacked sheet로 변경되는 것을 막기 위한 보정값 10.2 추가
+            // 최대 높이에 도달하면 stacked sheet로 자동 전환되므로, 10.2pt 낮춰 전환을 막는다.
             // https://wantedx.slack.com/archives/C04TTGN5F1C/p1761040362320469?thread_ts=1761035208.156399&cid=C04TTGN5F1C
-            (UIApplication.keyWindow?.safeAreaSize.height ?? 0) - 10.2
+            return safeAreaHeight - 10.2
         }
     }
     


### PR DESCRIPTION
# 개요
- 이슈 링크 :
- BottomSheet의 detent 최대 높이 계산은 그대로 두고, 그 값을 설명하던 주석과 Select에 남아 있던 옛 계산 잔재만 정리했다. 동작과 렌더 결과는 바뀌지 않는다.

# 수정사항

## BottomSheet - `maxDetentHeight` 주석 정리
- iOS 26 분기 주석이 "보정값 제거"라고 해놓고 바로 다음 줄에서 그 임계를 넘는다는 식으로 읽혀 모순돼 보였다. 실제 기준값은 세이프 에어리어 상하를 뺀 높이라 해당 임계와 무관하므로, 오해를 부르던 문장을 걷어내고 stacked sheet 자동 전환 방지라는 의도만 남겼다.
- 기준값을 지역 상수(`safeAreaHeight`)로 묶어 두 분기가 같은 값에서 출발한다는 점을 드러냈다.
- 프로퍼티에 docstring을 붙여 시트가 화면 최상단까지 올라가지 않는 이유를 남겼다.

## Select - 미사용 detent 계산 제거
- Select는 이미 BottomSheet를 통해 메뉴를 띄우고 있어 detent 높이는 전적으로 BottomSheet가 계산한다. 자체 시트 시절에 쓰던 `maxDetentValue`, `bottomSheetMaxHeight`와 이를 받치던 `@State` 두 개는 어디서도 참조되지 않은 채 남아 있었다.
- 특히 `maxDetentValue`의 `-10` 보정은 BottomSheet의 `-10.2`와 값이 어긋나, 읽는 사람에게 기준이 두 벌 있는 것처럼 보였다.

# 미리보기
시각 변화 없음. public API 변경도 없어 마이그레이션 가이드 갱신 대상이 아니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBh5dLQCtzgexpXz15hEeN
