### PR TITLE
fix: TextArea fixed 리사이즈에서 주입된 텍스트가 내부 스크롤되지 않는 문제 수정

### DIFF
--- a/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
+++ b/Sources/Blueprint/Sources/Scene/Previews/TextAreaPreview.swift
@@ -54,6 +54,11 @@ struct TextAreaPreview: View {
         ]
     }
     
+    /// fixed 리사이즈 최대 높이(200)를 충분히 넘는 길이의 샘플 텍스트. 줄 번호로 스크롤 위치를 식별한다.
+    static let longSampleText = (1...18)
+        .map { String(format: "L%02d lorem ipsum dolor sit amet consectetur adipiscing", $0) }
+        .joined(separator: " ")
+
     @State private var showTransparentChecker: Bool = false
     @State private var text: String = ""
     @State private var resize: Resize = .normal
@@ -200,6 +205,19 @@ struct TextAreaPreview: View {
                             Button("reset") {
                                 trailingResources.removeAll()
                             }
+                        }
+                    }
+                    .font(.font(variant: .label1))
+                    // 서버 데이터처럼 코드로 텍스트를 주입하는 시나리오 재현용 (E2E: Tests/E2E/textarea-scroll)
+                    HStack {
+                        Text("Text :")
+                            .typography(variant: .headline2, weight: .medium)
+                        Spacer()
+                        Button("inject") {
+                            text = Self.longSampleText
+                        }
+                        Button("clear") {
+                            text = ""
                         }
                     }
                     .font(.font(variant: .label1))

--- a/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
+++ b/Sources/Montage/1 Components/3 Selection And Input/TextArea.swift
@@ -642,16 +642,16 @@ public struct TextArea: View {
             _text = text
         }
         
-        func makeUIView(context: Context) -> UITextView {
-            let textView = UITextView()
+        func makeUIView(context: Context) -> CustomTextView {
+            let textView = CustomTextView()
             textView.font = UIFont.systemFont(ofSize: 16)
             textView.isScrollEnabled = false
             textView.backgroundColor = .clear
             textView.delegate = context.coordinator
             return textView
         }
-        
-        func updateUIView(_ uiView: UITextView, context: Context) {
+
+        func updateUIView(_ uiView: CustomTextView, context: Context) {
             if uiView.text != text {
                 // 외부(코드)에서 텍스트가 교체되는 경우. 직접 대입은 UITextView의 UndoManager와
                 // 동기화되지 않아 stale operation이 남고, 이후 Undo 시 저장된 range가 현재 길이를
@@ -670,8 +670,11 @@ public struct TextArea: View {
             context.coordinator.parent.overflow = overflow
             context.coordinator.parent.inputLimit = inputLimit
             context.coordinator.parent.inputTransform = inputTransform
-            context.coordinator.minHeight = minHeight
-            context.coordinator.maxHeight = maxHeight
+            // 코드로 주입된 텍스트는 textViewDidChange를 거치지 않으므로 여기서도 스크롤 여부를
+            // 갱신한다. 아직 폭이 확정되지 않았다면 CustomTextView.layoutSubviews가 이어받는다.
+            // (WRP-2846: fixed 리사이즈에서 주입 텍스트가 스크롤되지 않고 바깥 ScrollView가 스크롤되던 문제)
+            uiView.maxHeight = maxHeight
+            uiView.updateScrollEnabled()
         }
         
         func makeCoordinator() -> Coordinator {
@@ -680,10 +683,7 @@ public struct TextArea: View {
         
         class Coordinator: NSObject, UITextViewDelegate {
             var parent: UITextViewWrapper
-            var minHeight: CGFloat?
-            var maxHeight: CGFloat?
-            private var heightConstraint: NSLayoutConstraint?
-            
+
             init(_ parent: UITextViewWrapper) {
                 self.parent = parent
             }
@@ -736,11 +736,8 @@ public struct TextArea: View {
                 }
                 // sizeThatFits 반환 높이가 maxHeight에서 포화되면 SwiftUI가 sizeThatFits를
                 // 재호출하지 않아 스크롤 토글 기회가 사라진다. 매 입력마다 호출되는 이 시점에서
-                // 무제한 높이로 측정한 콘텐츠 높이로 스크롤 여부를 직접 갱신한다.
-                let fit = textView.sizeThatFits(
-                    CGSize(width: textView.bounds.width, height: .greatestFiniteMagnitude)
-                ).height
-                textView.isScrollEnabled = fit > (maxHeight ?? .greatestFiniteMagnitude)
+                // 실제 폭 기준으로 스크롤 여부를 다시 계산한다.
+                (textView as? CustomTextView)?.updateScrollEnabled()
             }
         }
         
@@ -755,8 +752,8 @@ public struct TextArea: View {
 
             // isScrollEnabled는 여기서 설정하지 않는다. SwiftUI는 레이아웃 협상 과정에서
             // sizeThatFits를 비정상 width(예: 9, .infinity)로도 호출하는데, 그때의 측정값으로
-            // 스크롤을 토글하면 textViewDidChange에서 올바르게 켠 값을 false로 덮어쓴다.
-            // 스크롤 토글은 실제 bounds.width가 보장되는 textViewDidChange에서만 수행한다.
+            // 스크롤을 토글하면 올바르게 켠 값을 false로 덮어쓴다.
+            // 스크롤 토글은 실제 bounds.width가 보장되는 CustomTextView.updateScrollEnabled에서만 수행한다.
             newSize.height = min(max(newSize.height, minHeight ?? 0), maxHeight ?? .greatestFiniteMagnitude)
             return CGSize(
                 width: proposal.width ?? uiView.bounds.width,
@@ -803,9 +800,42 @@ public struct TextArea: View {
         }
     }
     
-    class CustomTextView: UITextView {
-        override var intrinsicContentSize: CGSize {
-            sizeThatFits(CGSize(width: frame.width, height: CGFloat.greatestFiniteMagnitude))
+    /// 콘텐츠 높이가 최대 높이를 넘을 때만 스크롤을 켜는 UITextView입니다.
+    ///
+    /// SwiftUI의 `sizeThatFits`는 비정상 width로도 호출되고, `textViewDidChange`는 사용자 입력에만
+    /// 반응하므로 어느 한 곳에서만 토글하면 누락이 생깁니다. 텍스트 주입(`updateUIView`),
+    /// 레이아웃 폭 확정(`layoutSubviews`), 사용자 입력(`textViewDidChange`) 시점에 모두
+    /// 실제 `bounds.width` 기준으로 재계산합니다.
+    final class CustomTextView: UITextView {
+        /// 스크롤을 켤 기준이 되는 최대 높이. `nil`이면 스크롤을 켜지 않는다.
+        var maxHeight: CGFloat? {
+            didSet {
+                if maxHeight != oldValue {
+                    updateScrollEnabled()
+                }
+            }
+        }
+
+        private var lastLayoutWidth: CGFloat = 0
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            // 폭이 처음 확정되거나 바뀔 때(회전 등)만 재계산한다. isScrollEnabled 변경이 다시
+            // layoutSubviews를 유발해도 폭이 같으면 건너뛰므로 재귀하지 않는다.
+            if bounds.width != lastLayoutWidth {
+                lastLayoutWidth = bounds.width
+                updateScrollEnabled()
+            }
+        }
+
+        /// 실제 폭 기준으로 콘텐츠 높이를 측정해 스크롤 여부를 갱신한다. 폭이 확정되지 않았으면 건너뛴다.
+        func updateScrollEnabled() {
+            guard bounds.width > 0 else { return }
+            let fit = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude)).height
+            let shouldScroll = fit > (maxHeight ?? .greatestFiniteMagnitude)
+            if isScrollEnabled != shouldScroll {
+                isScrollEnabled = shouldScroll
+            }
         }
     }
 }

--- a/Tests/E2E/textarea-scroll/README.md
+++ b/Tests/E2E/textarea-scroll/README.md
@@ -1,0 +1,37 @@
+# TextArea 중첩 스크롤 E2E
+
+`TextArea`를 `SwiftUI.ScrollView` 안에서 `.resize(.fixed(min:max:))`로 쓸 때, 코드로 주입된 긴 텍스트가
+TextArea 내부에서 스크롤되는지(바깥 ScrollView가 제스처를 가로채지 않는지) 검증한다. WRP-2846 회귀 방지용.
+
+## 요구사항
+
+- Xcode, 부팅된 iPhone 시뮬레이터
+- [Maestro](https://maestro.dev) (`~/.maestro/bin` 또는 PATH)
+- Java 17+ (`brew install openjdk@21`이면 자동 탐지)
+
+## 실행
+
+```bash
+Tests/E2E/textarea-scroll/run.sh              # Blueprint 빌드 → 설치 → 검증
+Tests/E2E/textarea-scroll/run.sh --skip-build # 직전 빌드 재사용
+Tests/E2E/textarea-scroll/run.sh --udid <UDID>
+```
+
+## 판정
+
+1. `setup.yaml`: Blueprint > TextArea 프리뷰 이동 → Resize `Fixed` → `inject` 버튼으로 18줄 텍스트 주입
+2. 스크린샷 A 촬영
+3. `swipe-up.yaml`: 포커스 없는 TextArea 내부를 위로 스와이프
+4. 스크린샷 B 촬영
+5. 비교
+   - TextArea 영역(세로 19~43%)이 A ≠ B → 내부 스크롤 정상
+   - Options 영역(세로 46~62%)이 A = B → 바깥 ScrollView 미동작
+
+두 조건을 모두 만족하면 `PASS`. 스크린샷은 `$TMPDIR/montage-e2e-textarea-scroll/`에 남는다.
+
+## 참고
+
+- 좌표는 iPhone 시뮬레이터의 프리뷰 레이아웃 기준이다. 프리뷰 상단 구조가 바뀌면 `swipe-up.yaml`과 `run.sh`의 비율을 조정한다.
+- 결함 상태에서는 "TextArea 내부 텍스트가 스크롤되지 않았습니다"가 출력된다(음성 대조로 확인됨).
+  Blueprint 프리뷰의 바깥 ScrollView는 콘텐츠가 화면보다 짧아 결함 상태에서도 거의 움직이지 않으므로,
+  바깥 스크롤 판정은 회귀 감지보다 부수 효과 방지 목적이다. 핵심 판정은 내부 스크롤 여부다.

--- a/Tests/E2E/textarea-scroll/run.sh
+++ b/Tests/E2E/textarea-scroll/run.sh
@@ -57,9 +57,15 @@ echo "▶ simulator: $UDID"
 # --- Build & install ----------------------------------------------------------
 if [[ $SKIP_BUILD -eq 0 ]]; then
   echo "▶ building Blueprint..."
-  xcodebuild -workspace "$ROOT/Montage.xcworkspace" -scheme Blueprint \
+  # 빌드 실패는 그대로 종료한다. 무시하면 이전 DerivedData의 낡은 Blueprint.app으로 E2E가 통과할 수 있다.
+  if ! xcodebuild -workspace "$ROOT/Montage.xcworkspace" -scheme Blueprint \
     -destination "id=$UDID" -derivedDataPath "$DERIVED" -configuration Debug build \
-    2>&1 | grep -E "error:|BUILD (SUCCEEDED|FAILED)" || true
+    >"$WORK/build.log" 2>&1; then
+    grep -E "error:|BUILD (SUCCEEDED|FAILED)" "$WORK/build.log" || true
+    echo "✗ Blueprint 빌드 실패 (로그: $WORK/build.log)" >&2
+    exit 1
+  fi
+  grep -E "BUILD SUCCEEDED" "$WORK/build.log" || true
 fi
 APP="$(find "$DERIVED/Build/Products" -maxdepth 2 -name Blueprint.app | head -1 || true)"
 [[ -n "$APP" ]] || { echo "Blueprint.app을 찾을 수 없습니다 (빌드 실패 또는 --skip-build 전 빌드 필요)" >&2; exit 2; }

--- a/Tests/E2E/textarea-scroll/run.sh
+++ b/Tests/E2E/textarea-scroll/run.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# TextArea fixed 리사이즈 + 바깥 ScrollView 중첩 시, 코드로 주입된 텍스트가 내부 스크롤되는지 검증한다.
+# (WRP-2846 회귀 방지 E2E)
+#
+# 판정 방식: 스와이프 전/후 스크린샷을 영역별로 잘라 비교한다.
+#   - TextArea 영역(세로 19~43%)은 달라져야 한다  → 내부가 스크롤됨
+#   - Options 영역(세로 46~62%)은 같아야 한다     → 바깥 ScrollView가 움직이지 않음
+#
+# 사용법:
+#   Tests/E2E/textarea-scroll/run.sh [--skip-build] [--udid <UDID>]
+# 요구사항: Xcode, Maestro(~/.maestro/bin 또는 PATH), Java 17+ (Homebrew openjdk@21 자동 탐지)
+# iPhone 시뮬레이터 레이아웃 기준 좌표를 사용한다.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+BUNDLE_ID="com.wantedlab.Blueprint"
+WORK="${TMPDIR:-/tmp}/montage-e2e-textarea-scroll"
+DERIVED="$WORK/DerivedData"
+SKIP_BUILD=0
+UDID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --udid) UDID="$2"; shift 2 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$WORK"
+
+# --- Java / Maestro -----------------------------------------------------------
+export PATH="$HOME/.maestro/bin:$PATH"
+if [[ -z "${JAVA_HOME:-}" ]]; then
+  if JH="$(/usr/libexec/java_home -v 17+ 2>/dev/null)"; then
+    export JAVA_HOME="$JH"
+  else
+    for c in /opt/homebrew/opt/openjdk@21 /opt/homebrew/opt/openjdk@17 /opt/homebrew/opt/openjdk; do
+      if [[ -d "$c/libexec/openjdk.jdk/Contents/Home" ]]; then
+        export JAVA_HOME="$c/libexec/openjdk.jdk/Contents/Home"; break
+      fi
+    done
+  fi
+fi
+[[ -n "${JAVA_HOME:-}" ]] && export PATH="$JAVA_HOME/bin:$PATH"
+command -v maestro >/dev/null || { echo "maestro가 없습니다. https://maestro.dev 참고" >&2; exit 2; }
+java -version >/dev/null 2>&1 || { echo "Java 17+가 필요합니다 (brew install openjdk@21)" >&2; exit 2; }
+
+# --- Simulator ----------------------------------------------------------------
+if [[ -z "$UDID" ]]; then
+  UDID="$(xcrun simctl list devices booted | grep -Eo '[0-9A-F-]{36}' | head -1 || true)"
+fi
+[[ -n "$UDID" ]] || { echo "부팅된 iOS 시뮬레이터가 없습니다. --udid로 지정하거나 먼저 부팅하세요." >&2; exit 2; }
+echo "▶ simulator: $UDID"
+
+# --- Build & install ----------------------------------------------------------
+if [[ $SKIP_BUILD -eq 0 ]]; then
+  echo "▶ building Blueprint..."
+  xcodebuild -workspace "$ROOT/Montage.xcworkspace" -scheme Blueprint \
+    -destination "id=$UDID" -derivedDataPath "$DERIVED" -configuration Debug build \
+    2>&1 | grep -E "error:|BUILD (SUCCEEDED|FAILED)" || true
+fi
+APP="$(find "$DERIVED/Build/Products" -maxdepth 2 -name Blueprint.app | head -1 || true)"
+[[ -n "$APP" ]] || { echo "Blueprint.app을 찾을 수 없습니다 (빌드 실패 또는 --skip-build 전 빌드 필요)" >&2; exit 2; }
+xcrun simctl terminate "$UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+xcrun simctl install "$UDID" "$APP"
+
+# --- Drive --------------------------------------------------------------------
+snap() { xcrun simctl io "$UDID" screenshot "$1" >/dev/null 2>&1; }
+# 상대 좌표(세로 %)로 스크린샷을 잘라 md5를 돌려준다.
+crop_md5() { # file top% bottom%
+  local f="$1" top="$2" bottom="$3"
+  local w h y0 y1
+  w="$(sips -g pixelWidth "$f" | awk '/pixelWidth/{print $2}')"
+  h="$(sips -g pixelHeight "$f" | awk '/pixelHeight/{print $2}')"
+  y0=$(( h * top / 100 )); y1=$(( h * bottom / 100 ))
+  local x0=$(( w * 5 / 100 )) cw=$(( w * 90 / 100 ))
+  local out="$WORK/$(basename "$f" .png)-$top-$bottom.png"
+  sips --cropOffset "$y0" "$x0" -c $(( y1 - y0 )) "$cw" "$f" --out "$out" >/dev/null 2>&1
+  md5 -q "$out"
+}
+
+echo "▶ setup flow (navigate → Fixed → inject)..."
+maestro --device "$UDID" test "$HERE/setup.yaml" >"$WORK/setup.log" 2>&1 || { tail -30 "$WORK/setup.log"; exit 1; }
+sleep 1
+snap "$WORK/before.png"
+
+echo "▶ swipe inside TextArea..."
+maestro --device "$UDID" test "$HERE/swipe-up.yaml" >"$WORK/swipe.log" 2>&1 || { tail -30 "$WORK/swipe.log"; exit 1; }
+sleep 1
+snap "$WORK/after.png"
+
+# --- Verify -------------------------------------------------------------------
+inner_before="$(crop_md5 "$WORK/before.png" 19 43)"
+inner_after="$(crop_md5 "$WORK/after.png" 19 43)"
+outer_before="$(crop_md5 "$WORK/before.png" 46 62)"
+outer_after="$(crop_md5 "$WORK/after.png" 46 62)"
+
+status=0
+if [[ "$inner_before" == "$inner_after" ]]; then
+  echo "✗ TextArea 내부 텍스트가 스크롤되지 않았습니다 (isScrollEnabled 미적용 의심)"; status=1
+else
+  echo "✓ TextArea 내부 텍스트가 스크롤되었습니다"
+fi
+if [[ "$outer_before" != "$outer_after" ]]; then
+  echo "✗ 바깥 ScrollView가 스크롤되었습니다 (외부 스크롤이 제스처를 가로챔)"; status=1
+else
+  echo "✓ 바깥 ScrollView는 움직이지 않았습니다"
+fi
+
+echo "스크린샷: $WORK/before.png, $WORK/after.png"
+[[ $status -eq 0 ]] && echo "PASS" || echo "FAIL"
+exit $status

--- a/Tests/E2E/textarea-scroll/setup.yaml
+++ b/Tests/E2E/textarea-scroll/setup.yaml
@@ -1,0 +1,20 @@
+# Blueprint > TextArea 프리뷰로 이동해 Resize=Fixed, 긴 텍스트 주입 상태를 만든다.
+appId: com.wantedlab.Blueprint
+---
+- launchApp:
+    stopApp: true
+- tapOn: "Search"
+- inputText: "TextArea"
+# index 0은 검색 필드의 입력 텍스트에 매칭되므로 리스트 행은 index 1
+- tapOn:
+    text: "TextArea"
+    index: 1
+- extendedWaitUntil:
+    visible: "Resize :"
+    timeout: 5000
+- tapOn: "Normal"
+- tapOn: "Fixed"
+- tapOn: "inject"
+- extendedWaitUntil:
+    visible: "Options"
+    timeout: 3000

--- a/Tests/E2E/textarea-scroll/swipe-up.yaml
+++ b/Tests/E2E/textarea-scroll/swipe-up.yaml
@@ -1,0 +1,8 @@
+# 포커스가 없는 TextArea 내부(화면 세로 24~38% 구간)를 위로 스와이프한다.
+# 정상: TextArea 내부 텍스트만 스크롤. 결함: 바깥 ScrollView가 스크롤되고 내부는 고정.
+appId: com.wantedlab.Blueprint
+---
+- swipe:
+    start: "50%,38%"
+    end: "50%,24%"
+    duration: 800


### PR DESCRIPTION
# 개요
- 이슈 링크 : https://wantedlab.atlassian.net/browse/WRP-2846

`ScrollView` 안의 `TextArea(.fixed)`에 바인딩으로 긴 텍스트가 들어오면 안쪽이 스크롤되지 않고 바깥 ScrollView만 움직입니다. 직접 타이핑하면 그때부터 정상입니다. 이력서 상세 > 간단 소개 수정이 이 케이스입니다.

원인은 LIVE-1014(8fd69f45)에서 `isScrollEnabled` 갱신을 `textViewDidChange`로만 옮긴 것입니다. 사용자 입력이 없으면 스크롤이 켜지지 않아 UITextView가 팬 제스처를 받지 못합니다. f48e9b51의 리그레션입니다.

# 수정사항

- `CustomTextView.updateScrollEnabled()`에서 실제 `bounds.width` 기준으로 `isScrollEnabled`를 계산합니다.
- 호출 시점은 `updateUIView`(바인딩 변경), `layoutSubviews`(폭 변경 시에만), `textViewDidChange`(입력) 세 곳입니다. `sizeThatFits`에서는 LIVE-1014 때와 같은 이유로 건드리지 않습니다.
- Coordinator의 미사용 프로퍼티를 정리했습니다. public API 변경 없음.
- Blueprint TextArea 프리뷰에 `inject`/`clear` 버튼, `Tests/E2E/textarea-scroll/`에 Maestro E2E(End-to-End) 테스트를 추가했습니다.

확인: E2E가 수정 후 PASS, 수정 전 FAIL. 타이핑 입력과 Resize 런타임 변경도 정상. Wanted 앱 Dev 빌드의 간단 소개 수정 화면에서 안쪽만 스크롤되는 것을 확인했습니다.

`make`는 돌리지 않았습니다. docstring 변경이 internal 타입에만 있어 생성 문서가 바뀌지 않습니다.

# 미리보기
작업 전|작업 후
---|---
<video src="https://github.com/user-attachments/assets/1276c271-e25a-4449-a1d0-dee3a3589fe6">|<video src="https://github.com/user-attachments/assets/6eeb4e66-f539-4313-b42a-34c94a8b2e80">




🤖 Generated with [Claude Code](https://claude.com/claude-code)
